### PR TITLE
Fix bug 462217: improve message for undefined abstract methods

### DIFF
--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendJavaValidator.java
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendJavaValidator.java
@@ -932,6 +932,7 @@ public class XtendJavaValidator extends XbaseWithAnnotationsJavaValidator {
 	protected void reportMissingImplementations(XtendTypeDeclaration xtendClass, JvmGenericType inferredType, List<IResolvedOperation> operationsMissingImplementation) {
 		StringBuilder errorMsg = new StringBuilder();
 		String name = xtendClass.getName();
+		boolean needsNewLine = operationsMissingImplementation.size() > 1;
 		if (xtendClass.isAnonymous()) {
 			JvmTypeReference superType = Iterables.getLast(inferredType.getSuperTypes());
 			errorMsg.append("The anonymous subclass of ").append(superType.getSimpleName());
@@ -939,8 +940,10 @@ public class XtendJavaValidator extends XbaseWithAnnotationsJavaValidator {
 		} else {
 			errorMsg.append("The class ").append(name);	
 			errorMsg.append(" must be defined abstract because it does not implement ");
+			if (needsNewLine) {
+				errorMsg.append("its inherited abstract methods ");
+			}
 		}
-		boolean needsNewLine = operationsMissingImplementation.size() > 1;
 		IResolvedOperation operation;
 		for(int i=0; i<operationsMissingImplementation.size() && i<3; ++i) {
 			operation = operationsMissingImplementation.get(i);


### PR DESCRIPTION
The message's first line (shown in problems view) said only "The class
X must be defined abstract because it does not implement", which is a
bit confusing. Adding "its inherited abstract method(s)" as suggested
by Sebastian