### PR TITLE
[462917]: Don’t show cross reference proposal

### DIFF
--- a/plugins/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/contentassist/CodetemplatesProposalProvider.java
+++ b/plugins/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/contentassist/CodetemplatesProposalProvider.java
@@ -322,7 +322,7 @@ public class CodetemplatesProposalProvider extends AbstractCodetemplatesProposal
 						DummyTextViewer dummyViewer = new DummyTextViewer(TextSelection.emptySelection(), document);
 						ContentAssistContext[] contexts = delegateFactory.create(dummyViewer, mappedOffset, resource);
 						ICompletionProposalAcceptor mappingAcceptor = new ProjectionAwareProposalAcceptor(acceptor, evaluatedTemplate);
-						createNestedProposals(contexts, context.getViewer(), mappingAcceptor);
+						createNestedProposals(contexts, context.getViewer(), mappingAcceptor, data);
 					}
 				});
 			}
@@ -392,12 +392,12 @@ public class CodetemplatesProposalProvider extends AbstractCodetemplatesProposal
 		
 	}
 	
-	public void createNestedProposals(ContentAssistContext[] contexts, ITextViewer originalViewer, final ICompletionProposalAcceptor acceptor) {
+	public void createNestedProposals(ContentAssistContext[] contexts, ITextViewer originalViewer, final ICompletionProposalAcceptor acceptor, TemplateData data) {
 		for(ContentAssistContext context: contexts) {
 			Builder builder = context.copy();
 			builder.setViewer(originalViewer);
 			ContentAssistContext myContext = builder.toContext();
-			IFollowElementAcceptor selector = createNestedSelector(myContext, acceptor);
+			IFollowElementAcceptor selector = createNestedSelector(myContext, acceptor, data);
 			for (AbstractElement element : myContext.getFirstSetGrammarElements()) {
 				selector.accept(element);
 			}
@@ -405,11 +405,11 @@ public class CodetemplatesProposalProvider extends AbstractCodetemplatesProposal
 	}
 	
 	protected IFollowElementAcceptor createNestedSelector(ContentAssistContext context,
-			ICompletionProposalAcceptor acceptor) {
-		return new NestedContentAssistProcessorSwitch(context, acceptor);
+			ICompletionProposalAcceptor acceptor, TemplateData data) {
+		return new NestedContentAssistProcessorSwitch(context, acceptor, data);
 	}
 	
-	public void completeNestedKeyword(Keyword keyword, ContentAssistContext contentAssistContext, ICompletionProposalAcceptor acceptor) {
+	public void completeNestedKeyword(Keyword keyword, ContentAssistContext contentAssistContext, ICompletionProposalAcceptor acceptor, TemplateData data) {
 		String keywordValue = keyword.getValue();
 		String escapedKeywordValue = keywordValue.replace("$", "$$");
 		StyledString displayString = new StyledString(keywordValue);
@@ -431,7 +431,7 @@ public class CodetemplatesProposalProvider extends AbstractCodetemplatesProposal
 		acceptor.accept(proposal);
 	}
 	
-	public void completeNestedAssignment(Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
+	public void completeNestedAssignment(Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor, TemplateData data) {
 		String proposalText = "${" + assignment.getFeature() + "}";
 		StyledString displayText;
 		if (assignment.getTerminal() instanceof RuleCall) {
@@ -461,38 +461,67 @@ public class CodetemplatesProposalProvider extends AbstractCodetemplatesProposal
 		acceptor.accept(proposal);
 	}
 	
-	public void completeNestedCrossReference(CrossReference crossReference, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-		Assignment assignment = (Assignment) crossReference.eContainer();
-		EReference reference = GrammarUtil.getReference(crossReference);
-		if (reference != null) {
-			String proposalText = "${" + assignment.getFeature() + ":CrossReference("+ reference.getEContainingClass().getName() + "." + reference.getName() +")}";
-			StyledString displayText = new StyledString("${", StyledString.DECORATIONS_STYLER)
-				.append(assignment.getFeature())
-				.append(":CrossReference(", StyledString.DECORATIONS_STYLER)
-				.append(reference.getEContainingClass().getName() + "." + reference.getName(), StyledString.COUNTER_STYLER)
-				.append(")}", StyledString.DECORATIONS_STYLER)
-				.append(" - Create a new template variable", StyledString.QUALIFIER_STYLER);
-			ICompletionProposal proposal = createCompletionProposal(proposalText, displayText, null, context);
-			if (proposal instanceof ConfigurableCompletionProposal) {
-				ConfigurableCompletionProposal configurable = (ConfigurableCompletionProposal) proposal;
-				configurable.setSelectionStart(configurable.getReplacementOffset() + 2);
-				configurable.setSelectionLength(assignment.getFeature().length());
-				configurable.setAutoInsertable(false);
-				configurable.setSimpleLinkedMode(context.getViewer(), '\t');
-				configurable.setPriority(configurable.getPriority() * 2);
+	public void completeNestedCrossReference(CrossReference crossReference, ContentAssistContext context,
+			ICompletionProposalAcceptor acceptor, TemplateData data) {
+		if (data.doCreateProposals()) {
+			ContextTypeIdHelper helper = languageRegistry.getContextTypeIdHelper(data.language);
+			if (helper != null) {
+				String contextTypeId = helper.getId(data.rule);
+				ContextTypeRegistry contextTypeRegistry = languageRegistry.getContextTypeRegistry(data.language);
+				TemplateContextType contextType = contextTypeRegistry.getContextType(contextTypeId);
+				TemplateVariableResolver crossRefResolver = getResolver(contextType, "CrossReference");
+				if (crossRefResolver != null) {
+					Assignment assignment = (Assignment) crossReference.eContainer();
+					EReference reference = GrammarUtil.getReference(crossReference);
+					if (reference != null) {
+						String proposalText = "${" + assignment.getFeature() + ":CrossReference("
+								+ reference.getEContainingClass().getName() + "." + reference.getName() + ")}";
+						StyledString displayText = new StyledString("${", StyledString.DECORATIONS_STYLER)
+								.append(assignment.getFeature())
+								.append(":CrossReference(", StyledString.DECORATIONS_STYLER)
+								.append(reference.getEContainingClass().getName() + "." + reference.getName(),
+										StyledString.COUNTER_STYLER)
+								.append(")}", StyledString.DECORATIONS_STYLER)
+								.append(" - Create a new template variable", StyledString.QUALIFIER_STYLER);
+						ICompletionProposal proposal = createCompletionProposal(proposalText, displayText, null, context);
+						if (proposal instanceof ConfigurableCompletionProposal) {
+							ConfigurableCompletionProposal configurable = (ConfigurableCompletionProposal) proposal;
+							configurable.setSelectionStart(configurable.getReplacementOffset() + 2);
+							configurable.setSelectionLength(assignment.getFeature().length());
+							configurable.setAutoInsertable(false);
+							configurable.setSimpleLinkedMode(context.getViewer(), '\t');
+							configurable.setPriority(configurable.getPriority() * 2);
+						}
+						acceptor.accept(proposal);
+					}
+				}
 			}
-			acceptor.accept(proposal);
 		}
+	}
+		
+	private TemplateVariableResolver getResolver(TemplateContextType contextType, String resolver) {
+		if (contextType == null)
+			return null;
+		Iterator<TemplateVariableResolver> resolvers = Iterators.filter(contextType.resolvers(), TemplateVariableResolver.class);
+		while(resolvers.hasNext()) {
+			TemplateVariableResolver result = resolvers.next();
+			if (resolver.equals(result.getType())) {
+				return result;
+			}
+		}
+		return null;
 	}
 
 	public class NestedContentAssistProcessorSwitch extends XtextSwitch<Boolean> implements IFollowElementAcceptor {
 
 		private final ContentAssistContext context;
 		private final ICompletionProposalAcceptor acceptor;
+		private final TemplateData data;
 
-		public NestedContentAssistProcessorSwitch(ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
+		public NestedContentAssistProcessorSwitch(ContentAssistContext context, ICompletionProposalAcceptor acceptor, TemplateData data) {
 			this.context = context;
 			this.acceptor = acceptor;
+			this.data = data;
 		}
 
 		@Override
@@ -502,7 +531,7 @@ public class CodetemplatesProposalProvider extends AbstractCodetemplatesProposal
 
 		@Override
 		public Boolean caseKeyword(Keyword object) {
-			completeNestedKeyword(object, context, acceptor);
+			completeNestedKeyword(object, context, acceptor, data);
 			return Boolean.TRUE;
 		}
 
@@ -514,7 +543,7 @@ public class CodetemplatesProposalProvider extends AbstractCodetemplatesProposal
 		
 		@Override
 		public Boolean caseCrossReference(CrossReference object) {
-			completeNestedCrossReference(object, context, acceptor);
+			completeNestedCrossReference(object, context, acceptor, data);
 			return Boolean.TRUE;
 		}
 		
@@ -524,7 +553,7 @@ public class CodetemplatesProposalProvider extends AbstractCodetemplatesProposal
 				
 			} else if (object.getRule() instanceof TerminalRule || GrammarUtil.isDatatypeRule((ParserRule) object.getRule())) {
 				if (object.eContainer() instanceof Assignment) {
-					completeNestedAssignment((Assignment) object.eContainer(), context, acceptor);
+					completeNestedAssignment((Assignment) object.eContainer(), context, acceptor, data);
 				}
 			}
 			return Boolean.TRUE;


### PR DESCRIPTION
If the template variable resolver is not available,
no proposal for it should be shown when editing 
templates.

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=462917#c10

Signed-off-by: szarnekow <Sebastian.Zarnekow@itemis.de>