### PR TITLE
[formatter][xtend][quickfix] assume formatted doc after sem qucikfix :)

### DIFF
--- a/tests/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/tests/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -97,7 +97,9 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertIssueCodes(WRONG_PACKAGE)
 		.assertResolutionLabels("Change package declaration to 'test'")
 		.assertModelAfterQuickfix('''
-			package test class Foo {
+			package test
+			
+			class Foo {
 			}
 		''')
 	}
@@ -155,7 +157,9 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertResolutionLabels("Change package declaration to 'test'")
 		// TODO formatting is wrong but this is currently expected
 		.assertModelAfterQuickfix('''
-			package test import static test.C.D.*
+			package test
+			
+			import static test.C.D.*
 			class Foo {
 				def void m() {
 					staticM

--- a/tests/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
+++ b/tests/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
@@ -150,7 +150,10 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     QuickfixTestBuilder _assertIssueCodes = _create.assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.WRONG_PACKAGE);
     QuickfixTestBuilder _assertResolutionLabels = _assertIssueCodes.assertResolutionLabels("Change package declaration to \'test\'");
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package test class Foo {");
+    _builder_1.append("package test");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("class Foo {");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
@@ -237,7 +240,10 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     QuickfixTestBuilder _assertIssueCodes = _create.assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.WRONG_PACKAGE);
     QuickfixTestBuilder _assertResolutionLabels = _assertIssueCodes.assertResolutionLabels("Change package declaration to \'test\'");
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package test import static test.C.D.*");
+    _builder_1.append("package test");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("import static test.C.D.*");
     _builder_1.newLine();
     _builder_1.append("class Foo {");
     _builder_1.newLine();


### PR DESCRIPTION
- assume the document is formattet after applying a semantic quickfix
- in the formatter, make sure only 'unknown' hidden regions are
  formatted. 'unknown' regions are the regions that didn't exist before
  the model was programmatically modified.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@itemis.de>