### PR TITLE
Added integration test for xtend.maven.archetype

### DIFF
--- a/maven/org.eclipse.xtend.maven.archetype/pom.xml
+++ b/maven/org.eclipse.xtend.maven.archetype/pom.xml
@@ -1,16 +1,23 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>org.eclipse.xtext</groupId>
 		<artifactId>org.eclipse.xtext.parent</artifactId>
 		<version>2.9.0-SNAPSHOT</version>
 		<relativePath>../org.eclipse.xtext.parent</relativePath>
 	</parent>
-	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.eclipse.xtend</groupId>
 	<artifactId>xtend-archetype</artifactId>
 	<packaging>maven-archetype</packaging>
 	<name>Create a simple Xtend project</name>
 	<url>http://xtend-lang.org</url>
+
+	<properties>
+		<maven.archetype.version>2.3</maven.archetype.version>
+	</properties>
 
 	<build>
 		<resources>
@@ -33,7 +40,7 @@
 			<extension>
 				<groupId>org.apache.maven.archetype</groupId>
 				<artifactId>archetype-packaging</artifactId>
-				<version>2.2</version>
+				<version>${maven.archetype.version}</version>
 			</extension>
 		</extensions>
 		<pluginManagement>
@@ -41,7 +48,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-archetype-plugin</artifactId>
-					<version>2.2</version>
+					<version>${maven.archetype.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -53,6 +60,20 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-archetype-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+						</goals>
+					</execution>
+				</executions>
+				
+			</plugin>
+		</plugins>
 	</build>
-	<groupId>org.eclipse.xtend</groupId>
+	
 </project>

--- a/maven/org.eclipse.xtend.maven.archetype/src/test/resources/projects/first/archetype.properties
+++ b/maven/org.eclipse.xtend.maven.archetype/src/test/resources/projects/first/archetype.properties
@@ -1,0 +1,6 @@
+sourceEncoding=UTF-8
+groupId=integrationtest.group
+artifactId=integrationtest.artifactId
+version=1.0.0-SNAPSHOT
+package=org.eclipse.xtend.xtend-archetype.integrationtest
+packageInPathFormat=org/eclipse/xtend/xtend-archetype/integrationtest

--- a/maven/org.eclipse.xtend.maven.archetype/src/test/resources/projects/first/goal.txt
+++ b/maven/org.eclipse.xtend.maven.archetype/src/test/resources/projects/first/goal.txt
@@ -1,0 +1,1 @@
+package

--- a/maven/org.eclipse.xtext.parent/pom.xml
+++ b/maven/org.eclipse.xtext.parent/pom.xml
@@ -78,7 +78,7 @@
 			<extension>
 				<groupId>org.apache.maven.archetype</groupId>
 				<artifactId>archetype-packaging</artifactId>
-				<version>2.2</version>
+				<version>2.3</version>
 			</extension>
 		</extensions>
 		<plugins>


### PR DESCRIPTION
Hi guys, perhaps this is useful? It adds an integration test to the xtend.maven.archetype, as in with this the build actually "instantiates" the archetype template, and runs a 'mvn package' on it, to make sure it cleanly builds.

PS: I built this because I suspect the archetype was broken, and meant to contribute a fix, but then later found it was another problem on my end, as I had already built this test, I though I'd contribute it anyway, as you may find this useful for future non-regression?

PPS: This doesn't actually pass on current master head for me, but the failure I'm getting is probably because you're working on something new on 2.9 and probably already know that it seems to be currently broken?