### PR TITLE
[463161]: Fixed NPE during annotation processing

### DIFF
--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/JvmAnnotationReferenceImpl.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/JvmAnnotationReferenceImpl.xtend
@@ -29,7 +29,9 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 		val annotationValue = delegate.values.findFirst[ operation == op || (operation == null && op.simpleName == 'value') ]
 		switch annotationValue {
 			JvmCustomAnnotationValue : {
-				return compilationUnit.toExpression(annotationValue.values.head as XExpression)
+				val expression = annotationValue.values.head as XExpression
+				if (expression !== null && compilationUnit.isBelongedToCompilationUnit(expression))
+					return compilationUnit.toExpression(expression)
 			}
 		}
 		return null

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmAnnotationReferenceImpl.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmAnnotationReferenceImpl.java
@@ -79,10 +79,21 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
     if (!_matched) {
       if (annotationValue instanceof JvmCustomAnnotationValue) {
         _matched=true;
-        CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
         EList<EObject> _values_1 = ((JvmCustomAnnotationValue)annotationValue).getValues();
         EObject _head = IterableExtensions.<EObject>head(_values_1);
-        return _compilationUnit.toExpression(((XExpression) _head));
+        final XExpression expression = ((XExpression) _head);
+        boolean _and = false;
+        if (!(expression != null)) {
+          _and = false;
+        } else {
+          CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
+          boolean _isBelongedToCompilationUnit = _compilationUnit.isBelongedToCompilationUnit(expression);
+          _and = _isBelongedToCompilationUnit;
+        }
+        if (_and) {
+          CompilationUnitImpl _compilationUnit_1 = this.getCompilationUnit();
+          return _compilationUnit_1.toExpression(expression);
+        }
       }
     }
     return null;

--- a/plugins/org.eclipse.xtend.lib.macro/src/org/eclipse/xtend/lib/macro/declaration/AnnotationReference.java
+++ b/plugins/org.eclipse.xtend.lib.macro/src/org/eclipse/xtend/lib/macro/declaration/AnnotationReference.java
@@ -317,6 +317,7 @@ public interface AnnotationReference extends Element {
 	
 	/**
 	 * Returns the expression for the given annotation property.
+	 * 
 	 * Returns <code>null</code> if no expression is set, or this annotation reference is an external element
 	 * (i.e. {@link Tracability#isExternal(Element)} returns <code>true</code>). 
 	 * 

--- a/plugins/org.eclipse.xtext.common.types/emf-gen/org/eclipse/xtext/common/types/JvmAnnotationReference.java
+++ b/plugins/org.eclipse.xtext.common.types/emf-gen/org/eclipse/xtext/common/types/JvmAnnotationReference.java
@@ -80,7 +80,7 @@ public interface JvmAnnotationReference extends EObject
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * <!-- begin-model-doc -->
-	 * <p>Returns all annotation values. That is, default values are not included if not explicitely given.</p>
+	 * <p>Returns all annotation values. That is, default values are included if not explicitly given.</p>
 	 * <!-- end-model-doc -->
 	 * @model kind="operation"
 	 * @generated

--- a/plugins/org.eclipse.xtext.common.types/model/JavaVMTypes.ecore
+++ b/plugins/org.eclipse.xtext.common.types/model/JavaVMTypes.ecore
@@ -288,7 +288,7 @@
   <eClassifiers xsi:type="ecore:EClass" name="JvmAnnotationReference">
     <eOperations name="getValues" upperBound="-1" eType="#//JvmAnnotationValue">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="documentation" value="&lt;p>Returns all annotation values. That is, default values are not included if not explicitely given.&lt;/p>"/>
+        <details key="documentation" value="&lt;p>Returns all annotation values. That is, default values are included if not explicitly given.&lt;/p>"/>
       </eAnnotations>
     </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="annotation" eType="#//JvmAnnotationType"/>

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.java
@@ -4723,6 +4723,89 @@ public abstract class AbstractReusableActiveAnnotationTests {
   }
   
   @Test
+  public void testAnnotationDefaultValuesBug463161() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package myannotation");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.append("import java.lang.annotation.RetentionPolicy");
+    _builder.newLine();
+    _builder.append("import org.eclipse.xtend.lib.macro.Active");
+    _builder.newLine();
+    _builder.append("import org.eclipse.xtend.lib.macro.TransformationContext");
+    _builder.newLine();
+    _builder.append("import org.eclipse.xtend.lib.macro.AbstractClassProcessor");
+    _builder.newLine();
+    _builder.append("import org.eclipse.xtend.lib.macro.declaration.MutableClassDeclaration");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("@Active(AnnotationDefaultValuesProcessor)");
+    _builder.newLine();
+    _builder.append("annotation AnnotationDefaultValues { }");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class AnnotationDefaultValuesProcessor extends AbstractClassProcessor {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("override doTransform(MutableClassDeclaration mutableClass, extension TransformationContext context) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("val annotationRef = mutableClass.findAnnotation(findTypeGlobally(MyAnnotation))");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("mutableClass.addField(annotationRef.getExpression(\'value\')?.toString ?: \'wasNull\') [");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("type = string");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("]");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("annotation MyAnnotation {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("int value = 1");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    Pair<String, String> _mappedTo = Pair.<String, String>of("myannotation/AnnotationDefaultValues.xtend", _builder.toString());
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package myusercode");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@myannotation.AnnotationDefaultValues");
+    _builder_1.newLine();
+    _builder_1.append("@myannotation.MyAnnotation");
+    _builder_1.newLine();
+    _builder_1.append("class MyClass {}");
+    _builder_1.newLine();
+    Pair<String, String> _mappedTo_1 = Pair.<String, String>of("myusercode/UserCode.xtend", _builder_1.toString());
+    final Procedure1<CompilationUnitImpl> _function = new Procedure1<CompilationUnitImpl>() {
+      @Override
+      public void apply(final CompilationUnitImpl it) {
+        TypeLookupImpl _typeLookup = it.getTypeLookup();
+        final MutableClassDeclaration clazz = _typeLookup.findClass("myusercode.MyClass");
+        Iterable<? extends MutableFieldDeclaration> _declaredFields = clazz.getDeclaredFields();
+        final MutableFieldDeclaration field = IterableExtensions.head(_declaredFields);
+        String _simpleName = field.getSimpleName();
+        Assert.assertEquals("wasNull", _simpleName);
+      }
+    };
+    this.assertProcessing(_mappedTo, _mappedTo_1, _function);
+  }
+  
+  @Test
   public void testAnnotationDefaultValues_01() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package myannotation");


### PR DESCRIPTION
JvmAnnotationReferenceImpl.getExpression violated the
contract of the AnnotationReference.getExpression.
For external elements, null is to be returned.

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=463161

Signed-off-by: szarnekow <Sebastian.Zarnekow@itemis.de>