### PR TITLE
 [463258]: Zip files must have at least one entry

### DIFF
--- a/tests/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJdtImplTest.java
+++ b/tests/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJdtImplTest.java
@@ -83,7 +83,7 @@ public class Storage2UriMapperJdtImplTest extends Assert {
 	@Test public void testBug463258_02() throws Exception {
 		IJavaProject project = createJavaProject("foo");
 		IFile file = project.getProject().getFile("foo.jar");
-		file.create(jarInputStream(new TextFile[0]), true, monitor());
+		file.create(jarInputStream(new TextFile("do/not", "care")), true, monitor());
 		addJarToClasspath(project, file);
 		
 		Storage2UriMapperJavaImpl impl = getStorage2UriMapper();

--- a/tests/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/JavaClassPathResourceForIEditorInputFactoryTest.java
+++ b/tests/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/JavaClassPathResourceForIEditorInputFactoryTest.java
@@ -81,7 +81,7 @@ public class JavaClassPathResourceForIEditorInputFactoryTest extends AbstractWor
 	@Test public void testBug463258_02() throws Exception {
 		IJavaProject project = createJavaProject("foo");
 		IFile file = project.getProject().getFile("foo.jar");
-		file.create(jarInputStream(new TextFile[0]), true, monitor());
+		file.create(jarInputStream(new TextFile("do/not", "care")), true, monitor());
 		addJarToClasspath(project, file);
 		
 		IPackageFragmentRoot root = project.getPackageFragmentRoot(file);


### PR DESCRIPTION
Maybe an OS specific invariant?

see https://hudson.eclipse.org/xtext/job/xtext-xtend-tests-maintenance/111/testReport/junit/org.eclipse.xtext.ui.tests.editor.model/JavaClassPathResourceForIEditorInputFactoryTest/testBug463258_02/

Signed-off-by: szarnekow <Sebastian.Zarnekow@itemis.de>