### PR TITLE
[460696]: Fixed erroneous genmodel declaration

### DIFF
--- a/plugins/org.eclipse.xtext.ui.codetemplates/model/generated/Codetemplates.ecore
+++ b/plugins/org.eclipse.xtext.ui.codetemplates/model/generated/Codetemplates.ecore
@@ -3,7 +3,7 @@
     xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="templates" nsURI="http://www.eclipse.org/xtext/codetemplate/Codetemplates"
     nsPrefix="templates">
   <eClassifiers xsi:type="ecore:EClass" name="Codetemplates">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="language" eType="ecore:EClass platform:/resource/org.eclipse.xtext/src/org/eclipse/xtext/Xtext.ecore#//Grammar"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="language" eType="ecore:EClass platform:/resource/org.eclipse.xtext/org/eclipse/xtext/Xtext.ecore#//Grammar"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="templates" upperBound="-1"
         eType="#//Codetemplate" containment="true"/>
   </eClassifiers>
@@ -11,7 +11,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" eType="ecore:EDataType platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="description" eType="ecore:EDataType platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="context" eType="ecore:EClass platform:/resource/org.eclipse.xtext/src/org/eclipse/xtext/Xtext.ecore#//AbstractRule"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="context" eType="ecore:EClass platform:/resource/org.eclipse.xtext/org/eclipse/xtext/Xtext.ecore#//AbstractRule"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="keywordContext" eType="ecore:EDataType platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="body" eType="#//TemplateBody"
         containment="true"/>

--- a/plugins/org.eclipse.xtext.ui.codetemplates/model/generated/Codetemplates.genmodel
+++ b/plugins/org.eclipse.xtext.ui.codetemplates/model/generated/Codetemplates.genmodel
@@ -3,9 +3,10 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/org.eclipse.xtext.ui.codetemplates/src-gen" editDirectory="/org.eclipse.xtext.ui.codetemplates.edit/src"
     editorDirectory="/org.eclipse.xtext.ui.codetemplates.editor/src" modelPluginID="org.eclipse.xtext.ui.codetemplates"
     forceOverwrite="true" modelName="Codetemplates" updateClasspath="false" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
-    complianceLevel="6.0" copyrightFields="false" editPluginID="org.eclipse.xtext.ui.codetemplates.edit"
-    editorPluginID="org.eclipse.xtext.ui.codetemplates.editor" runtimeVersion="2.9"
-    usedGenPackages="platform:/resource/org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore platform:/resource/org.eclipse.xtext/src/org/eclipse/xtext/Xtext.genmodel#//xtext">
+    importerID="org.eclipse.emf.importer.ecore" complianceLevel="6.0" copyrightFields="false"
+    editPluginID="org.eclipse.xtext.ui.codetemplates.edit" editorPluginID="org.eclipse.xtext.ui.codetemplates.editor"
+    runtimeVersion="2.9" usedGenPackages="platform:/resource/org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore platform:/resource/org.eclipse.xtext/org/eclipse/xtext/Xtext.genmodel#//xtext">
+  <foreignModel>Codetemplates.ecore</foreignModel>
   <genPackages prefix="Templates" basePackage="org.eclipse.xtext.ui.codetemplates"
       disposableProviderFactory="true" ecorePackage="Codetemplates.ecore#/">
     <genClasses ecoreClass="Codetemplates.ecore#//Codetemplates">

--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JdtClasspathUriResolver.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JdtClasspathUriResolver.java
@@ -103,6 +103,11 @@ public class JdtClasspathUriResolver implements IClasspathUriResolver {
 					}
 				}
 			}
+			// not found in a source folder - look for a resource relative to project root
+			IResource resourceFromProjectRoot = javaProject.getProject().findMember(classpathUri.path());
+			if (resourceFromProjectRoot != null && resourceFromProjectRoot.exists()) {
+				return createPlatformResourceURI(resourceFromProjectRoot);
+			}
 		}
 		return classpathUri;
 	}

--- a/plugins/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/reconciler/CancelIndicatorBasedProgressMonitor.java
+++ b/plugins/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/reconciler/CancelIndicatorBasedProgressMonitor.java
@@ -31,6 +31,7 @@ public class CancelIndicatorBasedProgressMonitor implements IProgressMonitor {
     this.cancelIndicator = cancelIndicator;
   }
   
+  @Override
   public boolean isCanceled() {
     return this.cancelIndicator.isCanceled();
   }

--- a/plugins/org.eclipse.xtext/build.properties
+++ b/plugins/org.eclipse.xtext/build.properties
@@ -7,7 +7,8 @@ bin.includes = .,\
                about.mappings,\
                about.properties,\
                about.html,\
-               modeling32.png
+               modeling32.png,\
+               org/
 jars.compile.order = .
 source.. = src/,\
            emf-gen/,\

--- a/plugins/org.eclipse.xtext/org/eclipse/xtext/Xtext.ecore
+++ b/plugins/org.eclipse.xtext/org/eclipse/xtext/Xtext.ecore
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ecore:EPackage xmi:version="2.0"
-    xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="xtext"
-    nsURI="http://www.eclipse.org/2008/Xtext" nsPrefix="xtext">
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="xtext" nsURI="http://www.eclipse.org/2008/Xtext" nsPrefix="xtext">
   <eClassifiers xsi:type="ecore:EClass" name="Grammar">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="usedGrammars" unique="false"

--- a/plugins/org.eclipse.xtext/org/eclipse/xtext/Xtext.genmodel
+++ b/plugins/org.eclipse.xtext/org/eclipse/xtext/Xtext.genmodel
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<genmodel:GenModel xmi:version="2.0"
-    xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
-    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/org.eclipse.xtext/emf-gen"
-    editDirectory="/org.eclipse.xtext.edit/src" editorDirectory="/org.eclipse.xtext.editor/src"
-    modelPluginID="org.eclipse.xtext" forceOverwrite="true" modelName="Xtext" updateClasspath="false"
-    rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container" importerID="org.eclipse.emf.importer.ecore"
-    complianceLevel="5.0" copyrightFields="false" editPluginID="org.eclipse.xtext.edit"
-    editorPluginID="org.eclipse.xtext.editor" usedGenPackages="platform:/resource/org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore">>
+<genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
+    xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/org.eclipse.xtext/emf-gen" editDirectory="/org.eclipse.xtext.edit/src"
+    editorDirectory="/org.eclipse.xtext.editor/src" modelPluginID="org.eclipse.xtext"
+    forceOverwrite="true" modelName="Xtext" updateClasspath="false" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
+    importerID="org.eclipse.emf.importer.ecore" complianceLevel="5.0" copyrightFields="false"
+    editPluginID="org.eclipse.xtext.edit" editorPluginID="org.eclipse.xtext.editor"
+    usedGenPackages="../../../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore">
   <foreignModel>Xtext.ecore</foreignModel>
   <genPackages prefix="Xtext" basePackage="org.eclipse" disposableProviderFactory="true"
       ecorePackage="Xtext.ecore#/">
@@ -42,6 +41,7 @@
     <genClasses ecoreClass="Xtext.ecore#//AbstractElement">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Xtext.ecore#//AbstractElement/cardinality"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Xtext.ecore#//AbstractElement/predicated"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Xtext.ecore#//AbstractElement/firstSetPredicated"/>
     </genClasses>
     <genClasses ecoreClass="Xtext.ecore#//Action">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Xtext.ecore#//Action/type"/>

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/metamodelreferencing/tests/MetamodelRefTestLanguage.ecore
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/metamodelreferencing/tests/MetamodelRefTestLanguage.ecore
@@ -5,7 +5,7 @@
   <eClassifiers xsi:type="ecore:EClass" name="Foo">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="nameRefs" upperBound="-1"
-        eType="ecore:EClass platform:/resource/org.eclipse.xtext/src/org/eclipse/xtext/Xtext.ecore#//RuleCall"
+        eType="ecore:EClass platform:/resource/org.eclipse.xtext/org/eclipse/xtext/Xtext.ecore#//RuleCall"
         containment="true"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/tests/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/util/JdtClasspathUriResolverTest.java
+++ b/tests/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/util/JdtClasspathUriResolverTest.java
@@ -50,6 +50,18 @@ public class JdtClasspathUriResolverTest extends AbstractClasspathUriResolverTes
 		URI normalizedUri = _resolver.resolve(_javaProject, classpathUri);
 		assertResourceLoadable(classpathUri, normalizedUri, expectedUri);
 	}
+	
+	@Test public void testClasspathUriForFileInWorkspaceWithFragmentInProjectRoot() throws Exception {
+		_javaProject = JavaProjectSetupUtil.createJavaProject(TEST_PROJECT_NAME);
+		_project = _javaProject.getProject();
+		_project.getFolder("model").create(true, true, null);
+		PluginUtil.copyFileToWorkspace(Activator.getInstance(), "/testfiles/" + MODEL_FILE, _project, "model/"
+				+ MODEL_FILE);
+		URI classpathUri = URI.createURI("classpath:/model/" + MODEL_FILE + "#/");
+		String expectedUri = "platform:/resource/" + TEST_PROJECT_NAME + "/model/" + MODEL_FILE + "#/";
+		URI normalizedUri = _resolver.resolve(_javaProject, classpathUri);
+		assertResourceLoadable(classpathUri, normalizedUri, expectedUri);
+	}
 
 	@Test public void testClasspathUriForFileInJarInWorkspace() throws Exception {
 		_javaProject = JavaProjectSetupUtil.createJavaProject(TEST_PROJECT_NAME);


### PR DESCRIPTION
Moved Xtext.ecore and Xtext.genmodel to a folder
org/eclipse/xtext which is not a source folder but
a model folder.

Change-Id: I6e5fea5f34bf3e52a36c59099162e20e1783fb38
Signed-off-by: Sebastian Zarnekow <Sebastian.Zarnekow@itemis.de>