### PR TITLE
[461939]: Fixed performance problem with Strings.countLines

### DIFF
--- a/plugins/org.eclipse.xtext.util/src/org/eclipse/xtext/util/Strings.java
+++ b/plugins/org.eclipse.xtext.util/src/org/eclipse/xtext/util/Strings.java
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.util;
 
+import java.io.LineNumberReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -431,17 +432,29 @@ public class Strings {
 
 	/**
 	 * Counts the number of line breaks. Assumes {@code '\r'}, {@code '\n'} or {@code '\r\n'} to be valid line breaks.
+	 * 
+	 * This follows the semantics of the {@link LineNumberReader}.
+	 * 
 	 * @since 2.3
 	 */
 	public static int countLineBreaks(CharSequence text) {
+		return countLineBreaks(text, 0, text.length());
+	}
+	
+	/**
+	 * Counts the number of line breaks. Assumes {@code '\r'}, {@code '\n'} or {@code '\r\n'} to be valid line breaks.
+	 * 
+	 * This follows the semantics of the {@link LineNumberReader}.
+	 * 
+	 * @since 2.8
+	 */
+	public static int countLineBreaks(CharSequence text, int startInclusive, int endExclusive) {
 		int result = 0;
-		char ch;
-		int length= text.length();
-		for (int i= 0; i < length; i++) {
-			ch= text.charAt(i);
+		for (int i = startInclusive; i < endExclusive; i++) {
+			char ch= text.charAt(i);
 			if (ch == '\r') {
 				result++;
-				if (i + 1 < length) {
+				if (i + 1 < endExclusive) {
 					if (text.charAt(i + 1) == '\n') {
 						i++;
 					}
@@ -475,19 +488,34 @@ public class Strings {
 		return s;
 	}
 	
-
 	/**
-	 * Counts the number of lines where {@link #separator} is assumed to be a valid line break.
+	 * Counts the number of lines where {@link #separator} is assumed to be the only valid line break sequence.
+	 * A string without any line separators returns {@code 0} as the number of lines.
 	 */
 	public static int countLines(String text) {
 		return countLines(text, separator);
 	}
 
+	/**
+	 * Counts the number of lines where the given separator sequence is the only valid line break sequence.
+	 * A string without any line separators returns {@code 0} as the number of lines.
+	 */
 	public static int countLines(String text, char[] separator) {
+		return countLines(text, separator, 0, text.length());
+	}
+
+	/**
+	 * Counts the number of lines between {@code startInclusive} and {@code endExclusive}
+	 * where the given separator sequence is the only valid line break sequence.
+	 * A string without any line separators in that range returns {@code 0} as the number of lines.
+	 * 
+	 * @since 2.8
+	 */
+	public static int countLines(String text, char[] separator, int startInclusive, int endExclusive) {
 		int line = 0;
 		if (separator.length == 1) {
 			char c = separator[0];
-			for (int i = 0; i < text.length(); i++) {
+			for (int i = startInclusive; i < endExclusive; i++) {
 				if (text.charAt(i) == c) {
 					line++;
 				}
@@ -495,8 +523,8 @@ public class Strings {
 		} else if (separator.length == 2) {
 			char c1 = separator[0];
 			char c2 = separator[1];
-			for (int i = 0; i < text.length(); i++) {
-				if (text.charAt(i) == c1 && text.length() > i + 1 && text.charAt(i + 1) == c2) {
+			for (int i = startInclusive; i < endExclusive; i++) {
+				if (text.charAt(i) == c1 && endExclusive > i + 1 && text.charAt(i + 1) == c2) {
 					line++;
 					i++;
 				} else if (text.charAt(i) == c2) {
@@ -509,6 +537,7 @@ public class Strings {
 		return line;
 	}
 	
+	// TODO is it worthwhile to deprecate this method and fix the typo 'Whitespace'?
 	public static String getLeadingWhiteSpace(String original) {
 		for(int i=0; i < original.length(); i++) {
 			if (!Character.isWhitespace(original.charAt(i))) {

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/output/AppendableBasedTraceRegion.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/output/AppendableBasedTraceRegion.java
@@ -103,7 +103,7 @@ public class AppendableBasedTraceRegion extends AbstractTraceRegion {
 			if (diff == nested.length) {
 				allNested.remove(i);
 			} else {
-				nested.lineNumber += Strings.countLineBreaks(completeContent.substring(offset, offset + diff));
+				nested.lineNumber += Strings.countLineBreaks(completeContent, offset, offset + diff);
 				nested.offset += diff;
 				nested.length -= diff;
 				nested.leftCompressTrace(completeContent);
@@ -123,7 +123,7 @@ public class AppendableBasedTraceRegion extends AbstractTraceRegion {
 				diff++;
 			}
 			if (diff != 0) {
-				nested.endLineNumber -= Strings.countLineBreaks(completeContent.substring(endOffset - diff + 1, endOffset + 1));
+				nested.endLineNumber -= Strings.countLineBreaks(completeContent, endOffset - diff + 1, endOffset + 1);
 				nested.length -= diff;
 				nested.rightCompressTrace(completeContent);
 			}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/AbstractNode.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/AbstractNode.java
@@ -183,8 +183,7 @@ public abstract class AbstractNode implements INode, BidiTreeIterable<INode> {
 				return -insertionPoint;
 			}
 		}
-		String leadingText = rootNode.getText().substring(0, offset);
-		int result = Strings.countLines(leadingText);
+		int result = Strings.countLineBreaks(rootNode.getText(), 0, offset);
 		return result + 1;
 	}
 	

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/RootNode.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/RootNode.java
@@ -9,6 +9,7 @@ package org.eclipse.xtext.nodemodel.impl;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.LineNumberReader;
 import java.util.List;
 import java.util.Map;
 
@@ -147,6 +148,7 @@ public class RootNode extends CompositeNodeWithSemanticElementAndSyntaxError {
 	 * <p>Computes the line breaks in the given text and returns an array of offsets.
 	 * A line break is either <code>\r\n</code>, <code>\n</code>, or a single <code>\r</code>.</p>
 	 * This implementation was heavily adapted from <code>org.eclipse.jface.text.DefaultLineTracker</code>.
+	 * It follows the semantics of {@link LineNumberReader}.
 	 * @param text the text whose line-breaks should be computed. May not be <code>null</code>.
 	 * @return the array of line-break offsets in the given text. May be empty but is never <code>null</code>.
 	 * @since 2.0

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/resource/XtextSyntaxDiagnosticWithRange.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/resource/XtextSyntaxDiagnosticWithRange.java
@@ -41,8 +41,8 @@ public class XtextSyntaxDiagnosticWithRange extends XtextSyntaxDiagnostic {
 	@Override
 	public int getLine() {
 		int startLine = getNode().getTotalStartLine();
-		String text = getNode().getText().substring(0, offset);
-		int result = Strings.countLineBreaks(text) + startLine;
+		String text = getNode().getText();
+		int result = Strings.countLineBreaks(text, 0, offset) + startLine;
 		return result;
 	}
 	

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/tasks/DefaultTaskParser.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/tasks/DefaultTaskParser.xtend
@@ -22,13 +22,18 @@ class DefaultTaskParser implements ITaskParser {
 		val taskTagsByName = Maps.uniqueIndex(taskTags)[name.toLowerCase]
 		val matcher = taskTags.toPattern.matcher(source)
 		val tasks = newArrayList
+		// keep track of the offset and line numbers to avoid unnecessary line counting from start
+		var prevLine = 1;
+		var prevOffset = 0;
 		while (matcher.find) {
-			tasks += new Task => [
-				tag = taskTagsByName.get(matcher.group(2).toLowerCase)
-				description = matcher.group(3)
-				offset = matcher.start(2)
-				lineNumber = Strings.countLineBreaks(source.substring(0, offset)) + 1
-			]
+			val task = new Task()
+			task.tag = taskTagsByName.get(matcher.group(2).toLowerCase)
+			task.description = matcher.group(3)
+			task.offset = matcher.start(2)
+			task.lineNumber = Strings.countLineBreaks(source, prevOffset, task.offset) + prevLine
+			prevLine = task.lineNumber
+			prevOffset = task.offset
+			tasks += task
 		}
 		tasks
 	}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/validation/DiagnosticConverterImpl.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/validation/DiagnosticConverterImpl.java
@@ -181,7 +181,7 @@ public class DiagnosticConverterImpl implements IDiagnosticConverter {
 				IssueLocation result = new IssueLocation();
 				if (parserNode != null) {
 					String completeText = parserNode.getRootNode().getText();
-					int startLine = Strings.countLines(completeText.substring(0, castedDiagnostic.getOffset())) + 1;
+					int startLine = Strings.countLineBreaks(completeText, 0, castedDiagnostic.getOffset()) + 1;
 					result.lineNumber = startLine;
 				}
 				result.offset = castedDiagnostic.getOffset();

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskParser.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskParser.java
@@ -24,8 +24,6 @@ import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.ObjectExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * @author Stefan Oehme - Initial contribution and API
@@ -52,28 +50,29 @@ public class DefaultTaskParser implements ITaskParser {
       Pattern _pattern = this.toPattern(taskTags);
       final Matcher matcher = _pattern.matcher(source);
       final ArrayList<Task> tasks = CollectionLiterals.<Task>newArrayList();
+      int prevLine = 1;
+      int prevOffset = 0;
       while (matcher.find()) {
-        Task _task = new Task();
-        final Procedure1<Task> _function_1 = new Procedure1<Task>() {
-          @Override
-          public void apply(final Task it) {
-            String _group = matcher.group(2);
-            String _lowerCase = _group.toLowerCase();
-            TaskTag _get = taskTagsByName.get(_lowerCase);
-            it.setTag(_get);
-            String _group_1 = matcher.group(3);
-            it.setDescription(_group_1);
-            int _start = matcher.start(2);
-            it.setOffset(_start);
-            int _offset = it.getOffset();
-            String _substring = source.substring(0, _offset);
-            int _countLineBreaks = Strings.countLineBreaks(_substring);
-            int _plus = (_countLineBreaks + 1);
-            it.setLineNumber(_plus);
-          }
-        };
-        Task _doubleArrow = ObjectExtensions.<Task>operator_doubleArrow(_task, _function_1);
-        tasks.add(_doubleArrow);
+        {
+          final Task task = new Task();
+          String _group = matcher.group(2);
+          String _lowerCase = _group.toLowerCase();
+          TaskTag _get = taskTagsByName.get(_lowerCase);
+          task.setTag(_get);
+          String _group_1 = matcher.group(3);
+          task.setDescription(_group_1);
+          int _start = matcher.start(2);
+          task.setOffset(_start);
+          int _offset = task.getOffset();
+          int _countLineBreaks = Strings.countLineBreaks(source, prevOffset, _offset);
+          int _plus = (_countLineBreaks + prevLine);
+          task.setLineNumber(_plus);
+          int _lineNumber = task.getLineNumber();
+          prevLine = _lineNumber;
+          int _offset_1 = task.getOffset();
+          prevOffset = _offset_1;
+          tasks.add(task);
+        }
       }
       _xblockexpression = tasks;
     }

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/tasks/DefaultTaskParserTest.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/tasks/DefaultTaskParserTest.xtend
@@ -99,6 +99,23 @@ class DefaultTaskParserTest {
 				]
 			])
 	}
+	
+	@Test
+	def void testLongInputManyTasks() {
+		val expectation = 100000
+		val String source = '''
+			/*
+			 «FOR i: 1..expectation»
+			 	* FIXME this cannot work
+			 «ENDFOR»
+			 */
+		'''
+		val parsed = parser.parseTasks(LineDelimiters.toUnix(source), definitions)
+		assertEquals(expectation, parsed.size)
+		for(i: 0..<expectation) {
+			assertEquals(i+2, parsed.get(i).lineNumber)
+		}
+	}
 
 	private def assertContainsTasks(CharSequence source, List<Task> expectedTasks) {
 		val actualTasks = parser.parseTasks(LineDelimiters.toUnix(source.toString), definitions)

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskParserTest.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskParserTest.java
@@ -21,6 +21,7 @@ import org.eclipse.xtext.tasks.TaskTag;
 import org.eclipse.xtext.tasks.TaskTags;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.ExclusiveRange;
+import org.eclipse.xtext.xbase.lib.IntegerRange;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Assert;
@@ -183,6 +184,36 @@ public class DefaultTaskParserTest {
     Task _doubleArrow_3 = ObjectExtensions.<Task>operator_doubleArrow(_task_3, _function_3);
     this.assertContainsTasks(_builder, 
       Collections.<Task>unmodifiableList(CollectionLiterals.<Task>newArrayList(_doubleArrow, _doubleArrow_1, _doubleArrow_2, _doubleArrow_3)));
+  }
+  
+  @Test
+  public void testLongInputManyTasks() {
+    final int expectation = 100000;
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/*");
+    _builder.newLine();
+    {
+      IntegerRange _upTo = new IntegerRange(1, expectation);
+      for(final Integer i : _upTo) {
+        _builder.append(" ");
+        _builder.append("* FIXME this cannot work");
+        _builder.newLine();
+      }
+    }
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    final String source = _builder.toString();
+    String _unix = LineDelimiters.toUnix(source);
+    final List<Task> parsed = this.parser.parseTasks(_unix, this.definitions);
+    int _size = parsed.size();
+    Assert.assertEquals(expectation, _size);
+    ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, expectation, true);
+    for (final Integer i_1 : _doubleDotLessThan) {
+      Task _get = parsed.get((i_1).intValue());
+      int _lineNumber = _get.getLineNumber();
+      Assert.assertEquals(((i_1).intValue() + 2), _lineNumber);
+    }
   }
   
   private void assertContainsTasks(final CharSequence source, final List<Task> expectedTasks) {


### PR DESCRIPTION
Instead of using countLines with a substring, the start and endOffset
an be passed as an argument to the methods that deal with line
counting.

Signed-off-by: szarnekow <Sebastian.Zarnekow@itemis.de>