### PR TITLE
[serializer] excluded tests from old GenericSemanticSequencer

### DIFF
--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/GenericSemanticSequencerTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/GenericSemanticSequencerTest.java
@@ -170,5 +170,20 @@ public class GenericSemanticSequencerTest extends AbstractSemanticSequencerTest 
 	@Test public void testUnorderedGroupBoolean8() throws Exception {
 		// unsupported
 	}
+	
+	@Override
+	@Test public void testSingleKeyword1OrID() throws Exception {
+		// unsupported
+	}
+	
+	@Override
+	@Test public void testSingleKeywordOrID2() throws Exception {
+		// unsupported
+	}
+	
+	@Override
+	@Test public void testSingleKeywordOrID3() throws Exception {
+		// unsupported
+	}
 
 }


### PR DESCRIPTION
...because BacktrackingSemanticSequencer can handle them

Change-Id: I83ac829a43a5623dbb38e8086ab462c89e7e0a2d