### PR TITLE
Add missing return in DocumentRootNode.

### DIFF
--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/DocumentRootNode.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/DocumentRootNode.java
@@ -59,7 +59,7 @@ public class DocumentRootNode extends AbstractOutlineNode {
 		return document.readOnly(new IUnitOfWork<T, XtextResource>() {
 			public T exec(XtextResource resource) throws Exception {
 				if(resource != null && !resource.getContents().isEmpty()) {
-					work.exec(resource.getContents().get(0));
+					return work.exec(resource.getContents().get(0));
 				}
 				return null;
 			}


### PR DESCRIPTION
Otherwise null is returned always and the result is thrown away.