### PR TITLE
[xbase] Bug 458742

### DIFF
--- a/tests/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.xtend
+++ b/tests/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.xtend
@@ -1018,6 +1018,39 @@ class XbaseValidationTest extends AbstractXbaseTestCase {
 		}
 		'''.expression.assertNoIssues
 	}
+	
+	@Test def void testBug458742_01() {
+		'''
+			{
+				val list = #["foo"]
+				list?.add("bar")
+				return false
+			}
+		'''.expression.assertNoIssues
+	}
+	
+	@Test def void testBug458742_02() {
+		'''
+			{
+				val list = #["foo"]
+				list?.add("bar")
+			}
+		'''.expression.assertWarning(XbasePackage.Literals.XMEMBER_FEATURE_CALL,
+				IssueCodes.NULL_SAFE_FEATURE_CALL_OF_PRIMITIVE_VALUED_FEATURE,
+				"Null-safe call of primitive-valued feature")
+	}
+	
+	@Test def void testBug458742_03() {
+		'''
+		    {
+		    	val list = #["foo"]
+		        val b = list?.add("bar")
+		        return b
+		    }
+		'''.expression.assertWarning(XbasePackage.Literals.XMEMBER_FEATURE_CALL,
+				IssueCodes.NULL_SAFE_FEATURE_CALL_OF_PRIMITIVE_VALUED_FEATURE,
+				"Null-safe call of primitive-valued feature")
+	}
 
 	@Test def void testRedundantCases_01() {
 		'''

--- a/tests/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.java
+++ b/tests/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/validation/XbaseValidationTest.java
@@ -2409,6 +2409,79 @@ public class XbaseValidationTest extends AbstractXbaseTestCase {
   }
   
   @Test
+  public void testBug458742_01() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("{");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val list = #[\"foo\"]");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("list?.add(\"bar\")");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("return false");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      XExpression _expression = this.expression(_builder);
+      this._validationTestHelper.assertNoIssues(_expression);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testBug458742_02() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("{");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val list = #[\"foo\"]");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("list?.add(\"bar\")");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      XExpression _expression = this.expression(_builder);
+      this._validationTestHelper.assertWarning(_expression, XbasePackage.Literals.XMEMBER_FEATURE_CALL, 
+        IssueCodes.NULL_SAFE_FEATURE_CALL_OF_PRIMITIVE_VALUED_FEATURE, 
+        "Null-safe call of primitive-valued feature");
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testBug458742_03() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("{");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val list = #[\"foo\"]");
+      _builder.newLine();
+      _builder.append("    ");
+      _builder.append("val b = list?.add(\"bar\")");
+      _builder.newLine();
+      _builder.append("    ");
+      _builder.append("return b");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      XExpression _expression = this.expression(_builder);
+      this._validationTestHelper.assertWarning(_expression, XbasePackage.Literals.XMEMBER_FEATURE_CALL, 
+        IssueCodes.NULL_SAFE_FEATURE_CALL_OF_PRIMITIVE_VALUED_FEATURE, 
+        "Null-safe call of primitive-valued feature");
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
   public void testRedundantCases_01() {
     try {
       StringConcatenation _builder = new StringConcatenation();


### PR DESCRIPTION
No warning for null-safe feature call of primitive featue if the result isn't used