### PR TITLE
[462486]: Fixed bogus grammar validation

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/KeywordInspector.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/KeywordInspector.java
@@ -44,12 +44,17 @@ public class KeywordInspector {
 		Grammar grammar = GrammarUtil.getGrammar(container);
 		List<TerminalRule> rules = GrammarUtil.allTerminalRules(grammar);
 		for(TerminalRule rule: rules) {
+			if (!rule.isFragment()) {
 			AbstractElement element = rule.getAlternatives();
-			if (element instanceof Keyword && Strings.isEmpty(element.getCardinality())) {
-				String value = ((Keyword) element).getValue();
-				if (value.equals(keyword.getValue()))
-				acceptor.acceptError("The keyword '" + value + "' hides the terminal rule " + rule.getName()+ ".", 
-						keyword, XtextPackage.Literals.KEYWORD__VALUE, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, null);
+				if (element instanceof Keyword && Strings.isEmpty(element.getCardinality())) {
+					String value = ((Keyword) element).getValue();
+					if (value.equals(keyword.getValue()))
+					acceptor.acceptError(
+							"The keyword '" + value + "' hides the terminal rule " + rule.getName()+ ".", 
+							keyword,
+							XtextPackage.Literals.KEYWORD__VALUE,
+							ValidationMessageAcceptor.INSIGNIFICANT_INDEX, null);
+				}
 			}
 		}
 	}

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/KeywordInspectorTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/KeywordInspectorTest.java
@@ -48,6 +48,17 @@ public class KeywordInspectorTest extends AbstractXtextInspectorTest {
 			inspector.inspectKeywordHidesTerminalRule(keywords.next());
 	}
 	
+	@Test public void testBug462486() throws Exception {
+		String grammarAsString = "grammar org.xtext.example.MyDsl7 with org.eclipse.xtext.common.Terminals\n" + 
+				"generate myDsl \"http://www.xtext.org/example/MyDsl\"\n" + 
+				"Type : 'type' '#' name=ID;\n" + 
+				"terminal fragment POUND: '#';";
+		Grammar grammar = getGrammar(grammarAsString);
+		ParserRule rule = (ParserRule) GrammarUtil.findRuleForName(grammar, "Type");
+		validateRule(rule);
+		assertEquals(errors.toString(), 0, errors.size());
+	}
+	
 	@Test public void testBug285146_01() throws Exception {
 		String grammarAsString = "grammar org.xtext.example.MyDsl7 with org.eclipse.xtext.common.Terminals\n" + 
 				"generate myDsl \"http://www.xtext.org/example/MyDsl\"\n" + 


### PR DESCRIPTION
Terminal fragments cannot shadow keywords

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=462486

Signed-off-by: szarnekow <Sebastian.Zarnekow@itemis.de>