### PR TITLE
[462911]: Fix: Catch NPE from JDT

### DIFF
--- a/plugins/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtBasedTypeFactory.java
+++ b/plugins/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtBasedTypeFactory.java
@@ -674,7 +674,16 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 		IMemberValuePairBinding[] allMemberValuePairs = annotation.getDeclaredMemberValuePairs();
 		for (IMemberValuePairBinding memberValuePair : allMemberValuePairs) {
 			IMethodBinding methodBinding = memberValuePair.getMethodBinding();
-			values.addUnique(createAnnotationValue(annotationType, memberValuePair.getValue(), methodBinding));
+			try {
+				values.addUnique(createAnnotationValue(annotationType, memberValuePair.getValue(), methodBinding));
+			} catch(NullPointerException npe) {
+				// memberValuePair#getValue may throw an NPE if the methodBinding has no return type
+				if (methodBinding.getReturnType() != null) {
+					throw npe;
+				} else {
+					log.debug(npe.getMessage(), npe);
+				}
+			}
 		}
 		return annotationReference;
 	}


### PR DESCRIPTION
This is a workaround for a bug in JDT.

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=462911

Signed-off-by: Sebastian Zarnekow <Sebastian.Zarnekow@itemis.de>