### PR TITLE
[461764]: Fixed wrongly propagated exception

### DIFF
--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/CachingResourceValidatorImpl.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/CachingResourceValidatorImpl.xtend
@@ -23,6 +23,7 @@ import org.eclipse.xtext.xbase.annotations.validation.DerivedStateAwareResourceV
 import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociations
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypeExtensions
 import org.eclipse.xtext.xbase.typesystem.computation.DiagnosticOnFirstKeyword
+import org.eclipse.xtext.service.OperationCanceledError
 
 class CachingResourceValidatorImpl extends DerivedStateAwareResourceValidator {
 
@@ -33,7 +34,7 @@ class CachingResourceValidatorImpl extends DerivedStateAwareResourceValidator {
 	@Inject extension JvmTypeExtensions 
 	@Inject OperationCanceledManager operationCanceledManager
 	
-	override validate(Resource resource, CheckMode mode, CancelIndicator mon) {
+	override validate(Resource resource, CheckMode mode, CancelIndicator mon) throws OperationCanceledError {
 		return cache.get(mode, resource) [ |
 			operationCanceledManager.checkCanceled(mon)
 			return super.validate(resource, mode, mon)

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/validation/CachingResourceValidatorImpl.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/validation/CachingResourceValidatorImpl.java
@@ -28,6 +28,7 @@ import org.eclipse.xtext.common.types.JvmMember;
 import org.eclipse.xtext.common.types.JvmOperation;
 import org.eclipse.xtext.common.types.JvmTypeReference;
 import org.eclipse.xtext.diagnostics.Severity;
+import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.IAcceptor;
@@ -69,7 +70,7 @@ public class CachingResourceValidatorImpl extends DerivedStateAwareResourceValid
   private OperationCanceledManager operationCanceledManager;
   
   @Override
-  public List<Issue> validate(final Resource resource, final CheckMode mode, final CancelIndicator mon) {
+  public List<Issue> validate(final Resource resource, final CheckMode mode, final CancelIndicator mon) throws OperationCanceledError {
     final Provider<List<Issue>> _function = new Provider<List<Issue>>() {
       @Override
       public List<Issue> get() {

--- a/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/validator/XtendResourceValidator.xtend
+++ b/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/validator/XtendResourceValidator.xtend
@@ -13,13 +13,14 @@ import org.eclipse.xtext.util.CancelIndicator
 import org.eclipse.xtext.validation.CheckMode
 import org.eclipse.xtend.core.validation.CachingResourceValidatorImpl
 import org.eclipse.xtend.ide.macro.JdtBasedProcessorProvider.ProcessorClassloaderAdapter
+import org.eclipse.xtext.service.OperationCanceledError
 
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
 class XtendResourceValidator extends CachingResourceValidatorImpl {
 	
-	override validate(Resource resource, CheckMode mode, CancelIndicator mon) {
+	override validate(Resource resource, CheckMode mode, CancelIndicator mon) throws OperationCanceledError {
 		try {
 			super.validate(resource, mode, mon)
 		} finally {

--- a/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/validator/XtendResourceValidator.java
+++ b/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/validator/XtendResourceValidator.java
@@ -15,6 +15,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtend.core.validation.CachingResourceValidatorImpl;
 import org.eclipse.xtend.ide.macro.JdtBasedProcessorProvider;
 import org.eclipse.xtext.resource.ResourceSetContext;
+import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.Issue;
@@ -26,7 +27,7 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 @SuppressWarnings("all")
 public class XtendResourceValidator extends CachingResourceValidatorImpl {
   @Override
-  public List<Issue> validate(final Resource resource, final CheckMode mode, final CancelIndicator mon) {
+  public List<Issue> validate(final Resource resource, final CheckMode mode, final CancelIndicator mon) throws OperationCanceledError {
     List<Issue> _xtrycatchfinallyexpression = null;
     try {
       _xtrycatchfinallyexpression = super.validate(resource, mode, mon);

--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/ValidationJob.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/ValidationJob.java
@@ -19,6 +19,7 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.concurrent.CancelableUnitOfWork;
 import org.eclipse.xtext.util.concurrent.IReadAccess;
@@ -64,6 +65,8 @@ public class ValidationJob extends Job {
 		List<Issue> issues = null;
 		try {
 			issues = createIssues(monitor);
+		} catch (OperationCanceledError canceled) {
+			return Status.CANCEL_STATUS;
 		} catch (OperationCanceledException canceled) {
 			return Status.CANCEL_STATUS;
 		} catch (Exception e) {

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/service/OperationCanceledManager.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/service/OperationCanceledManager.xtend
@@ -9,8 +9,6 @@ package org.eclipse.xtext.service
 
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.OperationCanceledException
-import org.eclipse.xtend.lib.annotations.Accessors
-import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import org.eclipse.xtext.util.CancelIndicator
 
 /**
@@ -89,27 +87,11 @@ class OperationCanceledManager {
 /**
  * @since 2.8
  */
-@FinalFieldsConstructor class OperationCanceledError extends Error {
-	@Accessors final RuntimeException wrapped
-	
-	override fillInStackTrace() {
-		super.fillInStackTrace
+class OperationCanceledError extends Error {
+	new(RuntimeException cause) {
+		super(cause)
 	}
-
-	override getCause() {
-		wrapped
+	def RuntimeException getWrapped() {
+		return cause as RuntimeException
 	}
-	
-	override getLocalizedMessage() {
-		wrapped.localizedMessage
-	}
-	
-	override getMessage() {
-		wrapped.message
-	}
-	
-	override getStackTrace() {
-		wrapped.stackTrace
-	}
-	
 }

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/validation/IResourceValidator.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/validation/IResourceValidator.java
@@ -9,8 +9,9 @@ package org.eclipse.xtext.validation;
 
 import java.util.Collections;
 import java.util.List;
-import org.eclipse.xtext.util.CancelIndicator;
 
+import org.eclipse.xtext.service.OperationCanceledError;
+import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.emf.ecore.resource.Resource;
 
 import com.google.inject.ImplementedBy;
@@ -22,9 +23,14 @@ import com.google.inject.ImplementedBy;
 @ImplementedBy(ResourceValidatorImpl.class)
 public interface IResourceValidator {
 	/**
+	 * Validates the given resource according to the {@link CheckMode mode}. An optional {@link CancelIndicator}
+	 * may be provide to allow the method to exit early in case the long running validation was canceled by the
+	 * user.
+	 * 
 	 * @return all issues of the underlying resources (includes syntax errors as well as semantic problems)
+	 * @throws OperationCanceledError if the validation was cancelled, the method may exit with an {@link OperationCanceledError}
 	 */
-	List<Issue> validate(Resource resource, CheckMode mode, CancelIndicator indicator);
+	List<Issue> validate(Resource resource, CheckMode mode, CancelIndicator indicator) throws OperationCanceledError;
 
 	IResourceValidator NULL = new IResourceValidator() {
 		@Override

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/validation/ResourceValidatorImpl.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/validation/ResourceValidatorImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.ecore.util.Diagnostician;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.diagnostics.Severity;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.IAcceptor;
@@ -66,7 +67,7 @@ public class ResourceValidatorImpl implements IResourceValidator {
 	private OperationCanceledManager operationCanceledManager;
 	
 	@Override
-	public List<Issue> validate(Resource resource, final CheckMode mode, CancelIndicator mon) {
+	public List<Issue> validate(Resource resource, final CheckMode mode, CancelIndicator mon) throws OperationCanceledError {
 		StoppedTask task = Stopwatches.forTask("ResourceValidatorImpl.validation");
 		try {
 			task.start();

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/service/OperationCanceledError.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/service/OperationCanceledError.java
@@ -7,51 +7,17 @@
  */
 package org.eclipse.xtext.service;
 
-import org.eclipse.xtend.lib.annotations.Accessors;
-import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
-import org.eclipse.xtext.xbase.lib.Pure;
-
 /**
  * @since 2.8
  */
-@FinalFieldsConstructor
 @SuppressWarnings("all")
 public class OperationCanceledError extends Error {
-  @Accessors
-  private final RuntimeException wrapped;
-  
-  @Override
-  public Throwable fillInStackTrace() {
-    return super.fillInStackTrace();
+  public OperationCanceledError(final RuntimeException cause) {
+    super(cause);
   }
   
-  @Override
-  public Throwable getCause() {
-    return this.wrapped;
-  }
-  
-  @Override
-  public String getLocalizedMessage() {
-    return this.wrapped.getLocalizedMessage();
-  }
-  
-  @Override
-  public String getMessage() {
-    return this.wrapped.getMessage();
-  }
-  
-  @Override
-  public StackTraceElement[] getStackTrace() {
-    return this.wrapped.getStackTrace();
-  }
-  
-  public OperationCanceledError(final RuntimeException wrapped) {
-    super();
-    this.wrapped = wrapped;
-  }
-  
-  @Pure
   public RuntimeException getWrapped() {
-    return this.wrapped;
+    Throwable _cause = this.getCause();
+    return ((RuntimeException) _cause);
   }
 }


### PR DESCRIPTION
The IResourceValidator is not supposed to throw a platform
specific cancellation exception but should wrap it in an
OperationCanceledError instead.

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=461764

Signed-off-by: szarnekow <Sebastian.Zarnekow@itemis.de>