### PR TITLE
[bug 406066] Improve usage of simple names for java.lang classes

### DIFF
--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/ImportManager.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/ImportManager.java
@@ -195,7 +195,7 @@ public class ImportManager {
 	}
 
 	protected boolean allowsSimpleName(String qualifiedName, String simpleName) {
-		return thisTypeQualifiedNames.contains(qualifiedName) || (!thisCollidesWithJavaLang && JAVA_LANG_PACK.matcher(qualifiedName).matches())
+		return thisTypeQualifiedNames.contains(qualifiedName) || ((!thisCollidesWithJavaLang || !thisTypeSimpleNames.contains(simpleName)) && JAVA_LANG_PACK.matcher(qualifiedName).matches())
 				|| equal(qualifiedName, simpleName);
 	}
 

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug406066Test.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug406066Test.xtend
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.compiler
+
+import org.junit.Test
+
+/**
+ * @author Karsten Thoms - Initial contribution and API
+ */
+class CompilerBug406066Test extends AbstractXtendCompilerTest {
+	
+	@Test
+	def testBug406066_01() {
+		assertCompilesTo('''
+			class Error {
+				def static err(Integer i) {
+					i.toString
+				}
+			}
+		''', '''
+			@SuppressWarnings("all")
+			public class Error {
+			  public static String err(final Integer i) {
+			    return i.toString();
+			  }
+			}
+		''')
+	}
+}

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug406066Test.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug406066Test.xtend
@@ -31,4 +31,44 @@ class CompilerBug406066Test extends AbstractXtendCompilerTest {
 			}
 		''')
 	}
+
+	@Test
+	def testBug406066_02() {
+		assertCompilesTo('''
+			class Error {
+				def static err(Integer i) {
+					i.toString
+					val java.lang.Error e = new AssertionError()
+				}
+			}
+		''', '''
+			@SuppressWarnings("all")
+			public class Error {
+			  public static void err(final Integer i) {
+			    i.toString();
+			    final java.lang.Error e = new AssertionError();
+			  }
+			}
+		''')
+	}
+
+	@Test
+	def testBug406066_03() {
+		assertCompilesTo('''
+			class Error2 {
+				def static err(Integer i) {
+					i.toString
+					val Error e = new AssertionError()
+				}
+			}
+		''', '''
+			@SuppressWarnings("all")
+			public class Error2 {
+			  public static void err(final Integer i) {
+			    i.toString();
+			    final Error e = new AssertionError();
+			  }
+			}
+		''')
+	}
 }

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
@@ -66,7 +66,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 		''', '''
 			import types.SomeClassWithNestedInterface;
 			
-			@java.lang.SuppressWarnings("all")
+			@SuppressWarnings("all")
 			public class Foo extends SomeClassWithNestedInterface implements SomeClassWithNestedInterface.NestedInterface {
 			}
 		''')
@@ -82,7 +82,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 		''', '''
 			import types.SomeClassWithNestedInterface;
 			
-			@java.lang.SuppressWarnings("all")
+			@SuppressWarnings("all")
 			public class Foo extends SomeClassWithNestedInterface {
 			  public SomeClassWithNestedInterface.String convert(final java.lang.String s) {
 			    return null;
@@ -963,7 +963,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testAbstractIterator_04() { 
+	def testAbstractIterator_04() {
 		assertCompilesTo(
 			'''
 				import java.util.Iterator
@@ -1326,7 +1326,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testJavaLangReflectImport() { 
+	def testJavaLangReflectImport() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -1571,7 +1571,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	def testSwitchWithBooleanExpression_3() {
 		'''
 		class Foo {
-			def foo(int x) { 
+			def foo(int x) {
 				switch x {
 					case [|1 == x].apply || x == 2: true
 					default: false
@@ -1623,7 +1623,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			            case null : [Object it|it]
 			            case null : [Integer it|it]
 			        }
-			    }    
+			    }
 			}
 		''', '''
 			import com.google.common.base.Objects;
@@ -2266,7 +2266,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testTryCatch() { 
+	def testTryCatch() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2315,7 +2315,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testTryCatch_01() { 
+	def testTryCatch_01() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2361,7 +2361,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testTryCatch_02() { 
+	def testTryCatch_02() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2399,7 +2399,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 		''')
 	}
 
-	@Test	
+	@Test
 	def testClosureSneakyThrow() {
 		assertCompilesTo('''
 			import java.io.File
@@ -2496,7 +2496,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testFieldInitialization_01() { 
+	def testFieldInitialization_01() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2519,7 +2519,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testFieldInitialization_02() { 
+	def testFieldInitialization_02() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2545,7 +2545,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testFieldInitialization_03() { 
+	def testFieldInitialization_03() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2564,7 +2564,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testFieldInitialization_04() { 
+	def testFieldInitialization_04() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2581,7 +2581,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testConstructorDeclaration_01() { 
+	def testConstructorDeclaration_01() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2602,7 +2602,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testConstructorDeclaration_02() { 
+	def testConstructorDeclaration_02() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2630,7 +2630,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testConstructorDeclaration_03() { 
+	def testConstructorDeclaration_03() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2655,7 +2655,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testSneakyThrow() { 
+	def testSneakyThrow() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2683,7 +2683,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testSneakyThrow_01() { 
+	def testSneakyThrow_01() {
 		assertCompilesTo('''
 			package foo
 			
@@ -2708,7 +2708,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 		''')
 	}
 	@Test
-	def testSneakyThrow_02() { 
+	def testSneakyThrow_02() {
 		assertCompilesTo('''
 			package foo
 			
@@ -2739,7 +2739,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 		''')
 	}
 	@Test
-	def testSneakyThrow_04() { 
+	def testSneakyThrow_04() {
 		assertCompilesTo('''
 			package foo
 			
@@ -2770,7 +2770,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 		''')
 	}
 	@Test
-	def testSneakyThrow_03() { 
+	def testSneakyThrow_03() {
 		assertCompilesTo('''
 			package foo
 			
@@ -2798,7 +2798,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 
 	@Test
-	def testSimple() { 
+	def testSimple() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -2817,7 +2817,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 
 	@Test
-	def testConstructor() { 
+	def testConstructor() {
 		assertCompilesTo('''
 			package foo
 			class Bar {
@@ -3239,8 +3239,8 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 					if ('foo' == p)
 						return true
 					else
-						super.equals(p) 
-				} 
+						super.equals(p)
+				}
 			}
 		''', '''
 			package x;
@@ -3997,7 +3997,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
-	def testFindFirstOnIt_01() { 
+	def testFindFirstOnIt_01() {
 		assertCompilesTo(
 			'''
 				class FindFirstOnIt {
@@ -4055,7 +4055,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 				class MyClass implements ReturnTypeUsesTypeParameter {
 				
 					override <LocalName extends CharSequence> accept(LocalName param) {
-						[ if (true) it?.apply(param) ] 
+						[ if (true) it?.apply(param) ]
 					}
 				}
 			''', '''
@@ -4080,7 +4080,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			''')
 	}
 	
-	@Test 
+	@Test
 	def void testReturnType_03() {
 		'''
 			import java.util.LinkedList
@@ -4095,7 +4095,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 			
 			abstract class A {
-				def CharSequence m() 
+				def CharSequence m()
 			}
 		'''.assertCompilesTo('''
 			@SuppressWarnings("all")
@@ -4254,7 +4254,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	@Test
 	def testRichStringNoAutoConversionToString_02(){
 		assertCompilesTo(
-			"class Foo { def test(){ System::out.println('''SomeString''') } }", 
+			"class Foo { def test(){ System::out.println('''SomeString''') } }",
 			'''
 				import org.eclipse.xtend2.lib.StringConcatenation;
 				
@@ -4272,7 +4272,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	@Test
 	def testRichStringAutoConversionDueToUnboundTypeParam_02(){
 		assertCompilesTo(
-			"class Foo { def test(){ System::out.println(println('''SomeString''')) } }", 
+			"class Foo { def test(){ System::out.println(println('''SomeString''')) } }",
 			'''
 				import org.eclipse.xtend2.lib.StringConcatenation;
 				import org.eclipse.xtext.xbase.lib.InputOutput;
@@ -4292,7 +4292,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	@Test
 	def compileClassWithFileHeader(){
 		assertCompilesTo(
-		''' 
+		'''
 			/**
 			 * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
 			 * All rights reserved. This program and the accompanying materials
@@ -4302,7 +4302,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			 */
 			package foo
 			
-			class bar { 
+			class bar {
 			    String name = 'foobar'
 			}
 		''',
@@ -4325,13 +4325,13 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	
 	@Test
 	def compileClassInDefaultPackageWithFileHeader(){
-		assertCompilesTo(''' 
+		assertCompilesTo('''
 			/**
 			 * This comment is ambiguous because it could be both a file header and a
 			 * class comment. In any case it should be generated only once.
 			 */
 			
-			class bar { 
+			class bar {
 			}
 		''',
 		'''
@@ -4347,7 +4347,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	
 	@Test
 	def compileClassInDefaultPackageWithFileHeaderAndJavaDoc(){
-		assertCompilesTo(''' 
+		assertCompilesTo('''
 			/**
 			 * header
 			 */
@@ -4355,7 +4355,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			/**
 			 * javadoc
 			 */
-			class bar { 
+			class bar {
 			}
 		''',
 		'''
@@ -4374,7 +4374,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	@Test
 	def compileClassInDefaultPackageWithFileHeaderAndImport(){
 		assertCompilesTo(
-		''' 
+		'''
 			/**
 			 * header
 			 */
@@ -4400,7 +4400,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	
 	@Test
 	def compileClassInDefaultPackageWithJavadDocAndImport(){
-		assertCompilesTo(''' 
+		assertCompilesTo('''
 			import java.util.Date
 			
 			/**
@@ -4678,7 +4678,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	@Test def testNullSafeFeatureCall_07() {
 		assertCompilesTo(
 				'''
-					class Foo { 
+					class Foo {
 						extension org.eclipse.xtext.xbase.lib.util.ReflectExtensions
 						def bar() throws Throwable {
 							new String().get('toString')?.get('substring')
@@ -4709,7 +4709,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 	@Test def testNullSafeFeatureCall_08() {
 		assertCompilesTo(
 				'''
-					class Foo { 
+					class Foo {
 						String field
 						def bar(String str) {
 							new Foo().field?.toString?.substring(1) ?: ''
@@ -5094,7 +5094,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  }
 			}
 		''')
-	} 
+	}
 	
 	@Test def void basicForLoopWithReturnStatement() {
 		'''
@@ -5116,7 +5116,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  }
 			}
 		''')
-	} 
+	}
 	
 	@Test def void basicForLoopWithDuplicateSyntheticVariables() {
 		'''
@@ -5187,7 +5187,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 		'''
 			class Foo {
 				def m() {
-			      val x = 
+			      val x =
 			            if(false) {
 			               return ''
 			            }
@@ -5213,7 +5213,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  }
 			}
 		''')
-	} 
+	}
 	
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=437027
@@ -5222,7 +5222,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 		'''
 			class Foo {
 			   def m() {
-			      val x = 
+			      val x =
 			         identity(
 			            if(false) {
 			               return ''
@@ -5252,7 +5252,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  }
 			}
 		''')
-	} 
+	}
 	
 	@Test def void testXFunctionTypeRefAsSuperType_01() {
 		'''
@@ -5289,7 +5289,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  public abstract void apply();
 			}
 		''')
-	} 
+	}
 	
 	@Test def void testXFunctionTypeRefAsSuperType_03() {
 		'''
@@ -5326,7 +5326,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  public abstract void apply(final String value);
 			}
 		''')
-	} 
+	}
 	
 	@Test def void testXFunctionTypeRefAsSuperType_05() {
 		'''
@@ -5363,7 +5363,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  public abstract void apply(final Procedure1<? super String> procedure);
 			}
 		''')
-	} 
+	}
 	
 	@Test def void testXFunctionTypeRefAsSuperType_07() {
 		'''
@@ -5401,7 +5401,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  public abstract String apply();
 			}
 		''')
-	} 
+	}
 	
 	@Test def void testXFunctionTypeRefAsSuperType_09() {
 		'''
@@ -5446,17 +5446,17 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 }
 
 //class XtendCompilerTest extends AbstractXtendCompilerTest {
-//	
+//
 //	/*
 //	 * Refined questionable expectation.
 //	 */
 //	@Test
 //	override testRichStringNoAutoConversionToString_03(){
 //		assertCompilesTo(
-//			"class Foo { def test(){ System::out.println('''SomeString''') } }", 
+//			"class Foo { def test(){ System::out.println('''SomeString''') } }",
 //			'''
 //				import org.eclipse.xtend2.lib.StringConcatenation;
-//				
+//
 //				@SuppressWarnings("all")
 //				public class Foo {
 //				  public void test() {
@@ -5467,18 +5467,18 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 //				}
 //			''')
 //	}
-//	
+//
 //	/*
 //	 * Refined questionable expectation.
 //	 */
 //	@Test
 //	override testRichStringNoAutoConversionToString_04(){
 //		assertCompilesTo(
-//			"class Foo { def test(){ System::out.println(println('''SomeString''')) } }", 
+//			"class Foo { def test(){ System::out.println(println('''SomeString''')) } }",
 //			'''
 //				import org.eclipse.xtend2.lib.StringConcatenation;
 //				import org.eclipse.xtext.xbase.lib.InputOutput;
-//				
+//
 //				@SuppressWarnings("all")
 //				public class Foo {
 //				  public void test() {
@@ -5490,5 +5490,5 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 //				}
 //			''')
 //	}
-//	
+//
 //}

--- a/tests/org.eclipse.xtend.core.tests/suites/org/eclipse/xtend/core/tests/compiler/CompilerSuite.java
+++ b/tests/org.eclipse.xtend.core.tests/suites/org/eclipse/xtend/core/tests/compiler/CompilerSuite.java
@@ -31,6 +31,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	CompilerBug383534Test.class,
 	CompilerBug404051Test.class,
 	CompilerBug405825Test.class,
+	CompilerBug406066Test.class,
 	CompilerBug406425Test.class,
 	CompilerBug406549Test.class,
 	CompilerBug410555Test.class,

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug406066Test.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug406066Test.java
@@ -50,4 +50,86 @@ public class CompilerBug406066Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     this.assertCompilesTo(_builder, _builder_1);
   }
+  
+  @Test
+  public void testBug406066_02() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Error {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def static err(Integer i) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("i.toString");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("val java.lang.Error e = new AssertionError()");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class Error {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public static void err(final Integer i) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("i.toString();");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("final java.lang.Error e = new AssertionError();");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void testBug406066_03() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Error2 {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def static err(Integer i) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("i.toString");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("val Error e = new AssertionError()");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class Error2 {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public static void err(final Integer i) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("i.toString();");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("final Error e = new AssertionError();");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
 }

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug406066Test.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug406066Test.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.compiler;
+
+import org.eclipse.xtend.core.tests.compiler.AbstractXtendCompilerTest;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.junit.Test;
+
+/**
+ * @author Karsten Thoms - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class CompilerBug406066Test extends AbstractXtendCompilerTest {
+  @Test
+  public void testBug406066_01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Error {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def static err(Integer i) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("i.toString");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class Error {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public static String err(final Integer i) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return i.toString();");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+}

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
@@ -125,7 +125,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("import types.SomeClassWithNestedInterface;");
     _builder_1.newLine();
     _builder_1.newLine();
-    _builder_1.append("@java.lang.SuppressWarnings(\"all\")");
+    _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
     _builder_1.append("public class Foo extends SomeClassWithNestedInterface implements SomeClassWithNestedInterface.NestedInterface {");
     _builder_1.newLine();
@@ -154,7 +154,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("import types.SomeClassWithNestedInterface;");
     _builder_1.newLine();
     _builder_1.newLine();
-    _builder_1.append("@java.lang.SuppressWarnings(\"all\")");
+    _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
     _builder_1.append("public class Foo extends SomeClassWithNestedInterface {");
     _builder_1.newLine();
@@ -3618,7 +3618,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("class Foo {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def foo(int x) { ");
+    _builder.append("def foo(int x) {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("switch x {");
@@ -3749,7 +3749,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     _builder.append("    ");
-    _builder.append("}    ");
+    _builder.append("}");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
@@ -7336,10 +7336,10 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("else");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("super.equals(p) ");
+    _builder.append("super.equals(p)");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("} ");
+    _builder.append("}");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
@@ -9097,7 +9097,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("override <LocalName extends CharSequence> accept(LocalName param) {");
     _builder.newLine();
     _builder.append("\t\t");
-    _builder.append("[ if (true) it?.apply(param) ] ");
+    _builder.append("[ if (true) it?.apply(param) ]");
     _builder.newLine();
     _builder.append("\t");
     _builder.append("}");
@@ -9187,7 +9187,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("abstract class A {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def CharSequence m() ");
+    _builder.append("def CharSequence m()");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
@@ -9570,7 +9570,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("package foo");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("class bar { ");
+    _builder.append("class bar {");
     _builder.newLine();
     _builder.append("    ");
     _builder.append("String name = \'foobar\'");
@@ -9628,7 +9628,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("*/");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("class bar { ");
+    _builder.append("class bar {");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
@@ -9673,7 +9673,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.append(" ");
     _builder.append("*/");
     _builder.newLine();
-    _builder.append("class bar { ");
+    _builder.append("class bar {");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
@@ -10271,7 +10271,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
   @Test
   public void testNullSafeFeatureCall_07() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class Foo { ");
+    _builder.append("class Foo {");
     _builder.newLine();
     _builder.append("\t");
     _builder.append("extension org.eclipse.xtext.xbase.lib.util.ReflectExtensions");
@@ -10340,7 +10340,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
   @Test
   public void testNullSafeFeatureCall_08() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class Foo { ");
+    _builder.append("class Foo {");
     _builder.newLine();
     _builder.append("\t");
     _builder.append("String field");
@@ -11461,7 +11461,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("def m() {");
     _builder.newLine();
     _builder.append("      ");
-    _builder.append("val x = ");
+    _builder.append("val x =");
     _builder.newLine();
     _builder.append("            ");
     _builder.append("if(false) {");
@@ -11543,7 +11543,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("def m() {");
     _builder.newLine();
     _builder.append("      ");
-    _builder.append("val x = ");
+    _builder.append("val x =");
     _builder.newLine();
     _builder.append("         ");
     _builder.append("identity(");


### PR DESCRIPTION
When the import manager is created with a type that collides with java.lang, the flag thisCollidesWithJavaLang is set. But in method allowsSimpleName it is not considered that the actual type name that should be shortened is different from the one with that the ImportManager was created.
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>