### PR TITLE
 [463059]: Avoid spawning new threads in annotation processor

### DIFF
--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/XAnnotationExtensions.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/XAnnotationExtensions.xtend
@@ -40,20 +40,26 @@ class XAnnotationExtensions {
 	@Inject ConstantExpressionsInterpreter constantExpressionsInterpreter
 	
 	def XtendAnnotationTarget getAnnotatedTarget(XAnnotation annotation) {
-		// ignore synthetic containers
 		switch container : annotation.eContainer {
-			XtendAnnotationType : container
-			XtendClass : container
-			XtendInterface : container
-			XtendEnum : container
-			XtendField : container
-			XtendFunction : container
-			XtendConstructor : container
-			XtendEnumLiteral : container
+			XtendAnnotationType,
+			XtendClass,
+			XtendInterface,
+			XtendEnum,
+			XtendField,
+			XtendFunction,
+			XtendConstructor,
+			XtendEnumLiteral,
 			XtendParameter : container
-			XtendAnnotationTarget 	: container.eContainer as XtendAnnotationTarget
-			XAnnotation 			: getAnnotatedTarget(container)
-			default 				: null
+			// ignore synthetic containers
+			XtendAnnotationTarget : {
+				val containerContainer = container.eContainer
+				if (containerContainer instanceof XtendAnnotationTarget)
+					containerContainer
+			}
+			XAnnotation : 
+				getAnnotatedTarget(container)
+			default :
+				null
 		}
 	}
 	

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/XAnnotationExtensions.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/XAnnotationExtensions.java
@@ -66,62 +66,64 @@ public class XAnnotationExtensions {
     if (!_matched) {
       if (container instanceof XtendAnnotationType) {
         _matched=true;
-        _switchResult = ((XtendAnnotationTarget)container);
       }
-    }
-    if (!_matched) {
-      if (container instanceof XtendClass) {
-        _matched=true;
-        _switchResult = ((XtendAnnotationTarget)container);
+      if (!_matched) {
+        if (container instanceof XtendClass) {
+          _matched=true;
+        }
       }
-    }
-    if (!_matched) {
-      if (container instanceof XtendInterface) {
-        _matched=true;
-        _switchResult = ((XtendAnnotationTarget)container);
+      if (!_matched) {
+        if (container instanceof XtendInterface) {
+          _matched=true;
+        }
       }
-    }
-    if (!_matched) {
-      if (container instanceof XtendEnum) {
-        _matched=true;
-        _switchResult = ((XtendAnnotationTarget)container);
+      if (!_matched) {
+        if (container instanceof XtendEnum) {
+          _matched=true;
+        }
       }
-    }
-    if (!_matched) {
-      if (container instanceof XtendField) {
-        _matched=true;
-        _switchResult = ((XtendAnnotationTarget)container);
+      if (!_matched) {
+        if (container instanceof XtendField) {
+          _matched=true;
+        }
       }
-    }
-    if (!_matched) {
-      if (container instanceof XtendFunction) {
-        _matched=true;
-        _switchResult = ((XtendAnnotationTarget)container);
+      if (!_matched) {
+        if (container instanceof XtendFunction) {
+          _matched=true;
+        }
       }
-    }
-    if (!_matched) {
-      if (container instanceof XtendConstructor) {
-        _matched=true;
-        _switchResult = ((XtendAnnotationTarget)container);
+      if (!_matched) {
+        if (container instanceof XtendConstructor) {
+          _matched=true;
+        }
       }
-    }
-    if (!_matched) {
-      if (container instanceof XtendEnumLiteral) {
-        _matched=true;
-        _switchResult = ((XtendAnnotationTarget)container);
+      if (!_matched) {
+        if (container instanceof XtendEnumLiteral) {
+          _matched=true;
+        }
       }
-    }
-    if (!_matched) {
-      if (container instanceof XtendParameter) {
-        _matched=true;
+      if (!_matched) {
+        if (container instanceof XtendParameter) {
+          _matched=true;
+        }
+      }
+      if (_matched) {
         _switchResult = ((XtendAnnotationTarget)container);
       }
     }
     if (!_matched) {
       if (container instanceof XtendAnnotationTarget) {
         _matched=true;
-        EObject _eContainer_1 = ((XtendAnnotationTarget)container).eContainer();
-        _switchResult = ((XtendAnnotationTarget) _eContainer_1);
+        XtendAnnotationTarget _xblockexpression = null;
+        {
+          final EObject containerContainer = ((XtendAnnotationTarget)container).eContainer();
+          XtendAnnotationTarget _xifexpression = null;
+          if ((containerContainer instanceof XtendAnnotationTarget)) {
+            _xifexpression = ((XtendAnnotationTarget)containerContainer);
+          }
+          _xblockexpression = _xifexpression;
+        }
+        _switchResult = _xblockexpression;
       }
     }
     if (!_matched) {

--- a/tests/org.eclipse.xtend.core.tests/smoke-suites/org/eclipse/xtend/core/tests/smoke/FormatterSmokeSuite.java
+++ b/tests/org.eclipse.xtend.core.tests/smoke-suites/org/eclipse/xtend/core/tests/smoke/FormatterSmokeSuite.java
@@ -22,6 +22,7 @@ import org.eclipse.xtext.junit4.smoketest.ScenarioProcessor;
 import org.eclipse.xtext.junit4.smoketest.XtextSmokeTestRunner;
 import org.eclipse.xtext.junit4.util.ParseHelper;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.util.ExceptionAcceptor;
 import org.junit.ComparisonFailure;
 import org.junit.runner.RunWith;
@@ -29,6 +30,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 /**
  * @author Sebastian Zarnekow - Initial contribution and API
@@ -45,6 +47,12 @@ public class FormatterSmokeSuite {
 
 		@Inject
 		private ParseHelper<XtendFile> parseHelper;
+		
+		@Inject
+		private ClassLoader classLoader;
+		
+		@Inject
+		private Provider<XtextResourceSet> resourceSetProvider;
 
 		private MessageDigest messageDigest;
 		private Set<BigInteger> seen;
@@ -58,7 +66,9 @@ public class FormatterSmokeSuite {
 		public void processFile(String data) throws Exception {
 			byte[] hash = ((MessageDigest) messageDigest.clone()).digest(data.getBytes("UTF-8"));
 			if (seen.add(new BigInteger(hash))) {
-				XtendFile file = parseHelper.parse(data);
+				XtextResourceSet resourceSet = resourceSetProvider.get();
+				resourceSet.setClasspathURIContext(classLoader);
+				XtendFile file = parseHelper.parse(data, resourceSet);
 				if (file != null) {
 					try {
 						XtextResource resource = (XtextResource) file.eResource();


### PR DESCRIPTION
Instead a thread pool is used.

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=463059

Signed-off-by: szarnekow <Sebastian.Zarnekow@itemis.de>