### PR TITLE
[serializer] bugfix: never break datatype rules into individual tokens

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/analysis/ContextPDAProvider.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/analysis/ContextPDAProvider.java
@@ -41,7 +41,7 @@ public class ContextPDAProvider implements IContextPDAProvider {
 	protected class ExpandRuleCalls implements Function<ISerState, Pda<ISerState, RuleCall>> {
 		@Override
 		public Pda<ISerState, RuleCall> apply(ISerState input) {
-			if (GrammarUtil.isUnassignedParserRuleCall(input.getGrammarElement()))
+			if (GrammarUtil.isUnassignedEObjectRuleCall(input.getGrammarElement()))
 				return getContextPDA((((RuleCall) input.getGrammarElement()).getRule()));
 			return null;
 		}

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/ContextTypePDAProviderTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/ContextTypePDAProviderTest.java
@@ -345,4 +345,30 @@ public class ContextTypePDAProviderTest extends AbstractXtextTests {
 		expected.append("  >>Opt -> 'o'");
 		assertEquals(expected.toString(), actual);
 	}
+	
+	@Test
+	public void testUnassignedDatatypeRuleCall() throws Exception {
+		StringBuilder grammar = new StringBuilder();
+		grammar.append("Model: {Model} 'kw1' ({Foo.child=current} Sub)*;\n");
+		grammar.append("Sub: 'kw2' 'kw3';\n");
+		String actual = getParserRule(grammar.toString());
+		StringBuilder expected = new StringBuilder();
+		expected.append("Foo_Model:\n");
+		expected.append("  start -> {Foo.child=}\n");
+		expected.append("  Sub -> stop\n");
+		expected.append("  {Foo.child=} -> Sub\n");
+		expected.append("Foo_Model_Foo_2_0:\n");
+		expected.append("  start -> {Foo.child=}\n");
+		expected.append("  Sub -> stop\n");
+		expected.append("  {Foo.child=} -> Sub\n");
+		expected.append("Model_Model:\n");
+		expected.append("  start -> {Model}\n");
+		expected.append("  'kw1' -> stop\n");
+		expected.append("  {Model} -> 'kw1'\n");
+		expected.append("Model_Model_Foo_2_0:\n");
+		expected.append("  start -> {Model}\n");
+		expected.append("  'kw1' -> stop\n");
+		expected.append("  {Model} -> 'kw1'");
+		assertEquals(expected.toString(), actual);
+	}
 }


### PR DESCRIPTION
Change-Id: I25a55027dc588b41b70a4cb94ca2b81282c31f4e
Signed-off-by: Moritz Eysholdt <moritz.eysholdt@itemis.de>