### PR TITLE
[463407]: Fixed bogus ambiguity validation

### DIFF
--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/AmbiguityBug463407Test.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/AmbiguityBug463407Test.xtend
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.validation
+
+import org.junit.Test
+
+/**
+ * @author Sebastian Zarnekow - Initial contribution and API
+ */
+class AmbiguityBug463407Test extends AmbiguityValidationTest {
+	
+	@Test
+	def void testUnambiguousMethod_01() {
+		'''
+			import org.eclipse.xtext.xbase.lib.Functions.Function0
+			import java.util.List
+			
+			class A {
+			  def m() {
+			    aSetter(#["", ""])
+			  }
+			  def void aSetter(List<Object> c) {}
+			  def void aSetter(Function0<List<Object>> c) {}
+			}
+		'''.assertUnambiguous()
+	}
+	
+	@Test
+	def void testUnambiguousMethod_02() {
+		'''
+			import org.eclipse.xtext.xbase.lib.Functions.Function0
+			import java.util.List
+			
+			class A {
+			  def m() {
+			    aSetter(#[''])
+			  }
+			  def void aSetter(List<Object> c) {}
+			  def void aSetter(Function0<List<Object>> c) {}
+			}
+		'''.assertUnambiguous()
+	}
+	
+	@Test
+	def void testUnambiguousMethod_03() {
+		'''
+			import org.eclipse.xtext.xbase.lib.Functions.Function0
+			import java.util.List
+			
+			class A {
+			  def m() {
+			    aSetter(#[])
+			  }
+			  def void aSetter(List<Object> c) {}
+			  def void aSetter(Function0<List<Object>> c) {}
+			}
+		'''.assertUnambiguous()
+	}
+	
+	@Test
+	def void testUnambiguousMethod_04() {
+		'''
+			import org.eclipse.xtext.xbase.lib.Functions.Function0
+			import java.util.List
+			
+			class A {
+			  def m() {
+			    aSetter(newArrayList(''))
+			  }
+			  def void aSetter(List<Object> c) {}
+			  def void aSetter(Function0<List<Object>> c) {}
+			}
+		'''.assertUnambiguous()
+	}
+	
+	@Test
+	def void testUnambiguousMethod_05() {
+		'''
+			import org.eclipse.xtext.xbase.lib.Functions.Function0
+			import java.util.List
+			
+			class A {
+			  def m() {
+			    aSetter(newArrayList)
+			  }
+			  def void aSetter(List<Object> c) {}
+			  def void aSetter(Function0<List<Object>> c) {}
+			}
+		'''.assertUnambiguous()
+	}
+	
+	@Test
+	def void testUnambiguousMethod_06() {
+		'''
+			import org.eclipse.xtext.xbase.lib.Functions.Function0
+			import java.util.List
+			
+			class A {
+			  def m() {
+			    #["", ""].aSetter
+			  }
+			  def void aSetter(List<? extends Object> c) {}
+			  def void aSetter(Function0<List<Object>> c) {}
+			}
+		'''.assertUnambiguous()
+	}
+	
+	@Test
+	def void testUnambiguousMethod_07() {
+		'''
+			import org.eclipse.xtext.xbase.lib.Functions.Function0
+			import java.util.List
+			
+			class A {
+			  def m() {
+			    aSetter[]
+			  }
+			  def void aSetter(List<Object> c) {}
+			  def void aSetter(Function0<List<Object>> c) {}
+			}
+		'''.assertUnambiguous()
+	}
+	
+	@Test
+	def void testUnambiguousMethod_08() {
+		'''
+			import org.eclipse.xtext.xbase.lib.Functions.Function0
+			import java.util.List
+			
+			class A {
+			  def m() {
+			    aSetter[|]
+			  }
+			  def void aSetter(List<Object> c) {}
+			  def void aSetter(Function0<List<Object>> c) {}
+			}
+		'''.assertUnambiguous()
+	}
+	
+	@Test
+	def void testAmbiguousMethod_01() {
+		'''
+			import org.eclipse.xtext.xbase.lib.Functions.Function0
+			import java.util.List
+			
+			class A {
+			  def m() {
+			    aSetter(null)
+			  }
+			  def void aSetter(List<Object> c) {}
+			  def void aSetter(Function0<List<Object>> c) {}
+			}
+		'''.assertAmbiguous('''
+			Ambiguous feature call.
+			The methods
+				aSetter(List<Object>) in A and
+				aSetter(Function0<List<Object>>) in A
+			both match.''')
+	}
+	
+}

--- a/tests/org.eclipse.xtend.core.tests/suites/org/eclipse/xtend/core/tests/validation/AmbiguityValidationSuite.java
+++ b/tests/org.eclipse.xtend.core.tests/suites/org/eclipse/xtend/core/tests/validation/AmbiguityValidationSuite.java
@@ -25,7 +25,8 @@ import org.junit.runners.Suite.SuiteClasses;
 	AmbiguityBug426779Test.class,
 	AmbiguityBug427352Test.class,
 	AmbiguityBug429623Test.class,
-	AmbiguityBug438461Test.class
+	AmbiguityBug438461Test.class,
+	AmbiguityBug463407Test.class
 })
 public class AmbiguityValidationSuite {
 }

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/AmbiguityBug463407Test.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/AmbiguityBug463407Test.java
@@ -1,0 +1,300 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.validation;
+
+import org.eclipse.xtend.core.tests.validation.AmbiguityValidationTest;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.junit.Test;
+
+/**
+ * @author Sebastian Zarnekow - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class AmbiguityBug463407Test extends AmbiguityValidationTest {
+  @Test
+  public void testUnambiguousMethod_01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.eclipse.xtext.xbase.lib.Functions.Function0");
+    _builder.newLine();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def m() {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("aSetter(#[\"\", \"\"])");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(List<Object> c) {}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(Function0<List<Object>> c) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.assertUnambiguous(_builder);
+  }
+  
+  @Test
+  public void testUnambiguousMethod_02() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.eclipse.xtext.xbase.lib.Functions.Function0");
+    _builder.newLine();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def m() {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("aSetter(#[\'\'])");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(List<Object> c) {}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(Function0<List<Object>> c) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.assertUnambiguous(_builder);
+  }
+  
+  @Test
+  public void testUnambiguousMethod_03() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.eclipse.xtext.xbase.lib.Functions.Function0");
+    _builder.newLine();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def m() {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("aSetter(#[])");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(List<Object> c) {}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(Function0<List<Object>> c) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.assertUnambiguous(_builder);
+  }
+  
+  @Test
+  public void testUnambiguousMethod_04() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.eclipse.xtext.xbase.lib.Functions.Function0");
+    _builder.newLine();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def m() {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("aSetter(newArrayList(\'\'))");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(List<Object> c) {}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(Function0<List<Object>> c) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.assertUnambiguous(_builder);
+  }
+  
+  @Test
+  public void testUnambiguousMethod_05() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.eclipse.xtext.xbase.lib.Functions.Function0");
+    _builder.newLine();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def m() {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("aSetter(newArrayList)");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(List<Object> c) {}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(Function0<List<Object>> c) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.assertUnambiguous(_builder);
+  }
+  
+  @Test
+  public void testUnambiguousMethod_06() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.eclipse.xtext.xbase.lib.Functions.Function0");
+    _builder.newLine();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def m() {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("#[\"\", \"\"].aSetter");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(List<? extends Object> c) {}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(Function0<List<Object>> c) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.assertUnambiguous(_builder);
+  }
+  
+  @Test
+  public void testUnambiguousMethod_07() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.eclipse.xtext.xbase.lib.Functions.Function0");
+    _builder.newLine();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def m() {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("aSetter[]");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(List<Object> c) {}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(Function0<List<Object>> c) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.assertUnambiguous(_builder);
+  }
+  
+  @Test
+  public void testUnambiguousMethod_08() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.eclipse.xtext.xbase.lib.Functions.Function0");
+    _builder.newLine();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def m() {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("aSetter[|]");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(List<Object> c) {}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(Function0<List<Object>> c) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.assertUnambiguous(_builder);
+  }
+  
+  @Test
+  public void testAmbiguousMethod_01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.eclipse.xtext.xbase.lib.Functions.Function0");
+    _builder.newLine();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def m() {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("aSetter(null)");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(List<Object> c) {}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("def void aSetter(Function0<List<Object>> c) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("Ambiguous feature call.");
+    _builder_1.newLine();
+    _builder_1.append("The methods");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("aSetter(List<Object>) in A and");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("aSetter(Function0<List<Object>>) in A");
+    _builder_1.newLine();
+    _builder_1.append("both match.");
+    this.assertAmbiguous(_builder, _builder_1.toString());
+  }
+}


### PR DESCRIPTION
Collection literals cannot be used to implement a 
Function0 even though an Iterable can be coerced to
a Function0.

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=463407