### PR TITLE
[serializer] bug 462536: deprecate GenericSemanticSequencer

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/sequencer/GenericSemanticSequencer.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/sequencer/GenericSemanticSequencer.java
@@ -49,7 +49,9 @@ import com.google.inject.Inject;
 
 /**
  * @author Moritz Eysholdt - Initial contribution and API
+ * @deprecated use {@link BacktrackingSemanticSequencer}
  */
+@Deprecated
 public class GenericSemanticSequencer extends AbstractSemanticSequencer {
 
 	protected abstract class Allocation {

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/sequencer/ISemanticSequencer.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/sequencer/ISemanticSequencer.java
@@ -6,7 +6,7 @@ import org.eclipse.xtext.serializer.diagnostic.ISerializationDiagnostic;
 
 import com.google.inject.ImplementedBy;
 
-@ImplementedBy(GenericSemanticSequencer.class)
+@ImplementedBy(BacktrackingSemanticSequencer.class)
 public interface ISemanticSequencer {
 
 	void init(ISemanticSequenceAcceptor sequenceAcceptor, ISerializationDiagnostic.Acceptor errorAcceptor);


### PR DESCRIPTION
This also changes the just-in-time-binding for ISemanticSequencer from
GenericSemanticSequencer to BacktrackingSemanticSequencer. I'm not
expecting this it have an impact because the RuntimeModule overrides
this binding for ISemanticSequencer

Change-Id: I8eb0d71124bef43edee40101851e044e831f66d0