### PR TITLE
[xtend] Bug 446364: Problems when manipulating declared methods in AA

### DIFF
--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/IXtendJvmAssociations.java
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/IXtendJvmAssociations.java
@@ -64,11 +64,14 @@ public interface IXtendJvmAssociations extends IJvmModelAssociations {
 	JvmConstructor getInferredConstructor(XtendConstructor xtendConstructor);
 	
 	/**
-	 * Returns the directly inferred operation for the given function.
-	 * If the function is a dispatch function, the dispatch case is returned and not the dispatcher.
+	 * Returns the directly inferred operation for the given function. If possible, this method returns
+	 * an operation with exactly the same name as the {@code xtendFunction}, otherwise the first
+	 * associated JVM operation. {@code null} is returned if there is no associated operation.
 	 * 
-	 * If the function is a create function, the public visible function is returned and not
-	 * the synthetic initializer function.
+	 * <p>If the function is a dispatch function, the dispatch case is returned and not the dispatcher.</p>
+	 * 
+	 * <p>If the function is a create function, the public visible function is returned and not
+	 * the synthetic initializer function.</p>
 	 * 
 	 * @see #getDispatchOperation(XtendFunction)
 	 */
@@ -157,6 +160,10 @@ public interface IXtendJvmAssociations extends IJvmModelAssociations {
 					return jvmOperation;
 				}
 			}
+			// The operation might have been renamed by an active annotation - return the primary JVM element
+			Iterator<JvmOperation> iterator = jvmElements.iterator();
+			if (iterator.hasNext())
+				return iterator.next();
 			return null;
 		}
 		

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/typesystem/XtendReentrantTypeResolver.java
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/typesystem/XtendReentrantTypeResolver.java
@@ -298,9 +298,11 @@ public class XtendReentrantTypeResolver extends LogicalContainerAwareReentrantTy
 				LightweightTypeReference actualType = resolvedTypes.getReturnType(expression);
 				if (actualType == null) {
 					JvmOperation operation = typeResolver.associations.getDirectlyInferredOperation(createFunction);
-					IFeatureScopeSession session = operation.isStatic() ? featureScopeSession : featureScopeSession.toInstanceContext();
-					typeResolver.computeTypes(resolvedTypesByContext, resolvedTypes, session, operation);
-					actualType = resolvedTypes.getReturnType(expression);
+					if (operation != null) {
+						IFeatureScopeSession session = operation.isStatic() ? featureScopeSession : featureScopeSession.toInstanceContext();
+						typeResolver.computeTypes(resolvedTypesByContext, resolvedTypes, session, operation);
+						actualType = resolvedTypes.getReturnType(expression);
+					}
 				}
 				if (actualType == null)
 					return null;
@@ -660,11 +662,13 @@ public class XtendReentrantTypeResolver extends LogicalContainerAwareReentrantTy
 				XtendFunction function = (XtendFunction) sourceElement;
 				if (function.getCreateExtensionInfo() != null) {
 					JvmOperation operation = associations.getDirectlyInferredOperation(function);
-					declareTypeParameters(resolvedTypes, field, resolvedTypesByContext);
-					XComputedTypeReference fieldType = getServices().getXtypeFactory().createXComputedTypeReference();
-					fieldType.setTypeProvider(new CreateCacheFieldTypeReferenceProvider(operation, resolvedTypes, featureScopeSession));
-					castedKnownType.setEquivalent(fieldType);
-					return;
+					if (operation != null) {
+						declareTypeParameters(resolvedTypes, field, resolvedTypesByContext);
+						XComputedTypeReference fieldType = getServices().getXtypeFactory().createXComputedTypeReference();
+						fieldType.setTypeProvider(new CreateCacheFieldTypeReferenceProvider(operation, resolvedTypes, featureScopeSession));
+						castedKnownType.setEquivalent(fieldType);
+						return;
+					}
 				}
 			}
 		}

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendJavaValidator.java
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendJavaValidator.java
@@ -1570,9 +1570,9 @@ public class XtendJavaValidator extends XbaseWithAnnotationsJavaValidator {
 	public void checkCreateFunctionIsNotTypeVoid(XtendFunction func) {
 		if (func.getCreateExtensionInfo() == null)
 			return;
-		JvmOperation operation = associations.getDirectlyInferredOperation(func);
 		if (func.getReturnType() == null) {
-			if (isPrimitiveVoid(operation.getReturnType())) {
+			JvmOperation operation = associations.getDirectlyInferredOperation(func);
+			if (operation != null && isPrimitiveVoid(operation.getReturnType())) {
 				error("void is an invalid type for the create method " + func.getName(), func,
 						XtendPackage.Literals.XTEND_FUNCTION__NAME, INVALID_USE_OF_TYPE);
 			}
@@ -2079,7 +2079,7 @@ public class XtendJavaValidator extends XbaseWithAnnotationsJavaValidator {
 			return;
 		JvmOperation jvmOperation = associations.getDirectlyInferredOperation(method);
 		IResolvedTypes types = batchTypeResolver.resolveTypes(method);
-		if (types.getActualType(jvmOperation).isPrimitiveVoid()) 
+		if (jvmOperation != null && types.getActualType(jvmOperation).isPrimitiveVoid()) 
 			return;
 		implicitReturnFinder.findImplicitReturns(method.getExpression(), new Acceptor() {
 			@Override

--- a/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/editor/OverrideIndicatorRulerAction.java
+++ b/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/editor/OverrideIndicatorRulerAction.java
@@ -127,8 +127,10 @@ public class OverrideIndicatorRulerAction extends ResourceAction implements IAct
 			public void process(XtextResource resource) throws Exception {
 				XtendFunction xtendFunction = (XtendFunction) resource.getEObject(overrideIndicatorAnnotation.getFunctionURIFragment());
 				JvmOperation operation = associations.getDirectlyInferredOperation(xtendFunction);
-				JvmOperation overridden = overrideHelper.findOverriddenOperation(operation);
-				uriEditorOpener.open(EcoreUtil.getURI(overridden), javaElementFinder.findElementFor(overridden), true);
+				if (operation != null) {
+					JvmOperation overridden = overrideHelper.findOverriddenOperation(operation);
+					uriEditorOpener.open(EcoreUtil.getURI(overridden), javaElementFinder.findElementFor(overridden), true);
+				}
 			}
 		});
 	}

--- a/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hover/XtendHoverDocumentationProvider.java
+++ b/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hover/XtendHoverDocumentationProvider.java
@@ -44,7 +44,9 @@ public class XtendHoverDocumentationProvider extends XbaseHoverDocumentationProv
 	protected JvmDeclaredType getDeclaringType(EObject eObject) {
 		if (eObject instanceof XtendFunction) {
 			JvmOperation jvmOperation = associations.getDirectlyInferredOperation((XtendFunction) eObject);
-			return super.getDeclaringType(jvmOperation);
+			if (jvmOperation != null) {
+				return super.getDeclaringType(jvmOperation);
+			}
 		}
 		return super.getDeclaringType(eObject);
 	}

--- a/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hover/XtendHoverSignatureProvider.java
+++ b/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hover/XtendHoverSignatureProvider.java
@@ -78,22 +78,27 @@ public class XtendHoverSignatureProvider extends XbaseDeclarativeHoverSignatureP
 
 	protected String _signature(XtendFunction function, boolean typeAtEnd) {
 		JvmOperation inferredOperation = associations.getDirectlyInferredOperation(function);
-		String returnTypeString = "void";
-		JvmTypeReference returnType = inferredOperation.getReturnType();
-		if (returnType != null) {
-			if (returnType instanceof JvmAnyTypeReference) {
-				throw new IllegalStateException();
-			} else {
-				returnTypeString = getTypeName(returnType);
+		if (inferredOperation != null) {
+			String returnTypeString = "void";
+			JvmTypeReference returnType = inferredOperation.getReturnType();
+			if (returnType != null) {
+				if (returnType instanceof JvmAnyTypeReference) {
+					throw new IllegalStateException();
+				} else {
+					returnTypeString = getTypeName(returnType);
+				}
 			}
+			StringBuilder signature = new StringBuilder();
+			String typeParameter = uiStrings.typeParameters(function.getTypeParameters());
+			if (typeParameter != null && typeParameter.length() > 0){
+				signature.append(typeParameter).append(" ");
+			}
+			signature.append(returnTypeString).append(" ");
+			signature.append(function.getName()).append(hoverUiStrings.parameters(inferredOperation));
+			signature.append(getThrowsDeclaration(inferredOperation));
+			return signature.toString();
 		}
-		String signature = function.getName() + hoverUiStrings.parameters(inferredOperation)
-				+ getThrowsDeclaration(inferredOperation);
-		String typeParameter = uiStrings.typeParameters(function.getTypeParameters());
-		if(typeParameter != null && typeParameter.length() > 0){
-			return typeParameter + " " + returnTypeString + " " + signature;
-		}
-		return returnTypeString + " " + signature;
+		return function.getName() + "()";
 	}
 
 	protected String _signature(XtendField field, boolean typeAtEnd) {
@@ -162,7 +167,9 @@ public class XtendHoverSignatureProvider extends XbaseDeclarativeHoverSignatureP
 		if(container instanceof XtendFunction){
 			XtendFunction function = (XtendFunction) container;
 			JvmOperation inferredOperation = associations.getDirectlyInferredOperation(function);
-			return function.getName() + uiStrings.parameters(inferredOperation);
+			if (inferredOperation != null) {
+				return function.getName() + uiStrings.parameters(inferredOperation);
+			}
 		}
 		else if (container instanceof XtendConstructor){
 			XtendConstructor constructor = (XtendConstructor) container;

--- a/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/labeling/XtendLabelProvider.xtend
+++ b/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/labeling/XtendLabelProvider.xtend
@@ -15,13 +15,13 @@ import org.eclipse.xtend.core.xtend.XtendField
 import org.eclipse.xtend.core.xtend.XtendFile
 import org.eclipse.xtend.core.xtend.XtendFunction
 import org.eclipse.xtend.core.xtend.XtendInterface
+import org.eclipse.xtend.core.xtend.XtendParameter
 import org.eclipse.xtext.common.types.JvmOperation
 import org.eclipse.xtext.common.types.JvmTypeReference
 import org.eclipse.xtext.naming.QualifiedName
 import org.eclipse.xtext.xbase.scoping.featurecalls.OperatorMapping
 import org.eclipse.xtext.xbase.ui.labeling.XbaseImageAdornments
 import org.eclipse.xtext.xbase.validation.UIStrings
-import org.eclipse.xtend.core.xtend.XtendParameter
 
 /**
  * Provides labels for Xtend elements.
@@ -68,7 +68,9 @@ public class XtendLabelProvider extends XtendJvmLabelProvider {
 	}
 
 	protected def dispatch imageDescriptor(XtendFunction element) {
-		images.forOperation(element.visibility, adornments.get(element.directlyInferredOperation))
+		val operation = element.directlyInferredOperation
+		if (operation != null)
+			images.forOperation(element.visibility, adornments.get(operation))
 	}
 
 	protected def dispatch imageDescriptor(AnonymousClass element) {

--- a/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/CreateMemberQuickfixes.java
+++ b/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/CreateMemberQuickfixes.java
@@ -207,8 +207,10 @@ public class CreateMemberQuickfixes implements ILinkingIssueQuickfixProvider {
 	protected LightweightTypeReference getReceiverType(XAbstractFeatureCall featureCall) {
 		XExpression actualReceiver = featureCall.getActualReceiver();
 		ITypeReferenceOwner owner = new StandardTypeReferenceOwner(services, featureCall);
-		if(actualReceiver == null) {
-			return owner.newParameterizedTypeReference(getCallersType(featureCall));
+		if (actualReceiver == null) {
+			JvmDeclaredType callersType = getCallersType(featureCall);
+			if (callersType != null)
+				return owner.newParameterizedTypeReference(callersType);
 		} else if (actualReceiver instanceof XAbstractFeatureCall && ((XAbstractFeatureCall) actualReceiver).isTypeLiteral()) {
 			JvmType type = (JvmType) ((XAbstractFeatureCall) actualReceiver).getFeature();
 			ParameterizedTypeReference reference = owner.newParameterizedTypeReference(type);

--- a/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
+++ b/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
@@ -538,20 +538,22 @@ public class XtendQuickfixProvider extends XbaseQuickfixProvider {
 					jvmElement = associations.getJvmField((XtendField) element);
 				}
 				
-				LightweightTypeReference type = batchTypeResolver.resolveTypes(element).getActualType(jvmElement);
-				INode node = Iterables.getFirst(NodeModelUtils.findNodesForFeature(element, featureAfterType), null);
-				
-				if (node == null) {
-					throw new IllegalStateException("Could not determine node for " + element);
+				if (jvmElement != null) {
+					LightweightTypeReference type = batchTypeResolver.resolveTypes(element).getActualType(jvmElement);
+					INode node = Iterables.getFirst(NodeModelUtils.findNodesForFeature(element, featureAfterType), null);
+					
+					if (node == null) {
+						throw new IllegalStateException("Could not determine node for " + element);
+					}
+					if (type == null) {
+						throw new IllegalStateException("Could not determine type for " + element);
+					}
+					ReplacingAppendable appendable = appendableFactory.create(context.getXtextDocument(),
+							(XtextResource) element.eResource(), node.getOffset(), 0);
+					appendable.append(type);
+					appendable.append(" ");
+					appendable.commitChanges();
 				}
-				if (type == null) {
-					throw new IllegalStateException("Could not determine type for " + element);
-				}
-				ReplacingAppendable appendable = appendableFactory.create(context.getXtextDocument(),
-						(XtextResource) element.eResource(), node.getOffset(), 0);
-				appendable.append(type);
-				appendable.append(" ");
-				appendable.commitChanges();
 			}
 		});
 	}

--- a/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/labeling/XtendLabelProvider.java
+++ b/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/labeling/XtendLabelProvider.java
@@ -115,10 +115,19 @@ public class XtendLabelProvider extends XtendJvmLabelProvider {
   }
   
   protected ImageDescriptor _imageDescriptor(final XtendFunction element) {
-    JvmVisibility _visibility = element.getVisibility();
-    JvmOperation _directlyInferredOperation = this._iXtendJvmAssociations.getDirectlyInferredOperation(element);
-    int _get = this.adornments.get(_directlyInferredOperation);
-    return this.images.forOperation(_visibility, _get);
+    ImageDescriptor _xblockexpression = null;
+    {
+      final JvmOperation operation = this._iXtendJvmAssociations.getDirectlyInferredOperation(element);
+      ImageDescriptor _xifexpression = null;
+      boolean _notEquals = (!Objects.equal(operation, null));
+      if (_notEquals) {
+        JvmVisibility _visibility = element.getVisibility();
+        int _get = this.adornments.get(operation);
+        _xifexpression = this.images.forOperation(_visibility, _get);
+      }
+      _xblockexpression = _xifexpression;
+    }
+    return _xblockexpression;
   }
   
   protected ImageDescriptor _imageDescriptor(final AnonymousClass element) {

--- a/plugins/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/impl/JvmIdentifiableElementImplCustom.java
+++ b/plugins/org.eclipse.xtext.common.types/src/org/eclipse/xtext/common/types/impl/JvmIdentifiableElementImplCustom.java
@@ -26,7 +26,12 @@ public abstract class JvmIdentifiableElementImplCustom extends JvmIdentifiableEl
 			result.append(eProxyURI());
 			result.append(')');
 		} else {
-			result.append(getIdentifier());
+			try {
+				result.append(getIdentifier());
+			} catch (Exception e) {
+				// Some types could not be resolved while computing the identifier
+				result.append(getSimpleName());
+			}
 		}
 		return result.toString();
 	}

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/jvmmodel/JvmTypesBuilder.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/jvmmodel/JvmTypesBuilder.java
@@ -9,10 +9,7 @@ package org.eclipse.xtext.xbase.jvmmodel;
 
 import static com.google.common.collect.Iterables.*;
 
-import java.util.Iterator;
-
 import org.apache.log4j.Logger;
-import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.InternalEObject;
@@ -164,15 +161,16 @@ public class JvmTypesBuilder {
 	 * @param member the member to remove the body from
 	 */
 	public void removeExistingBody(/* @Nullable */ JvmMember member) {
-		if(member != null) {
-			// remove old adapters
-			Iterator<Adapter> iterator = member.eAdapters().iterator();
-			while (iterator.hasNext()) {
-				Adapter adapter = iterator.next();
-				if (adapter instanceof CompilationStrategyAdapter) {
-					iterator.remove();
-				} else if (adapter instanceof CompilationTemplateAdapter) {
-					iterator.remove();
+		if (member != null) {
+			// We have to be careful how to remove existing adapters due to an EMF bug:
+			// https://bugs.eclipse.org/bugs/show_bug.cgi?id=462451
+			Object[] adapters = member.eAdapters().toArray();
+			for (int i = 0, j = 0; i < adapters.length; i++) {
+				if (adapters[i] instanceof CompilationStrategyAdapter
+						|| adapters[i] instanceof CompilationTemplateAdapter) {
+					member.eAdapters().remove(j);
+				} else {
+					j++;
 				}
 			}
 			associator.removeLogicalChildAssociation(member);

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/Bug446364Test.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/Bug446364Test.xtend
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.macro
+
+import org.eclipse.xtend.lib.macro.AbstractClassProcessor
+import org.eclipse.xtend.lib.macro.Active
+import org.eclipse.xtend.lib.macro.TransformationContext
+import org.eclipse.xtend.lib.macro.declaration.MutableClassDeclaration
+import org.junit.Test
+
+/**
+ * @author Miro Spoenemann - Initial contribution and API
+ */
+class Bug446364Test extends AbstractActiveAnnotationTest {
+	
+	@Test def void testRenameMethods() {
+		'''
+			@org.eclipse.xtend.core.tests.macro.Bug446364('rename')
+			class C {
+				def String test() {
+					"code"
+				}
+				def create new StringBuilder createMethod(String p) {
+					append(p)
+				}
+			}
+		'''.assertCompilesTo('''
+			import java.util.ArrayList;
+			import java.util.HashMap;
+			import org.eclipse.xtend.core.tests.macro.Bug446364;
+			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+			
+			@Bug446364("rename")
+			@SuppressWarnings("all")
+			public class C {
+			  public String prefix_test() {
+			    return "code";
+			  }
+			  
+			  public StringBuilder prefix_createMethod(final String p) {
+			    final ArrayList<?> _cacheKey = CollectionLiterals.newArrayList(p);
+			    final StringBuilder _result;
+			    synchronized (_createCache_createMethod) {
+			      if (_createCache_createMethod.containsKey(_cacheKey)) {
+			        return _createCache_createMethod.get(_cacheKey);
+			      }
+			      StringBuilder _stringBuilder = new StringBuilder();
+			      _result = _stringBuilder;
+			      _createCache_createMethod.put(_cacheKey, _result);
+			    }
+			    prefix__init_createMethod(_result, p);
+			    return _result;
+			  }
+			  
+			  private final HashMap<ArrayList<?>, StringBuilder> _createCache_createMethod = CollectionLiterals.newHashMap();
+			  
+			  private void prefix__init_createMethod(final StringBuilder it, final String p) {
+			    it.append(p);
+			  }
+			}
+		''')
+	}
+	
+	@Test def void testChangeBody() {
+		// Changing the body of a create method does not make any sense, and it leads to type computation problems
+		// as seen below, but we want to make sure the AA processing completes without errors.
+		'''
+			@org.eclipse.xtend.core.tests.macro.Bug446364('changeBody')
+			class C {
+				def String test() {
+					"code"
+				}
+				def create new StringBuilder createMethod(String p) {
+					append(p)
+				}
+			}
+		'''.assertCompilesTo('''
+			import java.util.ArrayList;
+			import java.util.HashMap;
+			import org.eclipse.xtend.core.tests.macro.Bug446364;
+			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+			
+			@Bug446364("changeBody")
+			@SuppressWarnings("all")
+			public class C {
+			  public String test() {
+			    return null;
+			  }
+			  
+			  public StringBuilder createMethod(final String p) {
+			    return null;
+			  }
+			  
+			  private final HashMap<ArrayList<?>, StringBuilder> _createCache_createMethod = CollectionLiterals.newHashMap();
+			  
+			  private void _init_createMethod(final Object/* type is 'null' */ it, final String p) {
+			    return null;
+			  }
+			}
+		''')
+	}
+	
+}
+
+
+@Active(Bug446364Processor)
+annotation Bug446364 {
+	String value
+}
+class Bug446364Processor extends AbstractClassProcessor {
+	
+	override doTransform(MutableClassDeclaration annotatedClass, extension TransformationContext context) {
+		switch (annotatedClass.annotations.head.getStringValue('value')) {
+			case 'rename': {
+				annotatedClass.declaredMethods.forEach[
+					simpleName = 'prefix_' + simpleName
+				]
+			}
+			case 'changeBody': {
+				annotatedClass.declaredMethods.forEach[
+					body = '''return null;'''
+				]
+			}
+		}
+	}
+	
+}

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/Bug446364.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/Bug446364.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.macro;
+
+import org.eclipse.xtend.core.tests.macro.Bug446364Processor;
+import org.eclipse.xtend.lib.macro.Active;
+
+@Active(Bug446364Processor.class)
+public @interface Bug446364 {
+  public String value();
+}

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/Bug446364Processor.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/Bug446364Processor.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.macro;
+
+import com.google.common.base.Objects;
+import org.eclipse.xtend.lib.macro.AbstractClassProcessor;
+import org.eclipse.xtend.lib.macro.TransformationContext;
+import org.eclipse.xtend.lib.macro.declaration.AnnotationReference;
+import org.eclipse.xtend.lib.macro.declaration.MutableClassDeclaration;
+import org.eclipse.xtend.lib.macro.declaration.MutableMethodDeclaration;
+import org.eclipse.xtend2.lib.StringConcatenationClient;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+
+@SuppressWarnings("all")
+public class Bug446364Processor extends AbstractClassProcessor {
+  @Override
+  public void doTransform(final MutableClassDeclaration annotatedClass, @Extension final TransformationContext context) {
+    Iterable<? extends AnnotationReference> _annotations = annotatedClass.getAnnotations();
+    AnnotationReference _head = IterableExtensions.head(_annotations);
+    String _stringValue = _head.getStringValue("value");
+    boolean _matched = false;
+    if (!_matched) {
+      if (Objects.equal(_stringValue, "rename")) {
+        _matched=true;
+        Iterable<? extends MutableMethodDeclaration> _declaredMethods = annotatedClass.getDeclaredMethods();
+        final Procedure1<MutableMethodDeclaration> _function = new Procedure1<MutableMethodDeclaration>() {
+          @Override
+          public void apply(final MutableMethodDeclaration it) {
+            String _simpleName = it.getSimpleName();
+            String _plus = ("prefix_" + _simpleName);
+            it.setSimpleName(_plus);
+          }
+        };
+        IterableExtensions.forEach(_declaredMethods, _function);
+      }
+    }
+    if (!_matched) {
+      if (Objects.equal(_stringValue, "changeBody")) {
+        _matched=true;
+        Iterable<? extends MutableMethodDeclaration> _declaredMethods_1 = annotatedClass.getDeclaredMethods();
+        final Procedure1<MutableMethodDeclaration> _function_1 = new Procedure1<MutableMethodDeclaration>() {
+          @Override
+          public void apply(final MutableMethodDeclaration it) {
+            StringConcatenationClient _client = new StringConcatenationClient() {
+              @Override
+              protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
+                _builder.append("return null;");
+              }
+            };
+            it.setBody(_client);
+          }
+        };
+        IterableExtensions.forEach(_declaredMethods_1, _function_1);
+      }
+    }
+  }
+}

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/Bug446364Test.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/Bug446364Test.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.macro;
+
+import org.eclipse.xtend.core.tests.macro.AbstractActiveAnnotationTest;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.junit.Test;
+
+/**
+ * @author Miro Spoenemann - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class Bug446364Test extends AbstractActiveAnnotationTest {
+  @Test
+  public void testRenameMethods() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("@org.eclipse.xtend.core.tests.macro.Bug446364(\'rename\')");
+    _builder.newLine();
+    _builder.append("class C {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def String test() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("\"code\"");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def create new StringBuilder createMethod(String p) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("append(p)");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import java.util.ArrayList;");
+    _builder_1.newLine();
+    _builder_1.append("import java.util.HashMap;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtend.core.tests.macro.Bug446364;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@Bug446364(\"rename\")");
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public String prefix_test() {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return \"code\";");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public StringBuilder prefix_createMethod(final String p) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("final ArrayList<?> _cacheKey = CollectionLiterals.newArrayList(p);");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("final StringBuilder _result;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("synchronized (_createCache_createMethod) {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("if (_createCache_createMethod.containsKey(_cacheKey)) {");
+    _builder_1.newLine();
+    _builder_1.append("        ");
+    _builder_1.append("return _createCache_createMethod.get(_cacheKey);");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("StringBuilder _stringBuilder = new StringBuilder();");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_result = _stringBuilder;");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_createCache_createMethod.put(_cacheKey, _result);");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("prefix__init_createMethod(_result, p);");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return _result;");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("private final HashMap<ArrayList<?>, StringBuilder> _createCache_createMethod = CollectionLiterals.newHashMap();");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("private void prefix__init_createMethod(final StringBuilder it, final String p) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("it.append(p);");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this._xtendCompilerTester.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void testChangeBody() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("@org.eclipse.xtend.core.tests.macro.Bug446364(\'changeBody\')");
+    _builder.newLine();
+    _builder.append("class C {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def String test() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("\"code\"");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def create new StringBuilder createMethod(String p) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("append(p)");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import java.util.ArrayList;");
+    _builder_1.newLine();
+    _builder_1.append("import java.util.HashMap;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtend.core.tests.macro.Bug446364;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@Bug446364(\"changeBody\")");
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public String test() {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return null;");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public StringBuilder createMethod(final String p) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return null;");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("private final HashMap<ArrayList<?>, StringBuilder> _createCache_createMethod = CollectionLiterals.newHashMap();");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("private void _init_createMethod(final Object/* type is \'null\' */ it, final String p) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return null;");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this._xtendCompilerTester.assertCompilesTo(_builder, _builder_1);
+  }
+}


### PR DESCRIPTION
- `IXtendJvmAssociations.getDirectlyInferredOperation(XtendFunction)` now returns the first associated JVM operation if no directly matching operation is found (an AA might have renamed it).
- The helper method above can return null (e.g. an AA removes the operation); this has already been considered in several places where it is used. Added missing null checks.
- Added a workaround for [bug 462451](https://bugs.eclipse.org/bugs/show_bug.cgi?id=462451) to `JvmTypesBuilder.removeExistingBody(JvmMember)`
- Made `JvmIdentifiableElement.toString()` more robust for easier debugging.