### PR TITLE
 [463095]: Fixed accidentally ignored OperationCancelErrors

### DIFF
--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendGenerator.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendGenerator.xtend
@@ -40,6 +40,7 @@ import org.eclipse.xtext.xbase.compiler.output.ITreeAppendable
 import org.eclipse.xtext.xbase.compiler.output.SharedAppendableState
 import org.eclipse.xtext.xbase.typesystem.IBatchTypeResolver
 import org.eclipse.xtext.xbase.typesystem.references.ITypeReferenceOwner
+import org.eclipse.xtext.service.OperationCanceledManager
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -48,6 +49,8 @@ class XtendGenerator extends JvmModelGenerator {
 	
 	@Inject 
 	private IBatchTypeResolver typeResolver;
+	@Inject
+	private OperationCanceledManager operationCanceledManager
 	
 	override doGenerate(Resource input, IFileSystemAccess fsa) {
 		super.doGenerate(input, fsa)
@@ -72,6 +75,7 @@ class XtendGenerator extends JvmModelGenerator {
 						}
 					}
 				} catch (Throwable t) {
+					operationCanceledManager.propagateAsErrorIfCancelException(t)
 					context.handleProcessingError(input, t)
 				}
 			}

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
@@ -185,6 +185,7 @@ public class XtendJvmModelInferrer extends AbstractModelInferrer {
 			try {
 				contexts = contextProvider.computeContext(xtendFile);
 			} catch (Throwable t) {
+				operationCanceledManager.propagateAsErrorIfCancelException(t);
 				logger.error("Couldn't create annotation contexts", t);
 				return;
 			}

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
@@ -69,6 +69,7 @@ import org.eclipse.xtext.documentation.IFileHeaderProvider;
 import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.CompilerPhases;
+import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.XExpression;
@@ -145,6 +146,9 @@ public class XtendJvmModelInferrer extends AbstractModelInferrer {
 	@Inject
 	private IGeneratorConfigProvider generatorConfigProvider;
 	
+	@Inject
+	private OperationCanceledManager operationCanceledManager;
+	
 	private GeneratorConfig generatorConfig;
 	
 	@Override
@@ -190,6 +194,7 @@ public class XtendJvmModelInferrer extends AbstractModelInferrer {
 					try {
 						annotationProcessor.indexingPhase(ctx, wrapper, CancelIndicator.NullImpl);
 					} catch (Throwable t) {
+						operationCanceledManager.propagateAsErrorIfCancelException(t);
 						ctx.handleProcessingError(xtendFile.eResource(), t);
 					}
 				}
@@ -216,6 +221,7 @@ public class XtendJvmModelInferrer extends AbstractModelInferrer {
 							try {
 								annotationProcessor.inferencePhase(ctx, CancelIndicator.NullImpl);
 							} catch (Throwable t) {
+								operationCanceledManager.propagateAsErrorIfCancelException(t);
 								ctx.handleProcessingError(xtendFile.eResource(), t);
 							}
 						}

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ActiveAnnotationContext.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ActiveAnnotationContext.xtend
@@ -38,6 +38,8 @@ import com.google.common.base.Throwables
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.emf.common.notify.Notification
 import org.apache.log4j.Logger
+import org.eclipse.xtext.service.OperationCanceledError
+import org.eclipse.xtext.service.OperationCanceledManager
 
 /**
  * @author Sven Efftinge
@@ -168,6 +170,7 @@ class ActiveAnnotationContextProvider {
 	@Inject extension XAnnotationExtensions
 	@Inject extension ProcessorInstanceForJvmTypeProvider
 	@Inject Provider<CompilationUnitImpl> compilationUnitProvider
+	@Inject OperationCanceledManager operationCanceledManager
 	
 	def ActiveAnnotationContexts computeContext(XtendFile file) {
 		//TODO measure and improve (is called twice for each xtendfile)
@@ -192,6 +195,7 @@ class ActiveAnnotationContextProvider {
 					} catch (VirtualMachineError e) {
 						throw e
 					} catch (Throwable e) {
+						operationCanceledManager.propagateAsErrorIfCancelException(e)
 						val msg = switch e {
 							ExceptionInInitializerError : e.exception.message
 							default : e.message
@@ -206,6 +210,7 @@ class ActiveAnnotationContextProvider {
 			]
 			return result
 		} catch (Throwable e) {
+			operationCanceledManager.propagateAsErrorIfCancelException(e)
 			switch e {
 				VirtualMachineError : throw e
 				LinkageError: throw e // e.g. java.lang.UnsupportedClassVersionError: activetest/Processor : Unsupported major.minor version 51.0

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/CachingResourceValidatorImpl.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/CachingResourceValidatorImpl.xtend
@@ -61,6 +61,7 @@ class CachingResourceValidatorImpl extends DerivedStateAwareResourceValidator {
 				try {
 					annotationProcessor.validationPhase(ctx, monitor)
 				} catch (Throwable t) {
+					operationCanceledManager.propagateAsErrorIfCancelException(t);
 					ctx.handleProcessingError(resource, t)
 				}
 			}

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/compiler/XtendGenerator.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/compiler/XtendGenerator.java
@@ -53,6 +53,7 @@ import org.eclipse.xtext.common.types.JvmTypeParameterDeclarator;
 import org.eclipse.xtext.common.types.JvmTypeReference;
 import org.eclipse.xtext.common.types.JvmVisibility;
 import org.eclipse.xtext.generator.IFileSystemAccess;
+import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.XAbstractFeatureCall;
 import org.eclipse.xtext.xbase.XClosure;
@@ -88,6 +89,9 @@ public class XtendGenerator extends JvmModelGenerator {
   
   @Inject
   private IBatchTypeResolver typeResolver;
+  
+  @Inject
+  private OperationCanceledManager operationCanceledManager;
   
   @Override
   public void doGenerate(final Resource input, final IFileSystemAccess fsa) {
@@ -137,6 +141,7 @@ public class XtendGenerator extends JvmModelGenerator {
         } catch (final Throwable _t) {
           if (_t instanceof Throwable) {
             final Throwable t = (Throwable)_t;
+            this.operationCanceledManager.propagateAsErrorIfCancelException(t);
             context.handleProcessingError(input, t);
           } else {
             throw Exceptions.sneakyThrow(_t);

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ActiveAnnotationContextProvider.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ActiveAnnotationContextProvider.java
@@ -37,6 +37,7 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.common.types.JvmAnnotationType;
 import org.eclipse.xtext.common.types.JvmType;
 import org.eclipse.xtext.diagnostics.Severity;
+import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.util.IAcceptor;
 import org.eclipse.xtext.util.internal.Stopwatches;
 import org.eclipse.xtext.validation.EObjectDiagnosticImpl;
@@ -66,6 +67,9 @@ public class ActiveAnnotationContextProvider {
   
   @Inject
   private Provider<CompilationUnitImpl> compilationUnitProvider;
+  
+  @Inject
+  private OperationCanceledManager operationCanceledManager;
   
   public ActiveAnnotationContexts computeContext(final XtendFile file) {
     try {
@@ -106,6 +110,7 @@ public class ActiveAnnotationContextProvider {
                     throw e;
                   } else if (_t instanceof Throwable) {
                     final Throwable e_1 = (Throwable)_t;
+                    ActiveAnnotationContextProvider.this.operationCanceledManager.propagateAsErrorIfCancelException(e_1);
                     String _switchResult = null;
                     boolean _matched = false;
                     if (!_matched) {
@@ -154,6 +159,7 @@ public class ActiveAnnotationContextProvider {
       } catch (final Throwable _t) {
         if (_t instanceof Throwable) {
           final Throwable e = (Throwable)_t;
+          this.operationCanceledManager.propagateAsErrorIfCancelException(e);
           boolean _matched = false;
           if (!_matched) {
             if (e instanceof VirtualMachineError) {

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/validation/CachingResourceValidatorImpl.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/validation/CachingResourceValidatorImpl.java
@@ -108,6 +108,7 @@ public class CachingResourceValidatorImpl extends DerivedStateAwareResourceValid
           } catch (final Throwable _t) {
             if (_t instanceof Throwable) {
               final Throwable t = (Throwable)_t;
+              this.operationCanceledManager.propagateAsErrorIfCancelException(t);
               ctx.handleProcessingError(resource, t);
             } else {
               throw Exceptions.sneakyThrow(_t);

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/service/OperationCanceledManager.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/service/OperationCanceledManager.xtend
@@ -37,6 +37,9 @@ class OperationCanceledManager {
 	 * Rethrows OperationCanceledErrors and wraps platform specific OperationCanceledExceptions. Does nothing for any other type of Throwable.
 	 */
 	def void propagateAsErrorIfCancelException(Throwable t) {
+		if (t instanceof OperationCanceledError) {
+			throw t;
+		}
 		val opCanceledException = getPlatformOperationCanceledException(t);
 		if (opCanceledException != null)
 			throw new OperationCanceledError(opCanceledException);

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/service/OperationCanceledManager.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/service/OperationCanceledManager.java
@@ -65,6 +65,9 @@ public class OperationCanceledManager {
    */
   public void propagateAsErrorIfCancelException(final Throwable t) {
     try {
+      if ((t instanceof OperationCanceledError)) {
+        throw t;
+      }
       final RuntimeException opCanceledException = this.getPlatformOperationCanceledException(t);
       boolean _notEquals = (!Objects.equal(opCanceledException, null));
       if (_notEquals) {


### PR DESCRIPTION
Active annotation processors used to swallow all cancellation
information.

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=463095

Signed-off-by: szarnekow <Sebastian.Zarnekow@itemis.de>