### PR TITLE
[xtend] Fixed some Java converter bugs and cleaned up the code

### DIFF
--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/ASTFlattenerUtils.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/ASTFlattenerUtils.java
@@ -83,7 +83,7 @@ public class ASTFlattenerUtils {
     return false;
   }
   
-  public boolean isOverrideMethode(final MethodDeclaration declaration) {
+  public boolean isOverrideMethod(final MethodDeclaration declaration) {
     List _modifiers = declaration.modifiers();
     Iterable<Annotation> _filter = Iterables.<Annotation>filter(_modifiers, Annotation.class);
     final Function1<Annotation, Boolean> _function = new Function1<Annotation, Boolean>() {
@@ -94,10 +94,8 @@ public class ASTFlattenerUtils {
         return Boolean.valueOf(Objects.equal("Override", _string));
       }
     };
-    Iterable<Annotation> _filter_1 = IterableExtensions.<Annotation>filter(_filter, _function);
-    boolean _isEmpty = IterableExtensions.isEmpty(_filter_1);
-    boolean _not = (!_isEmpty);
-    if (_not) {
+    boolean _exists = IterableExtensions.<Annotation>exists(_filter, _function);
+    if (_exists) {
       return true;
     }
     final IMethodBinding iMethodBinding = declaration.resolveBinding();

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/JavaASTFlattener.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/JavaASTFlattener.java
@@ -191,11 +191,11 @@ public class JavaASTFlattener extends ASTVisitor {
     return (!_contains);
   }
   
-  public void appendModifieres(final ASTNode node, final Iterable<IExtendedModifier> ext) {
-    this.appendModifieres(node, ext, null);
+  public void appendModifiers(final ASTNode node, final Iterable<IExtendedModifier> ext) {
+    this.appendModifiers(node, ext, null);
   }
   
-  public void appendModifieres(final ASTNode node, final Iterable<IExtendedModifier> ext, final Function1<? super ASTNode, ? extends StringBuffer> callBack) {
+  public void appendModifiers(final ASTNode node, final Iterable<IExtendedModifier> ext, final Function1<? super ASTNode, ? extends StringBuffer> callBack) {
     final Procedure1<IExtendedModifier> _function = new Procedure1<IExtendedModifier>() {
       @Override
       public void apply(final IExtendedModifier p) {
@@ -206,7 +206,17 @@ public class JavaASTFlattener extends ASTVisitor {
     final Function1<IExtendedModifier, Boolean> _function_1 = new Function1<IExtendedModifier, Boolean>() {
       @Override
       public Boolean apply(final IExtendedModifier it) {
-        return Boolean.valueOf(it.isAnnotation());
+        boolean _and = false;
+        boolean _isAnnotation = it.isAnnotation();
+        if (!_isAnnotation) {
+          _and = false;
+        } else {
+          Name _typeName = ((Annotation) it).getTypeName();
+          String _string = _typeName.toString();
+          boolean _notEquals = (!Objects.equal(_string, "Override"));
+          _and = _notEquals;
+        }
+        return Boolean.valueOf(_and);
       }
     };
     Iterable<IExtendedModifier> _filter = IterableExtensions.<IExtendedModifier>filter(ext, _function_1);
@@ -225,9 +235,8 @@ public class JavaASTFlattener extends ASTVisitor {
         } else {
           Modifier.ModifierKeyword _keyword = ((Modifier) it).getKeyword();
           String _string = _keyword.toString();
-          boolean _equals = "default".equals(_string);
-          boolean _not = (!_equals);
-          _and = _not;
+          boolean _notEquals = (!Objects.equal(_string, "default"));
+          _and = _notEquals;
         }
         return Boolean.valueOf(_and);
       }
@@ -477,7 +486,7 @@ public class JavaASTFlattener extends ASTVisitor {
       _javadoc_1.accept(this);
     }
     List _modifiers = it.modifiers();
-    this.appendModifieres(it, _modifiers);
+    this.appendModifiers(it, _modifiers);
     List _modifiers_1 = it.modifiers();
     boolean _isStatic = this._aSTFlattenerUtils.isStatic(_modifiers_1);
     if (_isStatic) {
@@ -570,7 +579,7 @@ public class JavaASTFlattener extends ASTVisitor {
       _javadoc_1.accept(this);
     }
     List _modifiers = it.modifiers();
-    this.appendModifieres(it, _modifiers);
+    this.appendModifiers(it, _modifiers);
     boolean _isInterface = it.isInterface();
     if (_isInterface) {
       this.appendToBuffer("interface ");
@@ -770,7 +779,7 @@ public class JavaASTFlattener extends ASTVisitor {
       @Override
       public void apply(final VariableDeclarationFragment frag) {
         List _modifiers = it.modifiers();
-        JavaASTFlattener.this.appendModifieres(it, _modifiers);
+        JavaASTFlattener.this.appendModifiers(it, _modifiers);
         List _modifiers_1 = it.modifiers();
         Iterable<Modifier> _filter = Iterables.<Modifier>filter(_modifiers_1, Modifier.class);
         boolean _isPackageVisibility = JavaASTFlattener.this._aSTFlattenerUtils.isPackageVisibility(_filter);
@@ -805,7 +814,7 @@ public class JavaASTFlattener extends ASTVisitor {
       @Override
       public void apply(final VariableDeclarationFragment frag, final Integer counter) {
         List _modifiers = it.modifiers();
-        JavaASTFlattener.this.appendModifieres(it, _modifiers);
+        JavaASTFlattener.this.appendModifiers(it, _modifiers);
         List _modifiers_1 = it.modifiers();
         String _handleVariableDeclaration = JavaASTFlattener.this._aSTFlattenerUtils.handleVariableDeclaration(_modifiers_1);
         JavaASTFlattener.this.appendToBuffer(_handleVariableDeclaration);
@@ -903,7 +912,7 @@ public class JavaASTFlattener extends ASTVisitor {
             return _xifexpression;
           }
         };
-        JavaASTFlattener.this.appendModifieres(it, _modifiers, _function);
+        JavaASTFlattener.this.appendModifiers(it, _modifiers, _function);
         List _modifiers_1 = it.modifiers();
         String _handleVariableDeclaration = JavaASTFlattener.this._aSTFlattenerUtils.handleVariableDeclaration(_modifiers_1);
         JavaASTFlattener.this.appendToBuffer(_handleVariableDeclaration);
@@ -997,8 +1006,8 @@ public class JavaASTFlattener extends ASTVisitor {
           boolean _not = (!_isConstructor);
           if (_not) {
             StringBuffer _xifexpression_2 = null;
-            boolean _isOverrideMethode = JavaASTFlattener.this._aSTFlattenerUtils.isOverrideMethode(((MethodDeclaration)node));
-            if (_isOverrideMethode) {
+            boolean _isOverrideMethod = JavaASTFlattener.this._aSTFlattenerUtils.isOverrideMethod(((MethodDeclaration)node));
+            if (_isOverrideMethod) {
               _xifexpression_2 = JavaASTFlattener.this.appendToBuffer("override ");
             } else {
               _xifexpression_2 = JavaASTFlattener.this.appendToBuffer("def ");
@@ -1012,7 +1021,7 @@ public class JavaASTFlattener extends ASTVisitor {
     };
     final Function1<ASTNode, StringBuffer> afterAnnotationProcessingCallback = _function;
     List _modifiers = it.modifiers();
-    this.appendModifieres(it, _modifiers, afterAnnotationProcessingCallback);
+    this.appendModifiers(it, _modifiers, afterAnnotationProcessingCallback);
     List _modifiers_1 = it.modifiers();
     Iterable<Modifier> _filter = Iterables.<Modifier>filter(_modifiers_1, Modifier.class);
     boolean _isPackageVisibility = this._aSTFlattenerUtils.isPackageVisibility(_filter);
@@ -1109,8 +1118,8 @@ public class JavaASTFlattener extends ASTVisitor {
       this.appendToBuffer(" throws ");
       List _thrownExceptions_1 = it.thrownExceptions();
       this.visitAllSeparatedByComma(_thrownExceptions_1);
-      this.appendSpaceToBuffer();
     }
+    this.appendSpaceToBuffer();
     Block _body = it.getBody();
     boolean _notEquals_2 = (!Objects.equal(_body, null));
     if (_notEquals_2) {
@@ -1147,10 +1156,10 @@ public class JavaASTFlattener extends ASTVisitor {
         }
       };
       Iterable<IExtendedModifier> _filter = IterableExtensions.<IExtendedModifier>filter(_modifiers, _function);
-      this.appendModifieres(it, _filter);
+      this.appendModifiers(it, _filter);
     } else {
       List _modifiers_1 = it.modifiers();
-      this.appendModifieres(it, _modifiers_1);
+      this.appendModifiers(it, _modifiers_1);
     }
     Type _type = it.getType();
     _type.accept(this);
@@ -1184,6 +1193,9 @@ public class JavaASTFlattener extends ASTVisitor {
     }
     boolean _isLambdaCase = this._aSTFlattenerUtils.isLambdaCase(node);
     if (_isLambdaCase) {
+      if (this.fallBackStrategy) {
+        this.appendToBuffer("(");
+      }
       this.appendToBuffer("[");
       AnonymousClassDeclaration _anonymousClassDeclaration = node.getAnonymousClassDeclaration();
       List _bodyDeclarations = _anonymousClassDeclaration.bodyDeclarations();
@@ -1216,6 +1228,7 @@ public class JavaASTFlattener extends ASTVisitor {
         }
         Type _type = node.getType();
         _type.accept(this);
+        this.appendToBuffer(")");
       }
     } else {
       this.appendToBuffer("new ");
@@ -1305,8 +1318,8 @@ public class JavaASTFlattener extends ASTVisitor {
     final ASTNode parent = node.getParent();
     if ((parent instanceof IfStatement)) {
       Statement _elseStatement = ((IfStatement)parent).getElseStatement();
-      boolean _equals = Objects.equal(_elseStatement, null);
-      shouldWrap = _equals;
+      boolean _tripleEquals = (_elseStatement == null);
+      shouldWrap = _tripleEquals;
     } else {
       if ((parent instanceof TryStatement)) {
         boolean _and = false;
@@ -1316,8 +1329,8 @@ public class JavaASTFlattener extends ASTVisitor {
           _and = false;
         } else {
           Block _finally = ((TryStatement)parent).getFinally();
-          boolean _equals_1 = Objects.equal(_finally, null);
-          _and = _equals_1;
+          boolean _tripleEquals_1 = (_finally == null);
+          _and = _tripleEquals_1;
         }
         shouldWrap = _and;
       } else {
@@ -1439,7 +1452,6 @@ public class JavaASTFlattener extends ASTVisitor {
     this.appendToBuffer(") ");
     Statement _thenStatement = node.getThenStatement();
     _thenStatement.accept(this);
-    node.getElseStatement();
     Statement _elseStatement = node.getElseStatement();
     boolean _notEquals = (!Objects.equal(_elseStatement, null));
     if (_notEquals) {
@@ -1587,6 +1599,30 @@ public class JavaASTFlattener extends ASTVisitor {
       }
     }
     if (!_matched) {
+      if (Objects.equal(operator, InfixExpression.Operator.EQUALS)) {
+        _matched=true;
+        boolean _isNullInvolved = this.isNullInvolved(infixParent);
+        if (_isNullInvolved) {
+          this.appendToBuffer(" === ");
+        } else {
+          this.appendToBuffer(" == ");
+        }
+        rightSide.accept(this);
+      }
+    }
+    if (!_matched) {
+      if (Objects.equal(operator, InfixExpression.Operator.NOT_EQUALS)) {
+        _matched=true;
+        boolean _isNullInvolved_1 = this.isNullInvolved(infixParent);
+        if (_isNullInvolved_1) {
+          this.appendToBuffer(" !== ");
+        } else {
+          this.appendToBuffer(" != ");
+        }
+        rightSide.accept(this);
+      }
+    }
+    if (!_matched) {
       {
         this.appendSpaceToBuffer();
         String _string = operator.toString();
@@ -1608,6 +1644,18 @@ public class JavaASTFlattener extends ASTVisitor {
       Expression _rightOperand = it.getRightOperand();
       boolean _isBooleanType_1 = this.isBooleanType(_rightOperand);
       _or = _isBooleanType_1;
+    }
+    return _or;
+  }
+  
+  public boolean isNullInvolved(final InfixExpression it) {
+    boolean _or = false;
+    Expression _leftOperand = it.getLeftOperand();
+    if ((_leftOperand instanceof NullLiteral)) {
+      _or = true;
+    } else {
+      Expression _rightOperand = it.getRightOperand();
+      _or = (_rightOperand instanceof NullLiteral);
     }
     return _or;
   }
@@ -2269,7 +2317,7 @@ public class JavaASTFlattener extends ASTVisitor {
       _javadoc_1.accept(this);
     }
     List _modifiers = node.modifiers();
-    this.appendModifieres(node, _modifiers);
+    this.appendModifiers(node, _modifiers);
     this.appendToBuffer("annotation ");
     SimpleName _name = node.getName();
     _name.accept(this);
@@ -2290,7 +2338,7 @@ public class JavaASTFlattener extends ASTVisitor {
       _javadoc_1.accept(this);
     }
     List _modifiers = node.modifiers();
-    this.appendModifieres(node, _modifiers);
+    this.appendModifiers(node, _modifiers);
     Type _type = node.getType();
     _type.accept(this);
     this.appendSpaceToBuffer();
@@ -2569,7 +2617,7 @@ public class JavaASTFlattener extends ASTVisitor {
       _javadoc_1.accept(this);
     }
     List _modifiers = node.modifiers();
-    this.appendModifieres(node, _modifiers);
+    this.appendModifiers(node, _modifiers);
     SimpleName _name = node.getName();
     _name.accept(this);
     List _arguments = node.arguments();
@@ -2601,7 +2649,7 @@ public class JavaASTFlattener extends ASTVisitor {
       _javadoc_1.accept(this);
     }
     List _modifiers = node.modifiers();
-    this.appendModifieres(node, _modifiers);
+    this.appendModifiers(node, _modifiers);
     List _modifiers_1 = node.modifiers();
     Iterable<Modifier> _filter = Iterables.<Modifier>filter(_modifiers_1, Modifier.class);
     boolean _isPackageVisibility = this._aSTFlattenerUtils.isPackageVisibility(_filter);

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/javaconverter/JavaConverterTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/javaconverter/JavaConverterTest.xtend
@@ -432,14 +432,14 @@ class JavaConverterTest extends AbstractXtendTestCase {
 			/* ML */
 			int i=1
 			//singleline
-			def package void doStuff(){
+			def package void doStuff() {
 				/*
 				 multiline
 				*/
 				
 			}
 			/**/
-			def package void doStuff2(){
+			def package void doStuff2() {
 				/* some comments */
 				return;
 			}
@@ -757,7 +757,7 @@ class JavaConverterTest extends AbstractXtendTestCase {
 		'''
 		assertEquals('''
 		int[] ar=newIntArrayOfSize(1)
-		def void arDim(){
+		def void arDim() {
 			var int[] ar2=newIntArrayOfSize(2) 
 			
 		}'''.toString, toXtendClassBodyDeclr(xtendCode))
@@ -1060,7 +1060,7 @@ public String loadingURI='''classpath:/«('''«someVar»LoadingResourceWithError'''
 			}
 		}''')
 		assertEquals('''
-		def private String doSwitch(){
+		def private String doSwitch() {
 			var int i=0 
 			
 			switch (i) {
@@ -1175,7 +1175,7 @@ public String loadingURI='''classpath:/«('''«someVar»LoadingResourceWithError'''
 		assertEquals(xtendCode,
 			'''
 			class Foo {
-				def protected void doStuff(){
+				def protected void doStuff() {
 					val List<String> values/* FIXME empty initializer for final variable is not supported */ val List<String> values2=null val List<String> values3/* FIXME empty initializer for final variable is not supported */ 
 					values=new ArrayList<String>() 
 				}
@@ -1199,7 +1199,7 @@ public String loadingURI='''classpath:/«('''«someVar»LoadingResourceWithError'''
 		}'''
 		var body = toXtendClassBodyDeclr(java)
 		assertEquals('''
-		def void doBitwiseOperation(){
+		def void doBitwiseOperation() {
 			if ((1.bitwiseAnd(2)) > 0) {
 				return;
 			}
@@ -1221,7 +1221,7 @@ public String loadingURI='''classpath:/«('''«someVar»LoadingResourceWithError'''
 		assertNotNull(clazz)
 		var body = toXtendClassBodyDeclr(javaBody)
 		assertEquals('''
-		def void doBitwiseOperation(){
+		def void doBitwiseOperation() {
 			var int i=1 
 			i=i.bitwiseNot 
 		}'''.toString, body)
@@ -1243,7 +1243,7 @@ public String loadingURI='''classpath:/«('''«someVar»LoadingResourceWithError'''
 		assertNotNull(clazz)
 		var body = toXtendClassBodyDeclr(javaBody)
 		assertEquals('''
-		def void checkTryCatch(){
+		def void checkTryCatch() {
 			try {
 				
 			} catch (Exception e) {
@@ -1319,7 +1319,7 @@ public String loadingURI='''classpath:/«('''«someVar»LoadingResourceWithError'''
 			 }
 		'''
 		assertEquals('''
-		def void add(int value){
+		def void add(int value) {
 			synchronized (this) {
 				this.count+=value 
 			}
@@ -1356,6 +1356,59 @@ public String loadingURI='''classpath:/«('''«someVar»LoadingResourceWithError'''
 		String comments
 		}'''.toString, body)
 
+	}
+	
+	@Test def void testBug462099() throws Exception {
+		var xtendCode = toXtendCode('''
+			public class Foo {
+				public int foo(Object obj) {
+					if (obj == null) {
+						return 0;
+					} else if (obj == "test") {
+						return 1;
+					} else if (obj != null) {
+						return 2;
+					} else {
+						return 3;
+					}
+				}
+			}
+		''')
+		val expected = '''
+			class Foo {
+				def int foo(Object obj) {
+					if (obj === null) {
+						return 0 
+					} else if (obj == "test") {
+						return 1 
+					} else if (obj !== null) {
+						return 2 
+					} else {
+						return 3 
+					}
+				}
+				
+			}'''
+		assertEquals(expected, xtendCode)
+	}
+	
+	@Test def void testBug462100() throws Exception {
+		var xtendCode = toXtendCode('''
+			public class Foo {
+				@Override
+				public String toString() {
+					return "bar";
+				}
+			}
+		''')
+		val expected = '''
+			class Foo {
+				override String toString() {
+					return "bar" 
+				}
+				
+			}'''
+		assertEquals(expected, xtendCode)
 	}
 
 	def protected XtendClass toValidXtendClass(String javaCode) throws Exception {

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/javaconverter/JavaConverterTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/javaconverter/JavaConverterTest.java
@@ -765,7 +765,7 @@ public class JavaConverterTest extends AbstractXtendTestCase {
     _builder_1.append("//singleline");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def package void doStuff(){");
+    _builder_1.append("def package void doStuff() {");
     _builder_1.newLine();
     _builder_1.append("\t\t");
     _builder_1.append("/*");
@@ -785,7 +785,7 @@ public class JavaConverterTest extends AbstractXtendTestCase {
     _builder_1.append("/**/");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def package void doStuff2(){");
+    _builder_1.append("def package void doStuff2() {");
     _builder_1.newLine();
     _builder_1.append("\t\t");
     _builder_1.append("/* some comments */");
@@ -1355,7 +1355,7 @@ public class JavaConverterTest extends AbstractXtendTestCase {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("int[] ar=newIntArrayOfSize(1)");
     _builder_1.newLine();
-    _builder_1.append("def void arDim(){");
+    _builder_1.append("def void arDim() {");
     _builder_1.newLine();
     _builder_1.append("\t");
     _builder_1.append("var int[] ar2=newIntArrayOfSize(2) ");
@@ -1906,7 +1906,7 @@ public class JavaConverterTest extends AbstractXtendTestCase {
     _builder.append("}");
     String clazz = this.toXtendClassBodyDeclr(_builder);
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("def private String doSwitch(){");
+    _builder_1.append("def private String doSwitch() {");
     _builder_1.newLine();
     _builder_1.append("\t");
     _builder_1.append("var int i=0 ");
@@ -2179,7 +2179,7 @@ public class JavaConverterTest extends AbstractXtendTestCase {
     _builder_1.append("class Foo {");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def protected void doStuff(){");
+    _builder_1.append("def protected void doStuff() {");
     _builder_1.newLine();
     _builder_1.append("\t\t");
     _builder_1.append("val List<String> values/* FIXME empty initializer for final variable is not supported */ val List<String> values2=null val List<String> values3/* FIXME empty initializer for final variable is not supported */ ");
@@ -2233,7 +2233,7 @@ public class JavaConverterTest extends AbstractXtendTestCase {
     final String java = _builder.toString();
     String body = this.toXtendClassBodyDeclr(java);
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("def void doBitwiseOperation(){");
+    _builder_1.append("def void doBitwiseOperation() {");
     _builder_1.newLine();
     _builder_1.append("\t");
     _builder_1.append("if ((1.bitwiseAnd(2)) > 0) {");
@@ -2281,7 +2281,7 @@ public class JavaConverterTest extends AbstractXtendTestCase {
     Assert.assertNotNull(clazz);
     String body = this.toXtendClassBodyDeclr(javaBody);
     StringConcatenation _builder_2 = new StringConcatenation();
-    _builder_2.append("def void doBitwiseOperation(){");
+    _builder_2.append("def void doBitwiseOperation() {");
     _builder_2.newLine();
     _builder_2.append("\t");
     _builder_2.append("var int i=1 ");
@@ -2329,7 +2329,7 @@ public class JavaConverterTest extends AbstractXtendTestCase {
     Assert.assertNotNull(clazz);
     String body = this.toXtendClassBodyDeclr(javaBody);
     StringConcatenation _builder_2 = new StringConcatenation();
-    _builder_2.append("def void checkTryCatch(){");
+    _builder_2.append("def void checkTryCatch() {");
     _builder_2.newLine();
     _builder_2.append("\t");
     _builder_2.append("try {");
@@ -2482,7 +2482,7 @@ public class JavaConverterTest extends AbstractXtendTestCase {
     _builder.newLine();
     final String javaBody = _builder.toString();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("def void add(int value){");
+    _builder_1.append("def void add(int value) {");
     _builder_1.newLine();
     _builder_1.append("\t");
     _builder_1.append("synchronized (this) {");
@@ -2557,6 +2557,129 @@ public class JavaConverterTest extends AbstractXtendTestCase {
     _builder_2.append("}");
     String _string = _builder_2.toString();
     Assert.assertEquals(_string, body);
+  }
+  
+  @Test
+  public void testBug462099() throws Exception {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("public class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("public int foo(Object obj) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("if (obj == null) {");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("return 0;");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("} else if (obj == \"test\") {");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("return 1;");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("} else if (obj != null) {");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("return 2;");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("} else {");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("return 3;");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    String xtendCode = this.toXtendCode(_builder.toString());
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def int foo(Object obj) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("if (obj === null) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("return 0 ");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("} else if (obj == \"test\") {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("return 1 ");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("} else if (obj !== null) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("return 2 ");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("} else {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("return 3 ");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    final String expected = _builder_1.toString();
+    Assert.assertEquals(expected, xtendCode);
+  }
+  
+  @Test
+  public void testBug462100() throws Exception {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("public class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@Override");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("public String toString() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("return \"bar\";");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    String xtendCode = this.toXtendCode(_builder.toString());
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("override String toString() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("return \"bar\" ");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    final String expected = _builder_1.toString();
+    Assert.assertEquals(expected, xtendCode);
   }
   
   protected XtendClass toValidXtendClass(final String javaCode) throws Exception {


### PR DESCRIPTION
- Bug 462099: use `===` for comparisons with `null`
- Bug 462100: omit `@Override` for method declarations
- Added parentheses to fallback solution of lambda generation
- Added a space before the opening brace of a method declaration
- Renamed isOverrideMethode &rarr; isOverrideMethod
- Renamed appendModifieres &rarr; appendModifiers
- Fixed indentation in ASTFlattenerUtils