### PR TITLE
[grammar][contentAssist] Fixed two cosmetic issues

### DIFF
--- a/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/ui/contentassist/XtextProposalProvider.java
+++ b/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/ui/contentassist/XtextProposalProvider.java
@@ -66,6 +66,7 @@ import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.services.XtextGrammarAccess;
 import org.eclipse.xtext.ui.editor.contentassist.ConfigurableCompletionProposal;
 import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext;
+import org.eclipse.xtext.ui.editor.contentassist.FQNPrefixMatcher;
 import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor;
 import org.eclipse.xtext.ui.editor.contentassist.PrefixMatcher;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.DefaultHighlightingConfiguration;
@@ -98,6 +99,9 @@ public class XtextProposalProvider extends AbstractXtextProposalProvider {
 
 	@Inject
 	private IQualifiedNameConverter.DefaultImpl grammarIdQualifiedNameConverter;
+	
+	@Inject
+	private FQNPrefixMatcher fqnPrefixMatcher;
 
 	public static class ClassifierPrefixMatcher extends PrefixMatcher {
 		private PrefixMatcher delegate;
@@ -126,7 +130,6 @@ public class XtextProposalProvider extends AbstractXtextProposalProvider {
 			}
 			return false;
 		}
-
 	}
 
 	@Override
@@ -157,6 +160,13 @@ public class XtextProposalProvider extends AbstractXtextProposalProvider {
 				}
 			}
 		}
+	}
+	
+	@Override
+	public void completeGrammar_UsedGrammars(EObject model, Assignment assignment, ContentAssistContext context,
+			ICompletionProposalAcceptor acceptor) {
+		ContentAssistContext decorated = context.copy().setMatcher(fqnPrefixMatcher).toContext();
+		super.completeGrammar_UsedGrammars(model, assignment, decorated, acceptor);
 	}
 
 	@Override

--- a/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/ui/contentassist/XtextProposalProvider.java
+++ b/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/ui/contentassist/XtextProposalProvider.java
@@ -163,6 +163,16 @@ public class XtextProposalProvider extends AbstractXtextProposalProvider {
 	}
 	
 	@Override
+	public void completeKeyword(Keyword keyword, ContentAssistContext contentAssistContext,
+			ICompletionProposalAcceptor acceptor) {
+		if (keyword == grammarAccess.getGrammarAccess().getCommaKeyword_2_2_0()) {
+			// don't propose the comma after the used grammar
+			return;
+		}
+		super.completeKeyword(keyword, contentAssistContext, acceptor);
+	}
+	
+	@Override
 	public void completeGrammar_UsedGrammars(EObject model, Assignment assignment, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
 		ContentAssistContext decorated = context.copy().setMatcher(fqnPrefixMatcher).toContext();

--- a/tests/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/contentassist/XtextContentAssistTest.java
+++ b/tests/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/contentassist/XtextContentAssistTest.java
@@ -94,7 +94,7 @@ public class XtextContentAssistTest extends AbstractContentAssistProcessorTest {
 	        .appendNl("grammar foo with Terminal")
 	        .appendNl("generate meta \"url\"")
 	        .appendNl("Rule: name=ID;")
-	        .assertTextAtCursorPosition("Terminal", 2, "org.eclipse.xtext.common.Terminals", ",");
+	        .assertTextAtCursorPosition("Terminal", 2, "org.eclipse.xtext.common.Terminals");
     }
     
     /**
@@ -105,7 +105,7 @@ public class XtextContentAssistTest extends AbstractContentAssistProcessorTest {
     	.appendNl("grammar foo with or.e.xt")
     	.appendNl("generate meta \"url\"")
     	.appendNl("Rule: name=ID;")
-    	.assertTextAtCursorPosition("xt", 1, "org.eclipse.xtext.Xtext", "org.eclipse.xtext.common.Terminals", ",");
+    	.assertTextAtCursorPosition("xt", 1, "org.eclipse.xtext.Xtext", "org.eclipse.xtext.common.Terminals");
     }
 	
 	/**
@@ -116,7 +116,7 @@ public class XtextContentAssistTest extends AbstractContentAssistProcessorTest {
 	        .appendNl("grammar foo with org.eclipse.xtext.common.Terminals")
 	        .appendNl("generate meta \"url\"")
 	        .appendNl("Rule: name=ID;")
-	        .assertTextAtCursorPosition("org.eclipse.xtext", 2, "org.eclipse.xtext.Xtext", "org.eclipse.xtext.common.Terminals", ",");
+	        .assertTextAtCursorPosition("org.eclipse.xtext", 2, "org.eclipse.xtext.Xtext", "org.eclipse.xtext.common.Terminals");
     }
     
     /**
@@ -127,7 +127,7 @@ public class XtextContentAssistTest extends AbstractContentAssistProcessorTest {
 	        .appendNl("grammar foo with org.eclipse.xtext.common.Terminals")
 	        .appendNl("generate meta \"url\"")
 	        .appendNl("Rule: name=ID;")
-	        .assertTextAtCursorPosition("org.eclipse.xtext", 5, "org.eclipse.xtext.Xtext","org.eclipse.xtext.common.Terminals", ",");
+	        .assertTextAtCursorPosition("org.eclipse.xtext", 5, "org.eclipse.xtext.Xtext", "org.eclipse.xtext.common.Terminals");
     }
     
     @Test public void testCompletionOnDatatypeReference_03() throws Exception {
@@ -135,7 +135,7 @@ public class XtextContentAssistTest extends AbstractContentAssistProcessorTest {
 	        .appendNl("grammar foo with org.eclipse.xtext.common.Terminals")
 	        .appendNl("generate meta \"url\"")
 	        .appendNl("Rule: name=ID;")
-	        .assertTextAtCursorPosition("org.eclipse.xtext", 4, "org.eclipse.xtext.Xtext","org.eclipse.xtext.common.Terminals");
+	        .assertTextAtCursorPosition("org.eclipse.xtext", 4, "org.eclipse.xtext.Xtext", "org.eclipse.xtext.common.Terminals");
     }
     
     @Test public void testCompletionOnDatatypeReference_04() throws Exception {
@@ -315,7 +315,7 @@ public class XtextContentAssistTest extends AbstractContentAssistProcessorTest {
 	@Test public void testCompleteTypeRefReturnForParserRule() throws Exception {
         doTestCompleteTypeRefSetup()
                 .appendNl("NewType returns").assertText(
-                                "Class", "Import","Model","NewType"
+                                "Class", "Import", "Model", "NewType"
                 );
     }
 	
@@ -751,7 +751,7 @@ public class XtextContentAssistTest extends AbstractContentAssistProcessorTest {
 	@Test public void testCompleteTypeRef_02() throws Exception {
 		doTestCompleteTypeRefWithAliasSetup()
 	        .append("NewRule returns mYal").assertText(
-	                        "myAlias::Class", "myAlias::Import","myAlias::Model", "myAlias", ":", "::"
+	                        "myAlias::Class", "myAlias::Import", "myAlias::Model", "myAlias", ":", "::"
 	        );
     }
 	
@@ -779,7 +779,7 @@ public class XtextContentAssistTest extends AbstractContentAssistProcessorTest {
 	@Test public void testCompleteTypeRef_06() throws Exception {
 		doTestCompleteTypeRefWithAliasSetup()
 			.append("NewRule returns myAlias::NewRule: reference=[mYal").assertText(
-	                        "myAlias::Class", "myAlias::Import","myAlias::Model", "myAlias::NewRule", "myAlias", "]", "::", "|"
+	                        "myAlias::Class", "myAlias::Import", "myAlias::Model", "myAlias::NewRule", "myAlias", "]", "::", "|"
 	        );
     }
 	
@@ -807,7 +807,7 @@ public class XtextContentAssistTest extends AbstractContentAssistProcessorTest {
 	@Test public void testCompleteTypeRef_10() throws Exception {
 		doTestCompleteTypeRefWithAliasSetup()
 			.append("NewRule returns myAlias::NewRule: {mYal").assertText(
-	                        "myAlias::Class", "myAlias::Import","myAlias::Model", "myAlias::NewRule", "myAlias", "}", ".", "::"
+	                        "myAlias::Class", "myAlias::Import", "myAlias::Model", "myAlias::NewRule", "myAlias", "}", ".", "::"
 	        );
     }
 	

--- a/tests/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/contentassist/XtextContentAssistTest.java
+++ b/tests/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/contentassist/XtextContentAssistTest.java
@@ -87,6 +87,28 @@ public class XtextContentAssistTest extends AbstractContentAssistProcessorTest {
 	}
 	
 	/**
+     * https://bugs.eclipse.org/bugs/show_bug.cgi?id=463215
+     */
+    @Test public void testBug463215_01() throws Exception {
+        newBuilder()
+	        .appendNl("grammar foo with Terminal")
+	        .appendNl("generate meta \"url\"")
+	        .appendNl("Rule: name=ID;")
+	        .assertTextAtCursorPosition("Terminal", 2, "org.eclipse.xtext.common.Terminals", ",");
+    }
+    
+    /**
+     * https://bugs.eclipse.org/bugs/show_bug.cgi?id=463215
+     */
+    @Test public void testBug463215_02() throws Exception {
+    	newBuilder()
+    	.appendNl("grammar foo with or.e.xt")
+    	.appendNl("generate meta \"url\"")
+    	.appendNl("Rule: name=ID;")
+    	.assertTextAtCursorPosition("xt", 1, "org.eclipse.xtext.Xtext", "org.eclipse.xtext.common.Terminals", ",");
+    }
+	
+	/**
      * https://bugs.eclipse.org/bugs/show_bug.cgi?id=269680
      */
     @Test public void testCompletionOnDatatypeReference_01() throws Exception {
@@ -94,7 +116,7 @@ public class XtextContentAssistTest extends AbstractContentAssistProcessorTest {
 	        .appendNl("grammar foo with org.eclipse.xtext.common.Terminals")
 	        .appendNl("generate meta \"url\"")
 	        .appendNl("Rule: name=ID;")
-	        .assertTextAtCursorPosition("org.eclipse.xtext", 2, "org.eclipse.xtext.Xtext","org.eclipse.xtext.common.Terminals", ",");
+	        .assertTextAtCursorPosition("org.eclipse.xtext", 2, "org.eclipse.xtext.Xtext", "org.eclipse.xtext.common.Terminals", ",");
     }
     
     /**


### PR DESCRIPTION
- Prefix matching didn't work properly for the super grammar reference.
- The comma after the first super grammar should not be proposed since only one super grammar is supported.