### PR TITLE
[462121] don't log broken JARs during indexing as errors

### DIFF
--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/SourceAttachmentPackageFragmentRootWalker.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/SourceAttachmentPackageFragmentRootWalker.java
@@ -70,7 +70,7 @@ abstract class SourceAttachmentPackageFragmentRootWalker<T> extends PackageFragm
 							}
 						}
 					} catch (IOException e) {
-						LOG.error(e.getMessage(), e);
+						LOG.debug(e.getMessage(), e);
 					}
 				}
 			}


### PR DESCRIPTION
Change-Id: I
Signed-off-by: Jan Koehnlein <jan.koehnlein@itemis.de>

A PFR with a broken jar. This is likely detected and reported by JDT as well, so we should not log this as an error.