### PR TITLE
[460191]: [xtend][linking] Expected type had too high prio when linking

### DIFF
--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/ClosureWithExpectationHelper.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/computation/ClosureWithExpectationHelper.java
@@ -359,7 +359,7 @@ public class ClosureWithExpectationHelper extends AbstractClosureTypeHelper {
 							List<LightweightBoundTypeArgument> hints = reference.getAllHints();
 							for (LightweightBoundTypeArgument hint : hints) {
 								BoundTypeArgumentSource source = hint.getSource();
-								if (source == BoundTypeArgumentSource.INFERRED || source == BoundTypeArgumentSource.INFERRED_CONSTRAINT) {
+								if (source == BoundTypeArgumentSource.INFERRED || source == BoundTypeArgumentSource.EXPECTATION || source == BoundTypeArgumentSource.INFERRED_CONSTRAINT) {
 									reference.tryResolve();
 									if (reference.internalIsResolved()) {
 										return reference.accept(this, param);

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/ResolvedTypes.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/ResolvedTypes.java
@@ -1265,7 +1265,7 @@ public abstract class ResolvedTypes implements IResolvedTypes {
 				BoundTypeArgumentSource source = existingTypeArgument.getSource();
 				LightweightTypeReference existingTypeReference = existingTypeArgument.getTypeReference();
 				LightweightTypeReference boundTypeReference = boundTypeArgument.getTypeReference();
-				if (source == BoundTypeArgumentSource.INFERRED) {
+				if (source == BoundTypeArgumentSource.INFERRED || source == BoundTypeArgumentSource.INFERRED_EXPECTATION) {
 					if (existingTypeReference instanceof UnboundTypeReference) {
 						UnboundTypeReference existingReference = (UnboundTypeReference) existingTypeReference;
 						// resolve similar pending type arguments, too

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/FunctionTypes.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/FunctionTypes.java
@@ -113,7 +113,7 @@ public class FunctionTypes {
 		List<LightweightBoundTypeArgument> hints = unboundTypeReference.getAllHints();
 		for(LightweightBoundTypeArgument hint: hints) {
 			LightweightTypeReference hintReference = hint.getTypeReference();
-			if (hintReference != null && hint.getSource() == BoundTypeArgumentSource.INFERRED) {
+			if (hintReference != null && (hint.getSource() == BoundTypeArgumentSource.INFERRED || hint.getSource() == BoundTypeArgumentSource.INFERRED_EXPECTATION)) {
 				List<JvmType> rawTypes = hintReference.getRawTypes();
 				JvmOperation result = findImplementingOperation(rawTypes);
 				if (result != null) {

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/UnboundTypeReference.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/references/UnboundTypeReference.java
@@ -367,6 +367,7 @@ public class UnboundTypeReference extends LightweightTypeReference {
 	private boolean populateListsFromHints(List<LightweightBoundTypeArgument> allHints, List<LightweightBoundTypeArgument> inferredHints,
 			List<LightweightBoundTypeArgument> effectiveHints, List<LightweightBoundTypeArgument> inferredConstraintHints, EnumSet<VarianceInfo> varianceHints) {
 		boolean hasContraintHints = false;
+		List<LightweightBoundTypeArgument> expectationHints = null;
 		for(LightweightBoundTypeArgument hint: allHints) {
 			if (hint.getOrigin() instanceof VarianceInfo) {
 				varianceHints.add((VarianceInfo) hint.getOrigin());
@@ -378,10 +379,19 @@ public class UnboundTypeReference extends LightweightTypeReference {
 				if (hint.getSource() == BoundTypeArgumentSource.INFERRED) {
 					inferredHints.add(hint);
 				}
+				if (hint.getSource() == BoundTypeArgumentSource.INFERRED_EXPECTATION) {
+					if (expectationHints == null) {
+						expectationHints = Lists.newArrayListWithCapacity(2);
+					}
+					expectationHints.add(hint);
+				}
 				if (hint.getSource() == BoundTypeArgumentSource.INFERRED_CONSTRAINT) {
 					inferredConstraintHints.add(hint);
 				}
 			}
+		}
+		if (expectationHints != null) {
+			inferredHints.addAll(expectationHints);
 		}
 		return hasContraintHints;
 	}

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/BoundTypeArgumentSource.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/BoundTypeArgumentSource.java
@@ -54,11 +54,21 @@ public enum BoundTypeArgumentSource {
 	/**
 	 * <pre>
 	 *  public &lt;T extends CharSequence&gt; T method() {
+	 *    acceptor(method(), method());
+	 *  }
+	 *  public &lt;T&gt; acceptor(T t, T t2) {}
+	 * </pre>
+	 */
+	EXPECTATION,
+	
+	/**
+	 * <pre>
+	 *  public &lt;T extends CharSequence&gt; T method() {
 	 *    String s = method();
 	 *  }
 	 * </pre>
 	 */
-	EXPECTATION,
+	INFERRED_EXPECTATION,
 	
 	/**
 	 * <pre>

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/ExpectationTypeParameterHintCollector.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/ExpectationTypeParameterHintCollector.java
@@ -50,7 +50,7 @@ public class ExpectationTypeParameterHintCollector extends DeferredTypeParameter
 						// we don't break the list traversal here since we want to do the paired outerVisit for all constraints
 						if (declarationMatches) {
 							if (hint.getActualVariance() == VarianceInfo.OUT && hint.getDeclaredVariance() == VarianceInfo.OUT && 
-									(hint.getSource() == BoundTypeArgumentSource.INFERRED || hint.getSource() == BoundTypeArgumentSource.INFERRED_LATER)) {
+									(hint.getSource() == BoundTypeArgumentSource.INFERRED || hint.getSource() == BoundTypeArgumentSource.INFERRED_EXPECTATION || hint.getSource() == BoundTypeArgumentSource.INFERRED_LATER)) {
 								if (!declaration.isAssignableFrom(hint.getTypeReference())) {
 									declarationMatches = false;
 								}
@@ -141,7 +141,7 @@ public class ExpectationTypeParameterHintCollector extends DeferredTypeParameter
 					// we don't break the list traversal here since we want to do the paired outerVisit for all constraints
 					if (declarationMatches) {
 						if (hint.getActualVariance() == VarianceInfo.OUT && hint.getDeclaredVariance() == VarianceInfo.OUT && 
-								(hint.getSource() == BoundTypeArgumentSource.INFERRED || hint.getSource() == BoundTypeArgumentSource.INFERRED_LATER)) {
+								(hint.getSource() == BoundTypeArgumentSource.INFERRED || hint.getSource() == BoundTypeArgumentSource.INFERRED_LATER || hint.getSource() == BoundTypeArgumentSource.INFERRED_EXPECTATION)) {
 							if (!declaration.isAssignableFrom(hint.getTypeReference())) {
 								declarationMatches = false;
 							}

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug460963Test.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug460963Test.xtend
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.compiler
+
+import org.junit.Test
+
+/**
+ * @author Sebastian Zarnekow - Initial contribution and API
+ */
+class CompilerBug460963Test extends AbstractXtendCompilerTest {
+	
+	@Test def test_01() {
+		'''
+			import java.util.List
+			import java.util.Set
+			class C {
+			    def Set<String> m(List<String> list) {
+			    	newHashSet(list)
+			    }
+			}
+		'''.assertCompilesTo('''
+			import java.util.List;
+			import java.util.Set;
+			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+			import org.eclipse.xtext.xbase.lib.Conversions;
+			
+			@SuppressWarnings("all")
+			public class C {
+			  public Set<String> m(final List<String> list) {
+			    return CollectionLiterals.<String>newHashSet(((String[])Conversions.unwrapArray(list, String.class)));
+			  }
+			}
+		''')
+	}
+	
+	@Test def test_02() {
+		'''
+			import java.util.List
+			import java.util.Set
+			class C {
+			    def Set<List<String>> m(List<String> list) {
+			    	newHashSet(list)
+			    }
+			}
+		'''.assertCompilesTo('''
+			import java.util.List;
+			import java.util.Set;
+			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+			
+			@SuppressWarnings("all")
+			public class C {
+			  public Set<List<String>> m(final List<String> list) {
+			    return CollectionLiterals.<List<String>>newHashSet(list);
+			  }
+			}
+		''')
+	}
+	
+}

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/linking/LinkingTest.java
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/linking/LinkingTest.java
@@ -91,6 +91,25 @@ public class LinkingTest extends AbstractXtendTestCase {
 	@Inject
 	private IBatchTypeResolver typeResolver;
 	
+	@Test public void testBug460191() throws Exception {
+		XtendFile file = file(
+				"class C {\n" + 
+				"    def Iterable<K> getFs(Iterable<I> l) {\n" + 
+				"        l.filter[true]\n" + 
+				"    }\n" + 
+				"    interface I {}\n" + 
+				"    interface K extends I {}\n" + 
+				"}");
+		XtendClass c = (XtendClass) file.getXtendTypes().get(0);
+		XtendFunction m = (XtendFunction) c.getMembers().get(0);
+		XBlockExpression body = (XBlockExpression) m.getExpression();
+		XMemberFeatureCall featureCall = (XMemberFeatureCall) body.getExpressions().get(0);
+		JvmIdentifiableElement feature = featureCall.getFeature();
+		assertEquals("org.eclipse.xtext.xbase.lib.IterableExtensions.filter(java.lang.Iterable,org.eclipse.xtext.xbase.lib.Functions$Function1)", feature.getIdentifier());
+		assertNull(featureCall.getImplicitReceiver());
+		assertNull(featureCall.getImplicitFirstArgument());
+	}
+	
 	@Test public void testOverloadStaticInstance_01() throws Exception {
 		XtendFile file = file(
 				"class C {\n" + 

--- a/tests/org.eclipse.xtend.core.tests/suites/org/eclipse/xtend/core/tests/compiler/CompilerSuite.java
+++ b/tests/org.eclipse.xtend.core.tests/suites/org/eclipse/xtend/core/tests/compiler/CompilerSuite.java
@@ -84,6 +84,8 @@ import org.junit.runners.Suite.SuiteClasses;
 	CompilerBug458612Test.class,
 	CompilerBug461568Test.class,
 	CompilerBug459920Test.class,
+	CompilerBug460691Test.class,
+	CompilerBug460963Test.class,
 	CompilerBug461923Test.class,
 	CompilerBug462260Test.class,
 	CompilerBug462845Test.class,

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug460963Test.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug460963Test.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.compiler;
+
+import org.eclipse.xtend.core.tests.compiler.AbstractXtendCompilerTest;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.junit.Test;
+
+/**
+ * @author Sebastian Zarnekow - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class CompilerBug460963Test extends AbstractXtendCompilerTest {
+  @Test
+  public void test_01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.append("import java.util.Set");
+    _builder.newLine();
+    _builder.append("class C {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("def Set<String> m(List<String> list) {");
+    _builder.newLine();
+    _builder.append("    \t");
+    _builder.append("newHashSet(list)");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import java.util.List;");
+    _builder_1.newLine();
+    _builder_1.append("import java.util.Set;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Conversions;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public Set<String> m(final List<String> list) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return CollectionLiterals.<String>newHashSet(((String[])Conversions.unwrapArray(list, String.class)));");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void test_02() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.append("import java.util.Set");
+    _builder.newLine();
+    _builder.append("class C {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("def Set<List<String>> m(List<String> list) {");
+    _builder.newLine();
+    _builder.append("    \t");
+    _builder.append("newHashSet(list)");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import java.util.List;");
+    _builder_1.newLine();
+    _builder_1.append("import java.util.Set;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public Set<List<String>> m(final List<String> list) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return CollectionLiterals.<List<String>>newHashSet(list);");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+}


### PR DESCRIPTION
The expected type contributed to unresolved type parameters as if
it was directly inferred which caused trouble, e.g. with the overload
of IterableExtensions.filter

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=460191

Signed-off-by: szarnekow <Sebastian.Zarnekow@itemis.de>