### PR TITLE
[formatter] improve indent api

### DIFF
--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.xtend
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.xtend
@@ -33,26 +33,29 @@ class DomainmodelFormatter extends XbaseFormatter {
 		}
 	}
 
-	def dispatch void format(PackageDeclaration packagedeclaration, extension IFormattableDocument document) {
-		packagedeclaration.regionForFeature(ABSTRACT_ELEMENT__NAME).surround[oneSpace]
-		packagedeclaration.regionForKeyword("{").append[newLine; increaseIndentation]
-		for (AbstractElement element : packagedeclaration.elements) {
+	def dispatch void format(PackageDeclaration pkg, extension IFormattableDocument document) {
+		val open = pkg.regionForKeyword("{")
+		val close = pkg.regionForKeyword("}")
+		pkg.regionForFeature(ABSTRACT_ELEMENT__NAME).surround[oneSpace]
+		open.append[newLine]
+		interior(open, close)[indent]
+		for (AbstractElement element : pkg.elements) {
 			format(element, document);
 			element.append[setNewLines(1, 1, 2)]
 		}
-		packagedeclaration.regionForKeyword("}").prepend[decreaseIndentation]
 	}
 
 	def dispatch void format(Entity entity, extension IFormattableDocument document) {
+		val open = entity.regionForKeyword("{")
+		val close = entity.regionForKeyword("}")
 		entity.regionForFeature(ABSTRACT_ELEMENT__NAME).surround[oneSpace]
 		entity.superType.surround[oneSpace]
-		entity.regionForKeyword("{").append[newLine; increaseIndentation]
+		interior(open, close)[indent]
 		format(entity.getSuperType(), document);
 		for (Feature feature : entity.features) {
 			format(feature, document);
 			feature.append[setNewLines(1, 1, 2)]
 		}
-		entity.regionForKeyword("}").prepend[decreaseIndentation]
 	}
 
 	def dispatch void format(Property property, extension IFormattableDocument document) {

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.java
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.java
@@ -89,8 +89,10 @@ public class DomainmodelFormatter extends XbaseFormatter {
     }
   }
   
-  protected void _format(final PackageDeclaration packagedeclaration, @Extension final IFormattableDocument document) {
-    ISemanticRegion _regionForFeature = this.regionAccess.regionForFeature(packagedeclaration, DomainmodelPackage.Literals.ABSTRACT_ELEMENT__NAME);
+  protected void _format(final PackageDeclaration pkg, @Extension final IFormattableDocument document) {
+    final ISemanticRegion open = this.regionAccess.regionForKeyword(pkg, "{");
+    final ISemanticRegion close = this.regionAccess.regionForKeyword(pkg, "}");
+    ISemanticRegion _regionForFeature = this.regionAccess.regionForFeature(pkg, DomainmodelPackage.Literals.ABSTRACT_ELEMENT__NAME);
     final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
       @Override
       public void apply(final IHiddenRegionFormatter it) {
@@ -98,39 +100,38 @@ public class DomainmodelFormatter extends XbaseFormatter {
       }
     };
     document.surround(_regionForFeature, _function);
-    ISemanticRegion _regionForKeyword = this.regionAccess.regionForKeyword(packagedeclaration, "{");
     final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
       @Override
       public void apply(final IHiddenRegionFormatter it) {
         it.newLine();
-        it.increaseIndentation();
       }
     };
-    document.append(_regionForKeyword, _function_1);
-    EList<AbstractElement> _elements = packagedeclaration.getElements();
+    document.append(open, _function_1);
+    final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
+      @Override
+      public void apply(final IHiddenRegionFormatter it) {
+        it.indent();
+      }
+    };
+    document.<ISemanticRegion, ISemanticRegion>interior(open, close, _function_2);
+    EList<AbstractElement> _elements = pkg.getElements();
     for (final AbstractElement element : _elements) {
       {
         this.format(element, document);
-        final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
+        final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
             it.setNewLines(1, 1, 2);
           }
         };
-        document.<AbstractElement>append(element, _function_2);
+        document.<AbstractElement>append(element, _function_3);
       }
     }
-    ISemanticRegion _regionForKeyword_1 = this.regionAccess.regionForKeyword(packagedeclaration, "}");
-    final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
-      @Override
-      public void apply(final IHiddenRegionFormatter it) {
-        it.decreaseIndentation();
-      }
-    };
-    document.prepend(_regionForKeyword_1, _function_2);
   }
   
   protected void _format(final Entity entity, @Extension final IFormattableDocument document) {
+    final ISemanticRegion open = this.regionAccess.regionForKeyword(entity, "{");
+    final ISemanticRegion close = this.regionAccess.regionForKeyword(entity, "}");
     ISemanticRegion _regionForFeature = this.regionAccess.regionForFeature(entity, DomainmodelPackage.Literals.ABSTRACT_ELEMENT__NAME);
     final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
       @Override
@@ -147,15 +148,13 @@ public class DomainmodelFormatter extends XbaseFormatter {
       }
     };
     document.<JvmParameterizedTypeReference>surround(_superType, _function_1);
-    ISemanticRegion _regionForKeyword = this.regionAccess.regionForKeyword(entity, "{");
     final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
       @Override
       public void apply(final IHiddenRegionFormatter it) {
-        it.newLine();
-        it.increaseIndentation();
+        it.indent();
       }
     };
-    document.append(_regionForKeyword, _function_2);
+    document.<ISemanticRegion, ISemanticRegion>interior(open, close, _function_2);
     JvmParameterizedTypeReference _superType_1 = entity.getSuperType();
     this.format(_superType_1, document);
     EList<Feature> _features = entity.getFeatures();
@@ -171,14 +170,6 @@ public class DomainmodelFormatter extends XbaseFormatter {
         document.<Feature>append(feature, _function_3);
       }
     }
-    ISemanticRegion _regionForKeyword_1 = this.regionAccess.regionForKeyword(entity, "}");
-    final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
-      @Override
-      public void apply(final IHiddenRegionFormatter it) {
-        it.decreaseIndentation();
-      }
-    };
-    document.prepend(_regionForKeyword_1, _function_3);
   }
   
   protected void _format(final Property property, @Extension final IFormattableDocument document) {

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/XtendFormatter.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/XtendFormatter.xtend
@@ -102,11 +102,12 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 	}
 
 	def protected formatBody(XtendTypeDeclaration type, extension IFormattableDocument format) {
-		val clazzOpenBrace = type.regionForKeyword("{")
-		clazzOpenBrace.prepend(bracesInNewLine)
+		val open = type.regionForKeyword("{")
+		val close = type.regionForKeyword("}")
+		interior(open, close) [indent]
+		open.prepend(bracesInNewLine)
 		if (!type.members.empty) {
-			clazzOpenBrace.append[increaseIndentation]
-			clazzOpenBrace.append(blankLinesBeforeFirstMember)
+			open.append(blankLinesBeforeFirstMember)
 			for (i : 0 .. (type.members.size - 1)) {
 				val current = type.members.get(i)
 				current.format(format)
@@ -120,15 +121,11 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 						current.append(blankLinesBetweenFieldsAndMethods)
 				} else {
 					val member = type.members.get(i)
-					member.append[decreaseIndentation]
 					member.append(blankLinesAfterLastMember)
 				}
 			}
 		} else {
-			if (clazzOpenBrace?.nextHiddenRegion?.containsComment)
-				clazzOpenBrace.append[newLine increaseIndentation decreaseIndentation]
-			else
-				clazzOpenBrace.append[newLine]
+			open.append[newLine]
 		}
 	}
 
@@ -156,23 +153,23 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		formatAnnotations(enumeration, format, newLineAfterClassAnnotations)
 		formatModifiers(enumeration, format)
 		enumeration.regionForKeyword("enum").append[oneSpace]
-		val clazzOpenBrace = enumeration.regionForKeyword("{")
-		clazzOpenBrace.prepend(bracesInNewLine)
+		val open = enumeration.regionForKeyword("{")
+		val close = enumeration.regionForKeyword("}")
+		interior(open, close)[indent]
+		open.prepend(bracesInNewLine)
 		if (!enumeration.members.empty) {
-			clazzOpenBrace.append[increaseIndentation]
-			clazzOpenBrace.append(blankLinesBeforeFirstMember)
+			open.append(blankLinesBeforeFirstMember)
 			for (i : 0 .. (enumeration.members.size - 1)) {
 				val current = enumeration.members.get(i)
 				current.format(format)
 				if (i < enumeration.members.size - 1) {
 					current.immediatelyFollowingKeyword(",").prepend[noSpace].append(blankLinesBetweenEnumLiterals)
 				} else {
-					current.append[decreaseIndentation]
 					current.append(blankLinesAfterLastMember)
 				}
 			}
 		} else {
-			clazzOpenBrace.append[newLine]
+			open.append[newLine]
 		}
 	}
 

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
@@ -272,21 +272,22 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
   protected ISemanticRegion formatBody(final XtendTypeDeclaration type, @Extension final IFormattableDocument format) {
     ISemanticRegion _xblockexpression = null;
     {
-      final ISemanticRegion clazzOpenBrace = this.regionAccess.regionForKeyword(type, "{");
-      format.prepend(clazzOpenBrace, XbaseFormatterPreferenceKeys.bracesInNewLine);
+      final ISemanticRegion open = this.regionAccess.regionForKeyword(type, "{");
+      final ISemanticRegion close = this.regionAccess.regionForKeyword(type, "}");
+      final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
+        @Override
+        public void apply(final IHiddenRegionFormatter it) {
+          it.indent();
+        }
+      };
+      format.<ISemanticRegion, ISemanticRegion>interior(open, close, _function);
+      format.prepend(open, XbaseFormatterPreferenceKeys.bracesInNewLine);
       ISemanticRegion _xifexpression = null;
       EList<XtendMember> _members = type.getMembers();
       boolean _isEmpty = _members.isEmpty();
       boolean _not = (!_isEmpty);
       if (_not) {
-        final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.increaseIndentation();
-          }
-        };
-        format.append(clazzOpenBrace, _function);
-        format.append(clazzOpenBrace, XtendFormatterPreferenceKeys.blankLinesBeforeFirstMember);
+        format.append(open, XtendFormatterPreferenceKeys.blankLinesBeforeFirstMember);
         EList<XtendMember> _members_1 = type.getMembers();
         int _size = _members_1.size();
         int _minus = (_size - 1);
@@ -327,47 +328,18 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
             } else {
               EList<XtendMember> _members_5 = type.getMembers();
               final XtendMember member = _members_5.get((i).intValue());
-              final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
-                @Override
-                public void apply(final IHiddenRegionFormatter it) {
-                  it.decreaseIndentation();
-                }
-              };
-              format.<XtendMember>append(member, _function_1);
               format.<XtendMember>append(member, XtendFormatterPreferenceKeys.blankLinesAfterLastMember);
             }
           }
         }
       } else {
-        ISemanticRegion _xifexpression_1 = null;
-        IHiddenRegion _nextHiddenRegion = null;
-        if (clazzOpenBrace!=null) {
-          _nextHiddenRegion=clazzOpenBrace.getNextHiddenRegion();
-        }
-        boolean _containsComment = false;
-        if (_nextHiddenRegion!=null) {
-          _containsComment=_nextHiddenRegion.containsComment();
-        }
-        if (_containsComment) {
-          final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
-            @Override
-            public void apply(final IHiddenRegionFormatter it) {
-              it.newLine();
-              it.increaseIndentation();
-              it.decreaseIndentation();
-            }
-          };
-          _xifexpression_1 = format.append(clazzOpenBrace, _function_1);
-        } else {
-          final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
-            @Override
-            public void apply(final IHiddenRegionFormatter it) {
-              it.newLine();
-            }
-          };
-          _xifexpression_1 = format.append(clazzOpenBrace, _function_2);
-        }
-        _xifexpression = _xifexpression_1;
+        final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
+          @Override
+          public void apply(final IHiddenRegionFormatter it) {
+            it.newLine();
+          }
+        };
+        _xifexpression = format.append(open, _function_1);
       }
       _xblockexpression = _xifexpression;
     }
@@ -444,20 +416,21 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
       }
     };
     format.append(_regionForKeyword, _function);
-    final ISemanticRegion clazzOpenBrace = this.regionAccess.regionForKeyword(enumeration, "{");
-    format.prepend(clazzOpenBrace, XbaseFormatterPreferenceKeys.bracesInNewLine);
+    final ISemanticRegion open = this.regionAccess.regionForKeyword(enumeration, "{");
+    final ISemanticRegion close = this.regionAccess.regionForKeyword(enumeration, "}");
+    final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
+      @Override
+      public void apply(final IHiddenRegionFormatter it) {
+        it.indent();
+      }
+    };
+    format.<ISemanticRegion, ISemanticRegion>interior(open, close, _function_1);
+    format.prepend(open, XbaseFormatterPreferenceKeys.bracesInNewLine);
     EList<XtendMember> _members = enumeration.getMembers();
     boolean _isEmpty = _members.isEmpty();
     boolean _not = (!_isEmpty);
     if (_not) {
-      final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
-        @Override
-        public void apply(final IHiddenRegionFormatter it) {
-          it.increaseIndentation();
-        }
-      };
-      format.append(clazzOpenBrace, _function_1);
-      format.append(clazzOpenBrace, XtendFormatterPreferenceKeys.blankLinesBeforeFirstMember);
+      format.append(open, XtendFormatterPreferenceKeys.blankLinesBeforeFirstMember);
       EList<XtendMember> _members_1 = enumeration.getMembers();
       int _size = _members_1.size();
       int _minus = (_size - 1);
@@ -482,13 +455,6 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
             ISemanticRegion _prepend = format.prepend(_immediatelyFollowingKeyword, _function_2);
             format.append(_prepend, XtendFormatterPreferenceKeys.blankLinesBetweenEnumLiterals);
           } else {
-            final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
-              @Override
-              public void apply(final IHiddenRegionFormatter it) {
-                it.decreaseIndentation();
-              }
-            };
-            format.<XtendMember>append(current, _function_3);
             format.<XtendMember>append(current, XtendFormatterPreferenceKeys.blankLinesAfterLastMember);
           }
         }
@@ -500,7 +466,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
           it.newLine();
         }
       };
-      format.append(clazzOpenBrace, _function_2);
+      format.append(open, _function_2);
     }
   }
   

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/IndentOnceAutowrapFormatter.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/IndentOnceAutowrapFormatter.xtend
@@ -10,8 +10,10 @@ package org.eclipse.xtext.xbase.formatting2
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import org.eclipse.xtext.formatting2.IAutowrapFormatter
 import org.eclipse.xtext.formatting2.IFormattableDocument
-import org.eclipse.xtext.formatting2.IHiddenRegionFormatter
+import org.eclipse.xtext.formatting2.IHiddenRegionFormatting
 import org.eclipse.xtext.formatting2.regionaccess.IHiddenRegion
+import org.eclipse.xtext.formatting2.regionaccess.ITextSegment
+import org.eclipse.xtext.formatting2.regionaccess.IHiddenRegionPart
 
 /**
  * @author Moritz Eysholdt - Initial contribution and API
@@ -20,10 +22,10 @@ import org.eclipse.xtext.formatting2.regionaccess.IHiddenRegion
 	val IHiddenRegion last
 	var hasWrapped = false
 
-	override format(IHiddenRegionFormatter wrapped, extension IFormattableDocument document) {
+	override format(ITextSegment region, IHiddenRegionFormatting wrapped, extension IFormattableDocument document) {
 		if (!hasWrapped) {
-			wrapped.increaseIndentation
-			last.set[decreaseIndentation]
+			val hiddenRegion = switch region { IHiddenRegion: region IHiddenRegionPart: region.hiddenRegion }
+			set(hiddenRegion, last)[indent]
 			hasWrapped = true
 		}
 	}

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
@@ -78,12 +78,13 @@ class XbaseFormatter extends XtypeFormatter {
 		} else if (elements.empty) {
 			open.append[noSpace]
 		} else if (close.previousHiddenRegion.multiline) {
-			open.append[newLine; increaseIndentation]
+			open.append[newLine]
 			for (elem : elements) {
 				elem.format(format)
 				elem.immediatelyFollowingKeyword(",").prepend[noSpace].append[newLine]
 			}
-			elements.last.append[newLine; decreaseIndentation]
+			elements.last.append[newLine]
+			interior(open, close) [indent]
 		} else {
 			val indent = new IndentOnceAutowrapFormatter(close.previousHiddenRegion)
 			val region = new TextSegment(regionAccess, open.endOffset, close.offset - open.endOffset)
@@ -290,8 +291,7 @@ class XbaseFormatter extends XtypeFormatter {
 
 	def dispatch void format(XSynchronizedExpression expr, extension IFormattableDocument format) {
 		if (expr.eContainer instanceof XVariableDeclaration) {
-			expr.regionForKeyword("synchronized").append[increaseIndentation]
-			expr.append[decreaseIndentation]
+			expr.surround[indent]
 		}
 		val multiline = expr.expression.multiline || expr.expression.leadingHiddenRegion.multiline
 		expr.param.surround[noSpace]
@@ -304,7 +304,7 @@ class XbaseFormatter extends XtypeFormatter {
 		} else if (!multiline) {
 			expr.expression.prepend[oneSpace]
 		} else {
-			expr.expression.prepend[newLine increaseIndentation].append[decreaseIndentation]
+			expr.expression.prepend[newLine].surround[indent]
 		}
 		expr.param.format(format)
 		expr.expression.format(format)
@@ -312,8 +312,7 @@ class XbaseFormatter extends XtypeFormatter {
 
 	def dispatch void format(XIfExpression expr, extension IFormattableDocument format) {
 		if (expr.eContainer instanceof XVariableDeclaration) {
-			expr.regionForKeyword("if").append[increaseIndentation]
-			expr.append[decreaseIndentation]
+			expr.surround[indent]
 		}
 		val multiline = expr.then.multilineOrInNewLine || expr.^else.multilineOrInNewLine
 		expr.^if.surround[noSpace]
@@ -330,19 +329,16 @@ class XbaseFormatter extends XtypeFormatter {
 			if (expr.^else != null)
 				expr.then.append[oneSpace]
 		} else {
-			expr.then.prepend[newLine increaseIndentation]
+			expr.then.prepend[newLine].surround[indent]
 			if (expr.^else != null)
-				expr.then.append[newLine; decreaseIndentation]
-			else
-				expr.then.append[decreaseIndentation]
+				expr.then.append[newLine]
 		}
 		if (expr.^else instanceof XBlockExpression) {
 			expr.^else.prepend(bracesInNewLine)
 		} else if (expr.^else instanceof XIfExpression || !multiline) {
 			expr.^else.prepend[oneSpace]
 		} else {
-			expr.^else.prepend[newLine increaseIndentation]
-			expr.^else.append[decreaseIndentation]
+			expr.^else.prepend[newLine].surround[indent]
 		}
 		expr.^if.format(format)
 		expr.then.format(format)
@@ -357,8 +353,7 @@ class XbaseFormatter extends XtypeFormatter {
 		if (expr.eachExpression instanceof XBlockExpression) {
 			expr.eachExpression.prepend(bracesInNewLine)
 		} else {
-			expr.eachExpression.prepend[newLine increaseIndentation]
-			expr.eachExpression.append[decreaseIndentation]
+			expr.eachExpression.prepend[newLine].surround[indent]
 		}
 		expr.forExpression.format(format)
 		expr.eachExpression.format(format)
@@ -378,8 +373,7 @@ class XbaseFormatter extends XtypeFormatter {
 		if (expr.eachExpression instanceof XBlockExpression) {
 			expr.eachExpression.prepend(bracesInNewLine)
 		} else {
-			expr.eachExpression.prepend[newLine increaseIndentation]
-			expr.eachExpression.append[decreaseIndentation]
+			expr.eachExpression.prepend[newLine].surround[indent]
 		}
 		expr.eachExpression.format(format)
 	}
@@ -390,8 +384,7 @@ class XbaseFormatter extends XtypeFormatter {
 		if (expr.body instanceof XBlockExpression) {
 			expr.body.prepend(bracesInNewLine)
 		} else {
-			expr.body.prepend[newLine increaseIndentation]
-			expr.body.append[decreaseIndentation]
+			expr.body.prepend[newLine].surround[indent]
 		}
 		expr.predicate.format(format)
 		expr.body.format(format)
@@ -403,7 +396,7 @@ class XbaseFormatter extends XtypeFormatter {
 		if (expr.body instanceof XBlockExpression) {
 			expr.body.prepend(bracesInNewLine).append(bracesInNewLine)
 		} else {
-			expr.body.prepend[newLine increaseIndentation].append[newLine decreaseIndentation]
+			expr.body.surround[newLine; indent]
 		}
 		expr.predicate.format(format)
 		expr.body.format(format)
@@ -455,7 +448,7 @@ class XbaseFormatter extends XtypeFormatter {
 		if (expr.expression instanceof XBlockExpression) {
 			expr.expression.prepend(bracesInNewLine).append(bracesInNewLine)
 		} else {
-			expr.expression.prepend[newLine increaseIndentation].append[newLine decreaseIndentation]
+			expr.expression.surround[newLine indent]
 		}
 		expr.expression.format(format)
 		for (cc : expr.catchClauses) {
@@ -471,7 +464,7 @@ class XbaseFormatter extends XtypeFormatter {
 			if (expr.finallyExpression instanceof XBlockExpression) {
 				expr.finallyExpression.prepend(bracesInNewLine)
 			} else {
-				expr.finallyExpression.prepend[newLine increaseIndentation].append[decreaseIndentation]
+				expr.finallyExpression.prepend[newLine].surround[indent]
 			}
 			expr.finallyExpression.format(format)
 		}
@@ -480,13 +473,10 @@ class XbaseFormatter extends XtypeFormatter {
 	def dispatch void format(XCatchClause expr, extension IFormattableDocument format) {
 		expr.regionForKeyword("catch").append(whitespaceBetweenKeywordAndParenthesisML)
 		expr.declaredParam.prepend[noSpace].append[noSpace]
-
-		//		val body = .tokenForEObject
 		if (expr.expression instanceof XBlockExpression)
 			expr.expression.prepend(bracesInNewLine)
 		else {
-			expr.expression.prepend[newLine increaseIndentation]
-			expr.expression.append[decreaseIndentation]
+			expr.expression.prepend[newLine].surround[indent]
 		}
 		expr.declaredParam.format(format)
 		expr.expression.format(format)
@@ -531,7 +521,7 @@ class XbaseFormatter extends XtypeFormatter {
 			if (!expr.cases.empty) {
 				open.append[newLine]
 			}
-			open.append[increaseIndentation]
+			interior(open, close)[indent]
 			for (c : expr.cases) {
 				c.then.prepend[oneSpace]
 				if (c != expr.cases.last)
@@ -541,36 +531,28 @@ class XbaseFormatter extends XtypeFormatter {
 				expr.regionForKeyword("default").prepend[newLine].append[noSpace]
 				expr.^default.prepend[oneSpace]
 			}
-			close.prepend[newLine; decreaseIndentation]
+			close.prepend[newLine]
 		} else {
 			open.prepend(bracesInNewLine)
 			open.append[newLine]
 			if (!expr.cases.empty || expr.^default != null) {
-				open.append[increaseIndentation]
+				interior(open, close) [indent]
 			}
 			for (c : expr.cases) {
 				if (c.then instanceof XBlockExpression) {
-					c.then.prepend(bracesInNewLine)
-					if (expr.^default != null || c != expr.cases.last)
-						c.then.append[newLine]
-					else
-						c.then.append[newLine; decreaseIndentation]
+					c.then.prepend(bracesInNewLine).append[newLine]
 				} else if (c.isFallThrough) {
 					c.regionForFeature(XCASE_PART__FALL_THROUGH).prepend[noSpace].append[newLine]
 				} else {
-					c.then.prepend[newLine; increaseIndentation]
-					if (expr.^default != null || c != expr.cases.last)
-						c.then.append[newLine; decreaseIndentation]
-					else
-						c.then.append[newLine; decreaseIndentation = 2]
+					c.then.surround[newLine; indent]
 				}
 			}
 			if (expr.^default != null) {
 				expr.regionForKeyword("default").append[noSpace]
 				if (expr.^default instanceof XBlockExpression) {
-					expr.^default.prepend(bracesInNewLine).append[newLine; decreaseIndentation]
+					expr.^default.prepend(bracesInNewLine).append[newLine]
 				} else {
-					expr.^default.prepend[newLine; increaseIndentation].append[newLine; decreaseIndentation = 2]
+					expr.^default.surround[newLine; indent]
 				}
 			}
 		}
@@ -621,7 +603,7 @@ class XbaseFormatter extends XtypeFormatter {
 			// broken, do nothing
 		} else if (children.empty) {
 			if (open.nextHiddenRegion.containsComment)
-				open.append[newLine increaseIndentation decreaseIndentation]
+				open.append[newLine; indent]
 			else
 				open.append[noSpace]
 		} else if (close.previousHiddenRegion.multiline) {
@@ -659,13 +641,11 @@ class XbaseFormatter extends XtypeFormatter {
 
 	def protected void formatExpressionsMultiline(Collection<? extends XExpression> expressions, ISemanticRegion open,
 		ISemanticRegion close, extension IFormattableDocument format) {
+		interior(open, close)[indent]
 		if (expressions.empty) {
-			if (open.nextHiddenRegion.containsComment)
-				open.append[newLine increaseIndentation decreaseIndentation]
-			else
-				open.append[newLine]
+			open.append[newLine]
 		} else {
-			open.append(blankLinesAroundExpression).append[increaseIndentation]
+			open.append(blankLinesAroundExpression)
 			for (child : expressions) {
 				child.format(format)
 				val sem = child.immediatelyFollowingKeyword(";")
@@ -674,7 +654,6 @@ class XbaseFormatter extends XtypeFormatter {
 				else
 					child.append(blankLinesAroundExpression)
 			}
-			close.prepend[decreaseIndentation]
 		}
 	}
 

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/IndentOnceAutowrapFormatter.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/IndentOnceAutowrapFormatter.java
@@ -11,7 +11,10 @@ import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtext.formatting2.IAutowrapFormatter;
 import org.eclipse.xtext.formatting2.IFormattableDocument;
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatter;
+import org.eclipse.xtext.formatting2.IHiddenRegionFormatting;
 import org.eclipse.xtext.formatting2.regionaccess.IHiddenRegion;
+import org.eclipse.xtext.formatting2.regionaccess.IHiddenRegionPart;
+import org.eclipse.xtext.formatting2.regionaccess.ITextSegment;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
@@ -26,16 +29,30 @@ public class IndentOnceAutowrapFormatter implements IAutowrapFormatter {
   private boolean hasWrapped = false;
   
   @Override
-  public void format(final IHiddenRegionFormatter wrapped, @Extension final IFormattableDocument document) {
+  public void format(final ITextSegment region, final IHiddenRegionFormatting wrapped, @Extension final IFormattableDocument document) {
     if ((!this.hasWrapped)) {
-      wrapped.increaseIndentation();
+      IHiddenRegion _switchResult = null;
+      boolean _matched = false;
+      if (!_matched) {
+        if (region instanceof IHiddenRegion) {
+          _matched=true;
+          _switchResult = ((IHiddenRegion)region);
+        }
+      }
+      if (!_matched) {
+        if (region instanceof IHiddenRegionPart) {
+          _matched=true;
+          _switchResult = ((IHiddenRegionPart)region).getHiddenRegion();
+        }
+      }
+      final IHiddenRegion hiddenRegion = _switchResult;
       final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
-          it.decreaseIndentation();
+          it.indent();
         }
       };
-      document.set(this.last, _function);
+      document.set(hiddenRegion, this.last, _function);
       this.hasWrapped = true;
     }
   }

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
@@ -150,7 +150,6 @@ public class XbaseFormatter extends XtypeFormatter {
             @Override
             public void apply(final IHiddenRegionFormatter it) {
               it.newLine();
-              it.increaseIndentation();
             }
           };
           format.append(open, _function_1);
@@ -179,10 +178,16 @@ public class XbaseFormatter extends XtypeFormatter {
             @Override
             public void apply(final IHiddenRegionFormatter it) {
               it.newLine();
-              it.decreaseIndentation();
             }
           };
           format.<EObject>append(_last, _function_2);
+          final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
+            @Override
+            public void apply(final IHiddenRegionFormatter it) {
+              it.indent();
+            }
+          };
+          format.<ISemanticRegion, ISemanticRegion>interior(open, close, _function_3);
         } else {
           IHiddenRegion _previousHiddenRegion_1 = close.getPreviousHiddenRegion();
           final IndentOnceAutowrapFormatter indent = new IndentOnceAutowrapFormatter(_previousHiddenRegion_1);
@@ -209,7 +214,7 @@ public class XbaseFormatter extends XtypeFormatter {
               if (_prependNewLineIfMultiline) {
                 boolean _equals_2 = Objects.equal(sep, null);
                 if (_equals_2) {
-                  final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
+                  final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {
                     @Override
                     public void apply(final IHiddenRegionFormatter it) {
                       it.noSpace();
@@ -219,9 +224,9 @@ public class XbaseFormatter extends XtypeFormatter {
                       it.setOnAutowrap(indent);
                     }
                   };
-                  format.append(open, _function_3);
+                  format.append(open, _function_4);
                 } else {
-                  final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {
+                  final Procedure1<IHiddenRegionFormatter> _function_5 = new Procedure1<IHiddenRegionFormatter>() {
                     @Override
                     public void apply(final IHiddenRegionFormatter it) {
                       it.oneSpace();
@@ -231,35 +236,35 @@ public class XbaseFormatter extends XtypeFormatter {
                       it.setOnAutowrap(indent);
                     }
                   };
-                  format.append(sep, _function_4);
+                  format.append(sep, _function_5);
                 }
               } else {
-                final Procedure1<IHiddenRegionFormatter> _function_5 = new Procedure1<IHiddenRegionFormatter>() {
+                final Procedure1<IHiddenRegionFormatter> _function_6 = new Procedure1<IHiddenRegionFormatter>() {
                   @Override
                   public void apply(final IHiddenRegionFormatter it) {
                     it.oneSpace();
                   }
                 };
-                format.append(sep, _function_5);
+                format.append(sep, _function_6);
               }
-              final Procedure1<IHiddenRegionFormatter> _function_6 = new Procedure1<IHiddenRegionFormatter>() {
+              final Procedure1<IHiddenRegionFormatter> _function_7 = new Procedure1<IHiddenRegionFormatter>() {
                 @Override
                 public void apply(final IHiddenRegionFormatter it) {
                   it.noSpace();
                 }
               };
-              format.prepend(sep, _function_6);
+              format.prepend(sep, _function_7);
               EObject _object_1 = ele_1.getObject();
               this.format(_object_1, format);
             }
           }
-          final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
+          final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {
             @Override
             public void apply(final IHiddenRegionFormatter it) {
               it.noSpace();
             }
           };
-          format.prepend(close, _function_3);
+          format.prepend(close, _function_4);
         }
       }
     }
@@ -797,21 +802,13 @@ public class XbaseFormatter extends XtypeFormatter {
   protected void _format(final XSynchronizedExpression expr, @Extension final IFormattableDocument format) {
     EObject _eContainer = expr.eContainer();
     if ((_eContainer instanceof XVariableDeclaration)) {
-      ISemanticRegion _regionForKeyword = this.regionAccess.regionForKeyword(expr, "synchronized");
       final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
-          it.increaseIndentation();
+          it.indent();
         }
       };
-      format.append(_regionForKeyword, _function);
-      final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
-        @Override
-        public void apply(final IHiddenRegionFormatter it) {
-          it.decreaseIndentation();
-        }
-      };
-      format.<XSynchronizedExpression>append(expr, _function_1);
+      format.<XSynchronizedExpression>surround(expr, _function);
     }
     boolean _or = false;
     XExpression _expression = expr.getExpression();
@@ -826,13 +823,13 @@ public class XbaseFormatter extends XtypeFormatter {
     }
     final boolean multiline = _or;
     XExpression _param = expr.getParam();
-    final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
+    final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
       @Override
       public void apply(final IHiddenRegionFormatter it) {
         it.noSpace();
       }
     };
-    format.<XExpression>surround(_param, _function_2);
+    format.<XExpression>surround(_param, _function_1);
     boolean _or_1 = false;
     XExpression _expression_2 = expr.getExpression();
     if ((_expression_2 instanceof XBlockExpression)) {
@@ -841,11 +838,11 @@ public class XbaseFormatter extends XtypeFormatter {
       _or_1 = multiline;
     }
     if (_or_1) {
-      ISemanticRegion _regionForKeyword_1 = this.regionAccess.regionForKeyword(expr, "synchronized");
-      format.append(_regionForKeyword_1, XbaseFormatterPreferenceKeys.whitespaceBetweenKeywordAndParenthesisML);
+      ISemanticRegion _regionForKeyword = this.regionAccess.regionForKeyword(expr, "synchronized");
+      format.append(_regionForKeyword, XbaseFormatterPreferenceKeys.whitespaceBetweenKeywordAndParenthesisML);
     } else {
-      ISemanticRegion _regionForKeyword_2 = this.regionAccess.regionForKeyword(expr, "synchronized");
-      format.append(_regionForKeyword_2, XbaseFormatterPreferenceKeys.whitespaceBetweenKeywordAndParenthesisSL);
+      ISemanticRegion _regionForKeyword_1 = this.regionAccess.regionForKeyword(expr, "synchronized");
+      format.append(_regionForKeyword_1, XbaseFormatterPreferenceKeys.whitespaceBetweenKeywordAndParenthesisSL);
     }
     XExpression _expression_3 = expr.getExpression();
     if ((_expression_3 instanceof XBlockExpression)) {
@@ -854,30 +851,29 @@ public class XbaseFormatter extends XtypeFormatter {
     } else {
       if ((!multiline)) {
         XExpression _expression_5 = expr.getExpression();
-        final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
+        final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
             it.oneSpace();
           }
         };
-        format.<XExpression>prepend(_expression_5, _function_3);
+        format.<XExpression>prepend(_expression_5, _function_2);
       } else {
         XExpression _expression_6 = expr.getExpression();
-        final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {
+        final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
             it.newLine();
-            it.increaseIndentation();
           }
         };
-        XExpression _prepend = format.<XExpression>prepend(_expression_6, _function_4);
-        final Procedure1<IHiddenRegionFormatter> _function_5 = new Procedure1<IHiddenRegionFormatter>() {
+        XExpression _prepend = format.<XExpression>prepend(_expression_6, _function_3);
+        final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
-            it.decreaseIndentation();
+            it.indent();
           }
         };
-        format.<XExpression>append(_prepend, _function_5);
+        format.<XExpression>surround(_prepend, _function_4);
       }
     }
     XExpression _param_1 = expr.getParam();
@@ -889,21 +885,13 @@ public class XbaseFormatter extends XtypeFormatter {
   protected void _format(final XIfExpression expr, @Extension final IFormattableDocument format) {
     EObject _eContainer = expr.eContainer();
     if ((_eContainer instanceof XVariableDeclaration)) {
-      ISemanticRegion _regionForKeyword = this.regionAccess.regionForKeyword(expr, "if");
       final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
-          it.increaseIndentation();
+          it.indent();
         }
       };
-      format.append(_regionForKeyword, _function);
-      final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
-        @Override
-        public void apply(final IHiddenRegionFormatter it) {
-          it.decreaseIndentation();
-        }
-      };
-      format.<XIfExpression>append(expr, _function_1);
+      format.<XIfExpression>surround(expr, _function);
     }
     boolean _or = false;
     XExpression _then = expr.getThen();
@@ -917,13 +905,13 @@ public class XbaseFormatter extends XtypeFormatter {
     }
     final boolean multiline = _or;
     XExpression _if = expr.getIf();
-    final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
+    final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
       @Override
       public void apply(final IHiddenRegionFormatter it) {
         it.noSpace();
       }
     };
-    format.<XExpression>surround(_if, _function_2);
+    format.<XExpression>surround(_if, _function_1);
     boolean _or_1 = false;
     XExpression _then_1 = expr.getThen();
     if ((_then_1 instanceof XBlockExpression)) {
@@ -932,11 +920,11 @@ public class XbaseFormatter extends XtypeFormatter {
       _or_1 = multiline;
     }
     if (_or_1) {
-      ISemanticRegion _regionForKeyword_1 = this.regionAccess.regionForKeyword(expr, "if");
-      format.append(_regionForKeyword_1, XbaseFormatterPreferenceKeys.whitespaceBetweenKeywordAndParenthesisML);
+      ISemanticRegion _regionForKeyword = this.regionAccess.regionForKeyword(expr, "if");
+      format.append(_regionForKeyword, XbaseFormatterPreferenceKeys.whitespaceBetweenKeywordAndParenthesisML);
     } else {
-      ISemanticRegion _regionForKeyword_2 = this.regionAccess.regionForKeyword(expr, "if");
-      format.append(_regionForKeyword_2, XbaseFormatterPreferenceKeys.whitespaceBetweenKeywordAndParenthesisSL);
+      ISemanticRegion _regionForKeyword_1 = this.regionAccess.regionForKeyword(expr, "if");
+      format.append(_regionForKeyword_1, XbaseFormatterPreferenceKeys.whitespaceBetweenKeywordAndParenthesisSL);
     }
     XExpression _then_2 = expr.getThen();
     if ((_then_2 instanceof XBlockExpression)) {
@@ -951,35 +939,41 @@ public class XbaseFormatter extends XtypeFormatter {
     } else {
       if ((!multiline)) {
         XExpression _then_5 = expr.getThen();
-        final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
+        final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
             it.oneSpace();
           }
         };
-        format.<XExpression>prepend(_then_5, _function_3);
+        format.<XExpression>prepend(_then_5, _function_2);
         XExpression _else_2 = expr.getElse();
         boolean _notEquals_1 = (!Objects.equal(_else_2, null));
         if (_notEquals_1) {
           XExpression _then_6 = expr.getThen();
-          final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {
+          final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
             @Override
             public void apply(final IHiddenRegionFormatter it) {
               it.oneSpace();
             }
           };
-          format.<XExpression>append(_then_6, _function_4);
+          format.<XExpression>append(_then_6, _function_3);
         }
       } else {
         XExpression _then_7 = expr.getThen();
-        final Procedure1<IHiddenRegionFormatter> _function_5 = new Procedure1<IHiddenRegionFormatter>() {
+        final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
             it.newLine();
-            it.increaseIndentation();
           }
         };
-        format.<XExpression>prepend(_then_7, _function_5);
+        XExpression _prepend = format.<XExpression>prepend(_then_7, _function_4);
+        final Procedure1<IHiddenRegionFormatter> _function_5 = new Procedure1<IHiddenRegionFormatter>() {
+          @Override
+          public void apply(final IHiddenRegionFormatter it) {
+            it.indent();
+          }
+        };
+        format.<XExpression>surround(_prepend, _function_5);
         XExpression _else_3 = expr.getElse();
         boolean _notEquals_2 = (!Objects.equal(_else_3, null));
         if (_notEquals_2) {
@@ -988,19 +982,9 @@ public class XbaseFormatter extends XtypeFormatter {
             @Override
             public void apply(final IHiddenRegionFormatter it) {
               it.newLine();
-              it.decreaseIndentation();
             }
           };
           format.<XExpression>append(_then_8, _function_6);
-        } else {
-          XExpression _then_9 = expr.getThen();
-          final Procedure1<IHiddenRegionFormatter> _function_7 = new Procedure1<IHiddenRegionFormatter>() {
-            @Override
-            public void apply(final IHiddenRegionFormatter it) {
-              it.decreaseIndentation();
-            }
-          };
-          format.<XExpression>append(_then_9, _function_7);
         }
       }
     }
@@ -1018,42 +1002,40 @@ public class XbaseFormatter extends XtypeFormatter {
       }
       if (_or_2) {
         XExpression _else_7 = expr.getElse();
-        final Procedure1<IHiddenRegionFormatter> _function_8 = new Procedure1<IHiddenRegionFormatter>() {
+        final Procedure1<IHiddenRegionFormatter> _function_7 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
             it.oneSpace();
           }
         };
-        format.<XExpression>prepend(_else_7, _function_8);
+        format.<XExpression>prepend(_else_7, _function_7);
       } else {
         XExpression _else_8 = expr.getElse();
-        final Procedure1<IHiddenRegionFormatter> _function_9 = new Procedure1<IHiddenRegionFormatter>() {
+        final Procedure1<IHiddenRegionFormatter> _function_8 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
             it.newLine();
-            it.increaseIndentation();
           }
         };
-        format.<XExpression>prepend(_else_8, _function_9);
-        XExpression _else_9 = expr.getElse();
-        final Procedure1<IHiddenRegionFormatter> _function_10 = new Procedure1<IHiddenRegionFormatter>() {
+        XExpression _prepend_1 = format.<XExpression>prepend(_else_8, _function_8);
+        final Procedure1<IHiddenRegionFormatter> _function_9 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
-            it.decreaseIndentation();
+            it.indent();
           }
         };
-        format.<XExpression>append(_else_9, _function_10);
+        format.<XExpression>surround(_prepend_1, _function_9);
       }
     }
     XExpression _if_1 = expr.getIf();
     this.format(_if_1, format);
-    XExpression _then_10 = expr.getThen();
-    this.format(_then_10, format);
-    XExpression _else_10 = expr.getElse();
-    boolean _notEquals_3 = (!Objects.equal(_else_10, null));
+    XExpression _then_9 = expr.getThen();
+    this.format(_then_9, format);
+    XExpression _else_9 = expr.getElse();
+    boolean _notEquals_3 = (!Objects.equal(_else_9, null));
     if (_notEquals_3) {
-      XExpression _else_11 = expr.getElse();
-      this.format(_else_11, format);
+      XExpression _else_10 = expr.getElse();
+      this.format(_else_10, format);
     }
   }
   
@@ -1106,23 +1088,21 @@ public class XbaseFormatter extends XtypeFormatter {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
           it.newLine();
-          it.increaseIndentation();
         }
       };
-      format.<XExpression>prepend(_eachExpression_2, _function_5);
-      XExpression _eachExpression_3 = expr.getEachExpression();
+      XExpression _prepend_2 = format.<XExpression>prepend(_eachExpression_2, _function_5);
       final Procedure1<IHiddenRegionFormatter> _function_6 = new Procedure1<IHiddenRegionFormatter>() {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
-          it.decreaseIndentation();
+          it.indent();
         }
       };
-      format.<XExpression>append(_eachExpression_3, _function_6);
+      format.<XExpression>surround(_prepend_2, _function_6);
     }
     XExpression _forExpression_1 = expr.getForExpression();
     this.format(_forExpression_1, format);
-    XExpression _eachExpression_4 = expr.getEachExpression();
-    this.format(_eachExpression_4, format);
+    XExpression _eachExpression_3 = expr.getEachExpression();
+    this.format(_eachExpression_3, format);
   }
   
   protected void _format(final XBasicForLoopExpression expr, @Extension final IFormattableDocument format) {
@@ -1238,21 +1218,19 @@ public class XbaseFormatter extends XtypeFormatter {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
           it.newLine();
-          it.increaseIndentation();
         }
       };
-      format.<XExpression>prepend(_eachExpression_2, _function_9);
-      XExpression _eachExpression_3 = expr.getEachExpression();
+      XExpression _prepend = format.<XExpression>prepend(_eachExpression_2, _function_9);
       final Procedure1<IHiddenRegionFormatter> _function_10 = new Procedure1<IHiddenRegionFormatter>() {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
-          it.decreaseIndentation();
+          it.indent();
         }
       };
-      format.<XExpression>append(_eachExpression_3, _function_10);
+      format.<XExpression>surround(_prepend, _function_10);
     }
-    XExpression _eachExpression_4 = expr.getEachExpression();
-    this.format(_eachExpression_4, format);
+    XExpression _eachExpression_3 = expr.getEachExpression();
+    this.format(_eachExpression_3, format);
   }
   
   protected void _format(final XWhileExpression expr, @Extension final IFormattableDocument format) {
@@ -1283,23 +1261,21 @@ public class XbaseFormatter extends XtypeFormatter {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
           it.newLine();
-          it.increaseIndentation();
         }
       };
-      format.<XExpression>prepend(_body_2, _function_2);
-      XExpression _body_3 = expr.getBody();
+      XExpression _prepend_1 = format.<XExpression>prepend(_body_2, _function_2);
       final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
-          it.decreaseIndentation();
+          it.indent();
         }
       };
-      format.<XExpression>append(_body_3, _function_3);
+      format.<XExpression>surround(_prepend_1, _function_3);
     }
     XExpression _predicate_1 = expr.getPredicate();
     this.format(_predicate_1, format);
-    XExpression _body_4 = expr.getBody();
-    this.format(_body_4, format);
+    XExpression _body_3 = expr.getBody();
+    this.format(_body_3, format);
   }
   
   protected void _format(final XDoWhileExpression expr, @Extension final IFormattableDocument format) {
@@ -1331,18 +1307,10 @@ public class XbaseFormatter extends XtypeFormatter {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
           it.newLine();
-          it.increaseIndentation();
+          it.indent();
         }
       };
-      XExpression _prepend_2 = format.<XExpression>prepend(_body_2, _function_2);
-      final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
-        @Override
-        public void apply(final IHiddenRegionFormatter it) {
-          it.newLine();
-          it.decreaseIndentation();
-        }
-      };
-      format.<XExpression>append(_prepend_2, _function_3);
+      format.<XExpression>surround(_body_2, _function_2);
     }
     XExpression _predicate_1 = expr.getPredicate();
     this.format(_predicate_1, format);
@@ -1481,18 +1449,10 @@ public class XbaseFormatter extends XtypeFormatter {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
           it.newLine();
-          it.increaseIndentation();
+          it.indent();
         }
       };
-      XExpression _prepend_1 = format.<XExpression>prepend(_expression_2, _function);
-      final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
-        @Override
-        public void apply(final IHiddenRegionFormatter it) {
-          it.newLine();
-          it.decreaseIndentation();
-        }
-      };
-      format.<XExpression>append(_prepend_1, _function_1);
+      format.<XExpression>surround(_expression_2, _function);
     }
     XExpression _expression_3 = expr.getExpression();
     this.format(_expression_3, format);
@@ -1516,13 +1476,13 @@ public class XbaseFormatter extends XtypeFormatter {
           if ((_expression_4 instanceof XBlockExpression)) {
             format.<XCatchClause>append(cc, XbaseFormatterPreferenceKeys.bracesInNewLine);
           } else {
-            final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
+            final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
               @Override
               public void apply(final IHiddenRegionFormatter it) {
                 it.newLine();
               }
             };
-            format.<XCatchClause>append(cc, _function_2);
+            format.<XCatchClause>append(cc, _function_1);
           }
         }
       }
@@ -1536,21 +1496,20 @@ public class XbaseFormatter extends XtypeFormatter {
         format.<XExpression>prepend(_finallyExpression_2, XbaseFormatterPreferenceKeys.bracesInNewLine);
       } else {
         XExpression _finallyExpression_3 = expr.getFinallyExpression();
-        final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
+        final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
             it.newLine();
-            it.increaseIndentation();
           }
         };
-        XExpression _prepend_2 = format.<XExpression>prepend(_finallyExpression_3, _function_2);
-        final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
+        XExpression _prepend_1 = format.<XExpression>prepend(_finallyExpression_3, _function_1);
+        final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
-            it.decreaseIndentation();
+            it.indent();
           }
         };
-        format.<XExpression>append(_prepend_2, _function_3);
+        format.<XExpression>surround(_prepend_1, _function_2);
       }
       XExpression _finallyExpression_4 = expr.getFinallyExpression();
       this.format(_finallyExpression_4, format);
@@ -1585,23 +1544,21 @@ public class XbaseFormatter extends XtypeFormatter {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
           it.newLine();
-          it.increaseIndentation();
         }
       };
-      format.<XExpression>prepend(_expression_2, _function_2);
-      XExpression _expression_3 = expr.getExpression();
+      XExpression _prepend_1 = format.<XExpression>prepend(_expression_2, _function_2);
       final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
-          it.decreaseIndentation();
+          it.indent();
         }
       };
-      format.<XExpression>append(_expression_3, _function_3);
+      format.<XExpression>surround(_prepend_1, _function_3);
     }
     JvmFormalParameter _declaredParam_1 = expr.getDeclaredParam();
     this.format(_declaredParam_1, format);
-    XExpression _expression_4 = expr.getExpression();
-    this.format(_expression_4, format);
+    XExpression _expression_3 = expr.getExpression();
+    this.format(_expression_3, format);
   }
   
   protected void _format(final JvmFormalParameter expr, @Extension final IFormattableDocument format) {
@@ -1786,10 +1743,10 @@ public class XbaseFormatter extends XtypeFormatter {
         final Procedure1<IHiddenRegionFormatter> _function_11 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
-            it.increaseIndentation();
+            it.indent();
           }
         };
-        format.append(open, _function_11);
+        format.<ISemanticRegion, ISemanticRegion>interior(open, close, _function_11);
         EList<XCasePart> _cases_5 = expr.getCases();
         for (final XCasePart c_1 : _cases_5) {
           {
@@ -1846,7 +1803,6 @@ public class XbaseFormatter extends XtypeFormatter {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
             it.newLine();
-            it.decreaseIndentation();
           }
         };
         format.prepend(close, _function_15);
@@ -1874,238 +1830,173 @@ public class XbaseFormatter extends XtypeFormatter {
           final Procedure1<IHiddenRegionFormatter> _function_17 = new Procedure1<IHiddenRegionFormatter>() {
             @Override
             public void apply(final IHiddenRegionFormatter it) {
-              it.increaseIndentation();
+              it.indent();
             }
           };
-          format.append(open, _function_17);
+          format.<ISemanticRegion, ISemanticRegion>interior(open, close, _function_17);
         }
         EList<XCasePart> _cases_7 = expr.getCases();
         for (final XCasePart c_2 : _cases_7) {
           XExpression _then_2 = c_2.getThen();
           if ((_then_2 instanceof XBlockExpression)) {
             XExpression _then_3 = c_2.getThen();
-            format.<XExpression>prepend(_then_3, XbaseFormatterPreferenceKeys.bracesInNewLine);
-            boolean _or_2 = false;
-            XExpression _default_7 = expr.getDefault();
-            boolean _notEquals_4 = (!Objects.equal(_default_7, null));
-            if (_notEquals_4) {
-              _or_2 = true;
-            } else {
-              EList<XCasePart> _cases_8 = expr.getCases();
-              XCasePart _last = IterableExtensions.<XCasePart>last(_cases_8);
-              boolean _notEquals_5 = (!Objects.equal(c_2, _last));
-              _or_2 = _notEquals_5;
-            }
-            if (_or_2) {
-              XExpression _then_4 = c_2.getThen();
-              final Procedure1<IHiddenRegionFormatter> _function_18 = new Procedure1<IHiddenRegionFormatter>() {
-                @Override
-                public void apply(final IHiddenRegionFormatter it) {
-                  it.newLine();
-                }
-              };
-              format.<XExpression>append(_then_4, _function_18);
-            } else {
-              XExpression _then_5 = c_2.getThen();
-              final Procedure1<IHiddenRegionFormatter> _function_19 = new Procedure1<IHiddenRegionFormatter>() {
-                @Override
-                public void apply(final IHiddenRegionFormatter it) {
-                  it.newLine();
-                  it.decreaseIndentation();
-                }
-              };
-              format.<XExpression>append(_then_5, _function_19);
-            }
+            XExpression _prepend_2 = format.<XExpression>prepend(_then_3, XbaseFormatterPreferenceKeys.bracesInNewLine);
+            final Procedure1<IHiddenRegionFormatter> _function_18 = new Procedure1<IHiddenRegionFormatter>() {
+              @Override
+              public void apply(final IHiddenRegionFormatter it) {
+                it.newLine();
+              }
+            };
+            format.<XExpression>append(_prepend_2, _function_18);
           } else {
             boolean _isFallThrough = c_2.isFallThrough();
             if (_isFallThrough) {
               ISemanticRegion _regionForFeature = this.regionAccess.regionForFeature(c_2, XbasePackage.Literals.XCASE_PART__FALL_THROUGH);
-              final Procedure1<IHiddenRegionFormatter> _function_20 = new Procedure1<IHiddenRegionFormatter>() {
+              final Procedure1<IHiddenRegionFormatter> _function_19 = new Procedure1<IHiddenRegionFormatter>() {
                 @Override
                 public void apply(final IHiddenRegionFormatter it) {
                   it.noSpace();
                 }
               };
-              ISemanticRegion _prepend_2 = format.prepend(_regionForFeature, _function_20);
+              ISemanticRegion _prepend_3 = format.prepend(_regionForFeature, _function_19);
+              final Procedure1<IHiddenRegionFormatter> _function_20 = new Procedure1<IHiddenRegionFormatter>() {
+                @Override
+                public void apply(final IHiddenRegionFormatter it) {
+                  it.newLine();
+                }
+              };
+              format.append(_prepend_3, _function_20);
+            } else {
+              XExpression _then_4 = c_2.getThen();
               final Procedure1<IHiddenRegionFormatter> _function_21 = new Procedure1<IHiddenRegionFormatter>() {
                 @Override
                 public void apply(final IHiddenRegionFormatter it) {
                   it.newLine();
+                  it.indent();
                 }
               };
-              format.append(_prepend_2, _function_21);
-            } else {
-              XExpression _then_6 = c_2.getThen();
-              final Procedure1<IHiddenRegionFormatter> _function_22 = new Procedure1<IHiddenRegionFormatter>() {
-                @Override
-                public void apply(final IHiddenRegionFormatter it) {
-                  it.newLine();
-                  it.increaseIndentation();
-                }
-              };
-              format.<XExpression>prepend(_then_6, _function_22);
-              boolean _or_3 = false;
-              XExpression _default_8 = expr.getDefault();
-              boolean _notEquals_6 = (!Objects.equal(_default_8, null));
-              if (_notEquals_6) {
-                _or_3 = true;
-              } else {
-                EList<XCasePart> _cases_9 = expr.getCases();
-                XCasePart _last_1 = IterableExtensions.<XCasePart>last(_cases_9);
-                boolean _notEquals_7 = (!Objects.equal(c_2, _last_1));
-                _or_3 = _notEquals_7;
-              }
-              if (_or_3) {
-                XExpression _then_7 = c_2.getThen();
-                final Procedure1<IHiddenRegionFormatter> _function_23 = new Procedure1<IHiddenRegionFormatter>() {
-                  @Override
-                  public void apply(final IHiddenRegionFormatter it) {
-                    it.newLine();
-                    it.decreaseIndentation();
-                  }
-                };
-                format.<XExpression>append(_then_7, _function_23);
-              } else {
-                XExpression _then_8 = c_2.getThen();
-                final Procedure1<IHiddenRegionFormatter> _function_24 = new Procedure1<IHiddenRegionFormatter>() {
-                  @Override
-                  public void apply(final IHiddenRegionFormatter it) {
-                    it.newLine();
-                    it.setDecreaseIndentation(2);
-                  }
-                };
-                format.<XExpression>append(_then_8, _function_24);
-              }
+              format.<XExpression>surround(_then_4, _function_21);
             }
           }
         }
-        XExpression _default_9 = expr.getDefault();
-        boolean _notEquals_8 = (!Objects.equal(_default_9, null));
-        if (_notEquals_8) {
+        XExpression _default_7 = expr.getDefault();
+        boolean _notEquals_4 = (!Objects.equal(_default_7, null));
+        if (_notEquals_4) {
           ISemanticRegion _regionForKeyword_3 = this.regionAccess.regionForKeyword(expr, "default");
-          final Procedure1<IHiddenRegionFormatter> _function_25 = new Procedure1<IHiddenRegionFormatter>() {
+          final Procedure1<IHiddenRegionFormatter> _function_22 = new Procedure1<IHiddenRegionFormatter>() {
             @Override
             public void apply(final IHiddenRegionFormatter it) {
               it.noSpace();
             }
           };
-          format.append(_regionForKeyword_3, _function_25);
-          XExpression _default_10 = expr.getDefault();
-          if ((_default_10 instanceof XBlockExpression)) {
-            XExpression _default_11 = expr.getDefault();
-            XExpression _prepend_3 = format.<XExpression>prepend(_default_11, XbaseFormatterPreferenceKeys.bracesInNewLine);
-            final Procedure1<IHiddenRegionFormatter> _function_26 = new Procedure1<IHiddenRegionFormatter>() {
+          format.append(_regionForKeyword_3, _function_22);
+          XExpression _default_8 = expr.getDefault();
+          if ((_default_8 instanceof XBlockExpression)) {
+            XExpression _default_9 = expr.getDefault();
+            XExpression _prepend_4 = format.<XExpression>prepend(_default_9, XbaseFormatterPreferenceKeys.bracesInNewLine);
+            final Procedure1<IHiddenRegionFormatter> _function_23 = new Procedure1<IHiddenRegionFormatter>() {
               @Override
               public void apply(final IHiddenRegionFormatter it) {
                 it.newLine();
-                it.decreaseIndentation();
               }
             };
-            format.<XExpression>append(_prepend_3, _function_26);
+            format.<XExpression>append(_prepend_4, _function_23);
           } else {
-            XExpression _default_12 = expr.getDefault();
-            final Procedure1<IHiddenRegionFormatter> _function_27 = new Procedure1<IHiddenRegionFormatter>() {
+            XExpression _default_10 = expr.getDefault();
+            final Procedure1<IHiddenRegionFormatter> _function_24 = new Procedure1<IHiddenRegionFormatter>() {
               @Override
               public void apply(final IHiddenRegionFormatter it) {
                 it.newLine();
-                it.increaseIndentation();
+                it.indent();
               }
             };
-            XExpression _prepend_4 = format.<XExpression>prepend(_default_12, _function_27);
-            final Procedure1<IHiddenRegionFormatter> _function_28 = new Procedure1<IHiddenRegionFormatter>() {
-              @Override
-              public void apply(final IHiddenRegionFormatter it) {
-                it.newLine();
-                it.setDecreaseIndentation(2);
-              }
-            };
-            format.<XExpression>append(_prepend_4, _function_28);
+            format.<XExpression>surround(_default_10, _function_24);
           }
         }
       }
     }
-    EList<XCasePart> _cases_10 = expr.getCases();
-    for (final XCasePart c_3 : _cases_10) {
+    EList<XCasePart> _cases_8 = expr.getCases();
+    for (final XCasePart c_3 : _cases_8) {
       {
         boolean _and_4 = false;
         JvmTypeReference _typeGuard = c_3.getTypeGuard();
-        boolean _notEquals_9 = (!Objects.equal(_typeGuard, null));
-        if (!_notEquals_9) {
+        boolean _notEquals_5 = (!Objects.equal(_typeGuard, null));
+        if (!_notEquals_5) {
           _and_4 = false;
         } else {
           XExpression _case = c_3.getCase();
-          boolean _notEquals_10 = (!Objects.equal(_case, null));
-          _and_4 = _notEquals_10;
+          boolean _notEquals_6 = (!Objects.equal(_case, null));
+          _and_4 = _notEquals_6;
         }
         if (_and_4) {
           JvmTypeReference _typeGuard_1 = c_3.getTypeGuard();
-          final Procedure1<IHiddenRegionFormatter> _function_29 = new Procedure1<IHiddenRegionFormatter>() {
+          final Procedure1<IHiddenRegionFormatter> _function_25 = new Procedure1<IHiddenRegionFormatter>() {
             @Override
             public void apply(final IHiddenRegionFormatter it) {
               it.oneSpace();
             }
           };
-          format.<JvmTypeReference>append(_typeGuard_1, _function_29);
+          format.<JvmTypeReference>append(_typeGuard_1, _function_25);
           XExpression _case_1 = c_3.getCase();
-          final Procedure1<IHiddenRegionFormatter> _function_30 = new Procedure1<IHiddenRegionFormatter>() {
+          final Procedure1<IHiddenRegionFormatter> _function_26 = new Procedure1<IHiddenRegionFormatter>() {
             @Override
             public void apply(final IHiddenRegionFormatter it) {
               it.oneSpace();
             }
           };
-          XExpression _prepend_5 = format.<XExpression>prepend(_case_1, _function_30);
-          final Procedure1<IHiddenRegionFormatter> _function_31 = new Procedure1<IHiddenRegionFormatter>() {
+          XExpression _prepend_5 = format.<XExpression>prepend(_case_1, _function_26);
+          final Procedure1<IHiddenRegionFormatter> _function_27 = new Procedure1<IHiddenRegionFormatter>() {
             @Override
             public void apply(final IHiddenRegionFormatter it) {
               it.noSpace();
             }
           };
-          format.<XExpression>append(_prepend_5, _function_31);
+          format.<XExpression>append(_prepend_5, _function_27);
         } else {
           JvmTypeReference _typeGuard_2 = c_3.getTypeGuard();
-          boolean _notEquals_11 = (!Objects.equal(_typeGuard_2, null));
-          if (_notEquals_11) {
+          boolean _notEquals_7 = (!Objects.equal(_typeGuard_2, null));
+          if (_notEquals_7) {
             JvmTypeReference _typeGuard_3 = c_3.getTypeGuard();
-            final Procedure1<IHiddenRegionFormatter> _function_32 = new Procedure1<IHiddenRegionFormatter>() {
+            final Procedure1<IHiddenRegionFormatter> _function_28 = new Procedure1<IHiddenRegionFormatter>() {
               @Override
               public void apply(final IHiddenRegionFormatter it) {
                 it.noSpace();
               }
             };
-            format.<JvmTypeReference>append(_typeGuard_3, _function_32);
+            format.<JvmTypeReference>append(_typeGuard_3, _function_28);
           } else {
             XExpression _case_2 = c_3.getCase();
-            boolean _notEquals_12 = (!Objects.equal(_case_2, null));
-            if (_notEquals_12) {
+            boolean _notEquals_8 = (!Objects.equal(_case_2, null));
+            if (_notEquals_8) {
               XExpression _case_3 = c_3.getCase();
-              final Procedure1<IHiddenRegionFormatter> _function_33 = new Procedure1<IHiddenRegionFormatter>() {
+              final Procedure1<IHiddenRegionFormatter> _function_29 = new Procedure1<IHiddenRegionFormatter>() {
                 @Override
                 public void apply(final IHiddenRegionFormatter it) {
                   it.oneSpace();
                 }
               };
-              XExpression _prepend_6 = format.<XExpression>prepend(_case_3, _function_33);
-              final Procedure1<IHiddenRegionFormatter> _function_34 = new Procedure1<IHiddenRegionFormatter>() {
+              XExpression _prepend_6 = format.<XExpression>prepend(_case_3, _function_29);
+              final Procedure1<IHiddenRegionFormatter> _function_30 = new Procedure1<IHiddenRegionFormatter>() {
                 @Override
                 public void apply(final IHiddenRegionFormatter it) {
                   it.noSpace();
                 }
               };
-              format.<XExpression>append(_prepend_6, _function_34);
+              format.<XExpression>append(_prepend_6, _function_30);
             }
           }
         }
         XExpression _case_4 = c_3.getCase();
         this.format(_case_4, format);
-        XExpression _then_9 = c_3.getThen();
-        this.format(_then_9, format);
+        XExpression _then_5 = c_3.getThen();
+        this.format(_then_5, format);
       }
     }
-    XExpression _default_13 = expr.getDefault();
-    boolean _notEquals_9 = (!Objects.equal(_default_13, null));
-    if (_notEquals_9) {
-      XExpression _default_14 = expr.getDefault();
-      this.format(_default_14, format);
+    XExpression _default_11 = expr.getDefault();
+    boolean _notEquals_5 = (!Objects.equal(_default_11, null));
+    if (_notEquals_5) {
+      XExpression _default_12 = expr.getDefault();
+      this.format(_default_12, format);
     }
   }
   
@@ -2210,8 +2101,7 @@ public class XbaseFormatter extends XtypeFormatter {
             @Override
             public void apply(final IHiddenRegionFormatter it) {
               it.newLine();
-              it.increaseIndentation();
-              it.decreaseIndentation();
+              it.indent();
             }
           };
           format.append(open, _function);
@@ -2341,64 +2231,43 @@ public class XbaseFormatter extends XtypeFormatter {
   }
   
   protected void formatExpressionsMultiline(final Collection<? extends XExpression> expressions, final ISemanticRegion open, final ISemanticRegion close, @Extension final IFormattableDocument format) {
+    final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
+      @Override
+      public void apply(final IHiddenRegionFormatter it) {
+        it.indent();
+      }
+    };
+    format.<ISemanticRegion, ISemanticRegion>interior(open, close, _function);
     boolean _isEmpty = expressions.isEmpty();
     if (_isEmpty) {
-      IHiddenRegion _nextHiddenRegion = open.getNextHiddenRegion();
-      boolean _containsComment = _nextHiddenRegion.containsComment();
-      if (_containsComment) {
-        final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.newLine();
-            it.increaseIndentation();
-            it.decreaseIndentation();
-          }
-        };
-        format.append(open, _function);
-      } else {
-        final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.newLine();
-          }
-        };
-        format.append(open, _function_1);
-      }
-    } else {
-      ISemanticRegion _append = format.append(open, XbaseFormatterPreferenceKeys.blankLinesAroundExpression);
-      final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
+      final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
         @Override
         public void apply(final IHiddenRegionFormatter it) {
-          it.increaseIndentation();
+          it.newLine();
         }
       };
-      format.append(_append, _function_2);
+      format.append(open, _function_1);
+    } else {
+      format.append(open, XbaseFormatterPreferenceKeys.blankLinesAroundExpression);
       for (final XExpression child : expressions) {
         {
           this.format(child, format);
           final ISemanticRegion sem = this.regionAccess.immediatelyFollowingKeyword(child, ";");
           boolean _notEquals = (!Objects.equal(sem, null));
           if (_notEquals) {
-            final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
+            final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
               @Override
               public void apply(final IHiddenRegionFormatter it) {
                 it.noSpace();
               }
             };
-            ISemanticRegion _prepend = format.prepend(sem, _function_3);
+            ISemanticRegion _prepend = format.prepend(sem, _function_2);
             format.append(_prepend, XbaseFormatterPreferenceKeys.blankLinesAroundExpression);
           } else {
             format.<XExpression>append(child, XbaseFormatterPreferenceKeys.blankLinesAroundExpression);
           }
         }
       }
-      final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
-        @Override
-        public void apply(final IHiddenRegionFormatter it) {
-          it.decreaseIndentation();
-        }
-      };
-      format.prepend(close, _function_3);
     }
   }
   

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/AbstractFormatter2.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/AbstractFormatter2.java
@@ -15,11 +15,13 @@ import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.RuleCall;
 import org.eclipse.xtext.formatting2.internal.CommentReplacer;
+import org.eclipse.xtext.formatting2.internal.DoubleHiddenRegionFormatter;
 import org.eclipse.xtext.formatting2.internal.HiddenRegionFormatting;
 import org.eclipse.xtext.formatting2.internal.HiddenRegionFormattingMerger;
 import org.eclipse.xtext.formatting2.internal.HiddenRegionReplacer;
 import org.eclipse.xtext.formatting2.internal.MultilineCommentReplacer;
 import org.eclipse.xtext.formatting2.internal.RootDocument;
+import org.eclipse.xtext.formatting2.internal.SingleHiddenRegionFormatter;
 import org.eclipse.xtext.formatting2.internal.SinglelineCodeCommentReplacer;
 import org.eclipse.xtext.formatting2.internal.SinglelineDocCommentReplacer;
 import org.eclipse.xtext.formatting2.internal.SubDocument;
@@ -174,8 +176,8 @@ public abstract class AbstractFormatter2 implements IFormatter2 {
 	}
 
 	/**
-	 * For {@link XtextResource resources}, assume we want to format the first EObject from the contents list only. Because
-	 * that's where the parser puts the semantic model.
+	 * For {@link XtextResource resources}, assume we want to format the first EObject from the contents list only.
+	 * Because that's where the parser puts the semantic model.
 	 */
 	protected void _format(XtextResource resource, IFormattableDocument document) {
 		List<EObject> contents = resource.getContents();
@@ -210,6 +212,14 @@ public abstract class AbstractFormatter2 implements IFormatter2 {
 		return new HiddenRegionFormatting(this);
 	}
 
+	public IHiddenRegionFormatter createHiddenRegionFormatter(IHiddenRegionFormatting formatting) {
+		return new SingleHiddenRegionFormatter(formatting);
+	}
+
+	public IHiddenRegionFormatter createHiddenRegionFormatter(IHiddenRegionFormatting f1, IHiddenRegionFormatting f2) {
+		return new DoubleHiddenRegionFormatter(f1, f2);
+	}
+
 	public IMerger<IHiddenRegionFormatting> createHiddenRegionFormattingMerger() {
 		return new HiddenRegionFormattingMerger(this);
 	}
@@ -233,7 +243,7 @@ public abstract class AbstractFormatter2 implements IFormatter2 {
 	public ITextReplacer createWhitespaceReplacer(ITextSegment hiddens, IHiddenRegionFormatting formatting) {
 		return new WhitespaceReplacer(hiddens, formatting);
 	}
-	
+
 	public IFormattableDocument createFormattableRootDocument() {
 		return new RootDocument(this);
 	}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/IAutowrapFormatter.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/IAutowrapFormatter.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.xtext.formatting2;
 
+import org.eclipse.xtext.formatting2.regionaccess.ITextSegment;
+
 /**
  * A strategy for formatting that is to be applied on auto wrapping.
  * 
@@ -14,9 +16,9 @@ package org.eclipse.xtext.formatting2;
  * 
  * @see IHiddenRegionFormatter#setOnAutowrap(IAutowrapFormatter)
  */
-public interface IAutowrapFormatter { // TODO: add region
+public interface IAutowrapFormatter {
 	/**
 	 * Called if the region is supposed to be wrapped.
 	 */
-	void format(IHiddenRegionFormatter wrapped, IFormattableDocument document);
+	void format(ITextSegment region, IHiddenRegionFormatting wrapped, IFormattableDocument document);
 }

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/IFormattableDocument.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/IFormattableDocument.java
@@ -15,6 +15,7 @@ import org.eclipse.xtext.formatting2.regionaccess.ISemanticRegion;
 import org.eclipse.xtext.formatting2.regionaccess.ITextRegionAccess;
 import org.eclipse.xtext.formatting2.regionaccess.ITextReplacement;
 import org.eclipse.xtext.formatting2.regionaccess.ITextSegment;
+import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 import com.google.common.base.Predicate;
@@ -152,4 +153,12 @@ public interface IFormattableDocument {
 	 */
 	IHiddenRegion set(IHiddenRegion hiddenRegion, Procedure1<? super IHiddenRegionFormatter> init);
 
+	Pair<IHiddenRegion, IHiddenRegion> set(IHiddenRegion first, IHiddenRegion second,
+			Procedure1<? super IHiddenRegionFormatter> init);
+
+	<T1 extends ISemanticRegion, T2 extends ISemanticRegion> // 
+	Pair<T1, T2> interior(T1 first, T2 second, Procedure1<? super IHiddenRegionFormatter> init);
+
+	<T1 extends ISemanticRegion, T2 extends ISemanticRegion> // 
+	Pair<T1, T2> interior(Pair<T1, T2> pair, Procedure1<? super IHiddenRegionFormatter> init);
 }

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/IHiddenRegionFormatter.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/IHiddenRegionFormatter.java
@@ -8,8 +8,7 @@
 package org.eclipse.xtext.formatting2;
 
 /**
- * An {@link IHiddenRegionFormatter} is used to build a formatting
- * setting for a hidden region.
+ * An {@link IHiddenRegionFormatter} is used to build a formatting setting for a hidden region.
  * 
  * @see IHiddenRegionFormatting
  * @noimplement This interface is not intended to be implemented by clients.
@@ -23,28 +22,22 @@ public interface IHiddenRegionFormatter {
 	final int NORMAL_PRIORITY = 0;
 
 	/**
-	 * Allows to obtain the configured formatting setting.
-	 */
-	IHiddenRegionFormatting asBean();
-
-	/**
 	 * Configure autowrap. Same as {@link #autowrap(int) autowrap(0)}.
 	 */
 	void autowrap();
 
 	/**
-	 * Configure autowrap. The triggerLength allows to shift the wrapping point
-	 * beyond its actual position in the file. If a line has multiple wrapping points
-	 * it will scan backwards for the first autowrapped region. The triggerLength
+	 * Configure autowrap. The triggerLength allows to shift the wrapping point beyond its actual position in the file.
+	 * If a line has multiple wrapping points it will scan backwards for the first autowrapped region. The triggerLength
 	 * moves this region logically such it will be found earlier.
 	 */
 	void autowrap(int triggerLength);
-	
+
 	/**
 	 * Suppresses auto wrap in this hidden region.
 	 */
 	void noAutowrap();
-	
+
 	/**
 	 * Callback if autowrapping was applied.
 	 */
@@ -57,6 +50,7 @@ public interface IHiddenRegionFormatter {
 
 	/**
 	 * When merging, treat this configuration with a high priority.
+	 * 
 	 * @see #lowPriority()
 	 * @see #HIGH_PRIORITY
 	 */
@@ -64,78 +58,52 @@ public interface IHiddenRegionFormatter {
 
 	/**
 	 * When merging, treat this configuration with a low priority.
+	 * 
 	 * @see #highPriority()
 	 * @see #LOW_PRIORITY
 	 */
 	void lowPriority();
-	
-	/**
-	 * Sets the priority of this formatting configuration. Used when two
-	 * configurations should be merged.
-	 * The priority of this formatter; the default value is {@link #NORMAL_PRIORITY}.
-	 */
-	void setPriority(int priority);
-	
-	/**
-	 * Decrease the indentation by one level.
-	 * Subsequent calls decrease the indentation further.
-	 * @see #setDecreaseIndentation(int)
-	 */
-	void decreaseIndentation();
-	
-	/**
-	 * Increase the indentation by one level.
-	 */
-	void increaseIndentation();
-	
-	/**
-	 * Decreases the indentation by the given number of levels.
-	 * @see #setIncreaseIndentation(int)
-	 */
-	void setDecreaseIndentation(int indentation);
 
 	/**
-	 * Increases the indentation by the given number of levels.
+	 * Sets the priority of this formatting configuration. Used when two configurations should be merged. The priority
+	 * of this formatter; the default value is {@link #NORMAL_PRIORITY}.
 	 */
-	void setIncreaseIndentation(int indentation);
+	void setPriority(int priority);
 
 	/**
 	 * Resets the indentation level to zero.
 	 */
 	void noIndentation();
-	
+
+	void indent();
+
 	/**
-	 * Forces a line break in this hidden region.
-	 * Same as {@link #setNewLines(int) setNewLines(1)}.
+	 * Forces a line break in this hidden region. Same as {@link #setNewLines(int) setNewLines(1)}.
 	 */
 	void newLine();
-	
+
 	/**
-	 * Forces the number of newlines in this hidden region.
-	 * Same as {@link #setNewLines(int, int, int) setNewLines(nl, nl, nl)}
+	 * Forces the number of newlines in this hidden region. Same as {@link #setNewLines(int, int, int) setNewLines(nl,
+	 * nl, nl)}
 	 */
 	void setNewLines(int newLines);
 
 	/**
-	 * Configures the given new lines for this hidden region.
-	 * Keeps the current configuration if it is in the valid boundaries
-	 * of {@code minNewLines} and {@code maxNewLines}. Applies {@code defaultNewLines}
-	 * otherwise.
+	 * Configures the given new lines for this hidden region. Keeps the current configuration if it is in the valid
+	 * boundaries of {@code minNewLines} and {@code maxNewLines}. Applies {@code defaultNewLines} otherwise.
 	 */
 	void setNewLines(int minNewLines, int defaultNewLines, int maxNewLines);
 
 	/**
-	 * Format this hidden region with using no space (zero characters). 
-	 * Same as {@link #setSpace(String) setSpace("")}.
+	 * Format this hidden region with using no space (zero characters). Same as {@link #setSpace(String) setSpace("")}.
 	 */
 	void noSpace();
 
 	/**
-	 * One space is added at this hidden region.
-	 * Same as {@link #setSpace(String) setSpace(" ")}.
+	 * One space is added at this hidden region. Same as {@link #setSpace(String) setSpace(" ")}.
 	 */
 	void oneSpace();
-	
+
 	/**
 	 * The given space is used for this hidden region.
 	 */

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/IHiddenRegionFormatting.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/IHiddenRegionFormatting.java
@@ -30,8 +30,6 @@ public interface IHiddenRegionFormatting {
 
 	void mergeValuesFrom(IHiddenRegionFormatting other) throws ConflictingFormattingException;
 
-	IHiddenRegionFormatter asFormatter();
-
 	Integer getAutowrap();
 
 	Integer getIndentationDecrease();

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/AbstractHiddenRegionFormatter.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/AbstractHiddenRegionFormatter.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.formatting2.internal;
+
+import org.eclipse.xtext.formatting2.IHiddenRegionFormatter;
+
+/**
+ * @author Moritz Eysholdt - Initial contribution and API
+ * @since 2.9
+ */
+public abstract class AbstractHiddenRegionFormatter implements IHiddenRegionFormatter {
+
+	@Override
+	public void highPriority() {
+		setPriority(HIGH_PRIORITY);
+	}
+
+	@Override
+	public void lowPriority() {
+		setPriority(LOW_PRIORITY);
+	}
+
+	@Override
+	public void newLine() {
+		setNewLines(1);
+	}
+
+	@Override
+	public void noSpace() {
+		setSpace("");
+	}
+
+	@Override
+	public void oneSpace() {
+		setSpace(" ");
+
+	}
+
+	@Override
+	public void setNewLines(int newLines) {
+		setNewLines(newLines, newLines, newLines);
+	}
+}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/DoubleHiddenRegionFormatter.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/DoubleHiddenRegionFormatter.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.formatting2.internal;
+
+import org.eclipse.xtext.formatting2.FormatterRequest;
+import org.eclipse.xtext.formatting2.IAutowrapFormatter;
+import org.eclipse.xtext.formatting2.IHiddenRegionFormatting;
+
+/**
+ * @author Moritz Eysholdt - Initial contribution and API
+ * @since 2.9
+ */
+public class DoubleHiddenRegionFormatter extends AbstractHiddenRegionFormatter {
+
+	private final IHiddenRegionFormatting first;
+	private final IHiddenRegionFormatting second;
+
+	public DoubleHiddenRegionFormatter(IHiddenRegionFormatting first, IHiddenRegionFormatting second) {
+		super();
+		this.first = first;
+		this.second = second;
+	}
+
+	@Override
+	public void autowrap() {
+		Integer old1 = first.getAutowrap();
+		if (old1 == null || old1 < 0)
+			first.setAutowrap(0);
+		Integer old2 = second.getAutowrap();
+		if (old2 == null || old2 < 0)
+			second.setAutowrap(0);
+	}
+
+	@Override
+	public void autowrap(int triggerLength) {
+		first.setAutowrap(triggerLength);
+		second.setAutowrap(triggerLength);
+	}
+
+	@Override
+	public FormatterRequest getRequest() {
+		return first.getRequest();
+	}
+
+	@Override
+	public void indent() {
+		Integer inc = first.getIndentationIncrease();
+		Integer dec = second.getIndentationDecrease();
+		first.setIndentationIncrease(inc == null ? 1 : inc + 1);
+		second.setIndentationDecrease(dec == null ? 1 : dec + 1);
+	}
+
+	@Override
+	public void noAutowrap() {
+		first.setAutowrap(-1);
+		second.setAutowrap(-1);
+	}
+
+	@Override
+	public void noIndentation() {
+		first.setNoIndentation(true);
+		second.setNoIndentation(true);
+	}
+
+	@Override
+	public void setNewLines(int minNewLines, int defaultNewLines, int maxNewLines) {
+		first.setNewLinesMin(minNewLines);
+		first.setNewLinesDefault(defaultNewLines);
+		first.setNewLinesMax(maxNewLines);
+		second.setNewLinesMin(minNewLines);
+		second.setNewLinesDefault(defaultNewLines);
+		second.setNewLinesMax(maxNewLines);
+	}
+
+	@Override
+	public void setOnAutowrap(IAutowrapFormatter formatter) {
+		autowrap();
+		first.setOnAutowrap(formatter);
+		second.setOnAutowrap(formatter);
+	}
+
+	@Override
+	public void setPriority(int priority) {
+		first.setPriority(priority);
+		second.setPriority(priority);
+	}
+
+	@Override
+	public void setSpace(String space) {
+		first.setSpace(space);
+		second.setSpace(space);
+	}
+
+}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/HiddenRegionFormatting.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/HiddenRegionFormatting.java
@@ -15,9 +15,7 @@ import org.eclipse.xtext.formatting2.IHiddenRegionFormatter;
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatting;
 import org.eclipse.xtext.formatting2.debug.HiddenRegionFormattingToString;
 
-import com.google.common.base.Preconditions;
-
-public class HiddenRegionFormatting implements IHiddenRegionFormatter, IHiddenRegionFormatting {
+public class HiddenRegionFormatting implements IHiddenRegionFormatting {
 	private Integer autowrap = null;
 	private final AbstractFormatter2 formatter;
 	private Integer indentationDecrease = null;
@@ -33,32 +31,6 @@ public class HiddenRegionFormatting implements IHiddenRegionFormatter, IHiddenRe
 	public HiddenRegionFormatting(AbstractFormatter2 formatter) {
 		super();
 		this.formatter = formatter;
-	}
-
-	@Override
-	public IHiddenRegionFormatting asBean() {
-		return this;
-	}
-
-	@Override
-	public IHiddenRegionFormatter asFormatter() {
-		return this;
-	}
-
-	@Override
-	public void autowrap() {
-		if (this.autowrap == null || this.autowrap < 0)
-			this.autowrap = 0; // TODO: can newLineMax = 0 suppress autowrap?
-	}
-
-	@Override
-	public void autowrap(int triggerLength) {
-		autowrap = triggerLength;
-	}
-
-	@Override
-	public void decreaseIndentation() {
-		indentationDecrease = indentationDecrease == null ? 1 : indentationDecrease + 1;
 	}
 
 	@Override
@@ -120,21 +92,6 @@ public class HiddenRegionFormatting implements IHiddenRegionFormatter, IHiddenRe
 		return space;
 	}
 
-	@Override
-	public void highPriority() {
-		setPriority(IHiddenRegionFormatter.HIGH_PRIORITY);
-	}
-
-	@Override
-	public void increaseIndentation() {
-		indentationIncrease = indentationIncrease == null ? 1 : indentationIncrease + 1;
-	}
-
-	@Override
-	public void lowPriority() {
-		setPriority(IHiddenRegionFormatter.LOW_PRIORITY);
-	}
-
 	protected <T> T merge(T val1, T val2, int strategy, String propertyname) throws ConflictingFormattingException {
 		if (val1 != null && val2 != null) {
 			if (val1.equals(val2) || strategy < 0)
@@ -161,53 +118,18 @@ public class HiddenRegionFormatting implements IHiddenRegionFormatter, IHiddenRe
 		if (getIndentationIncrease() != null && other.getIndentationIncrease() != null)
 			setIndentationIncrease(getIndentationIncrease() + other.getIndentationIncrease());
 		else
-			setIndentationIncrease(getIndentationIncrease() != null ? getIndentationIncrease() : other
-					.getIndentationIncrease());
+			setIndentationIncrease(
+					getIndentationIncrease() != null ? getIndentationIncrease() : other.getIndentationIncrease());
 		if (getIndentationDecrease() != null && other.getIndentationDecrease() != null)
 			setIndentationDecrease(getIndentationDecrease() + other.getIndentationDecrease());
 		else
-			setIndentationDecrease(getIndentationDecrease() != null ? getIndentationDecrease() : other
-					.getIndentationDecrease());
-	}
-
-	@Override
-	public void newLine() {
-		setNewLines(1);
-	}
-
-	@Override
-	public void noAutowrap() {
-		this.autowrap = -1;
-	}
-
-	@Override
-	public void noIndentation() {
-		this.noIndentation = Boolean.TRUE;
-	}
-
-	@Override
-	public void noSpace() {
-		setSpace("");
-	}
-
-	@Override
-	public void oneSpace() {
-		setSpace(" ");
+			setIndentationDecrease(
+					getIndentationDecrease() != null ? getIndentationDecrease() : other.getIndentationDecrease());
 	}
 
 	@Override
 	public void setAutowrap(Integer value) {
 		this.autowrap = value;
-	}
-
-	@Override
-	public void setDecreaseIndentation(int indentation) {
-		this.indentationDecrease = indentation;
-	}
-
-	@Override
-	public void setIncreaseIndentation(int indentation) {
-		this.indentationIncrease = indentation;
 	}
 
 	@Override
@@ -218,21 +140,6 @@ public class HiddenRegionFormatting implements IHiddenRegionFormatter, IHiddenRe
 	@Override
 	public void setIndentationIncrease(Integer indentation) {
 		this.indentationIncrease = indentation;
-	}
-
-	@Override
-	public void setNewLines(int newLines) {
-		setNewLines(newLines, newLines, newLines);
-	}
-
-	@Override
-	public void setNewLines(int minNewLines, int defaultNewLines, int maxNewLines) {
-		Preconditions.checkArgument(minNewLines >= 0);
-		Preconditions.checkArgument(defaultNewLines >= 0);
-		Preconditions.checkArgument(maxNewLines >= 0);
-		this.newLineMin = minNewLines;
-		this.newLineDefault = defaultNewLines;
-		this.newLineMax = maxNewLines;
 	}
 
 	@Override
@@ -257,7 +164,6 @@ public class HiddenRegionFormatting implements IHiddenRegionFormatter, IHiddenRe
 
 	@Override
 	public void setOnAutowrap(IAutowrapFormatter formatter) {
-		autowrap();
 		this.onAutowrap = formatter;
 	}
 

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/SingleHiddenRegionFormatter.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/SingleHiddenRegionFormatter.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.formatting2.internal;
+
+import org.eclipse.xtext.formatting2.FormatterRequest;
+import org.eclipse.xtext.formatting2.IAutowrapFormatter;
+import org.eclipse.xtext.formatting2.IHiddenRegionFormatting;
+
+/**
+ * @author Moritz Eysholdt - Initial contribution and API
+ * @since 2.9
+ */
+public class SingleHiddenRegionFormatter extends AbstractHiddenRegionFormatter {
+
+	private final IHiddenRegionFormatting formatting;
+
+	public SingleHiddenRegionFormatter(IHiddenRegionFormatting formatting) {
+		super();
+		this.formatting = formatting;
+	}
+
+	@Override
+	public void autowrap() {
+		Integer old = formatting.getAutowrap();
+		if (old == null || old < 0)
+			formatting.setAutowrap(0);
+	}
+
+	@Override
+	public void autowrap(int triggerLength) {
+		formatting.setAutowrap(triggerLength);
+	}
+
+	@Override
+	public FormatterRequest getRequest() {
+		return formatting.getRequest();
+	}
+
+	@Override
+	public void indent() {
+		Integer inc = formatting.getIndentationIncrease();
+		Integer dec = formatting.getIndentationDecrease();
+		formatting.setIndentationIncrease(inc == null ? 1 : inc + 1);
+		formatting.setIndentationDecrease(dec == null ? 1 : dec + 1);
+	}
+
+	@Override
+	public void noAutowrap() {
+		formatting.setAutowrap(-1);
+	}
+
+	@Override
+	public void noIndentation() {
+		formatting.setNoIndentation(true);
+	}
+
+	@Override
+	public void setNewLines(int minNewLines, int defaultNewLines, int maxNewLines) {
+		formatting.setNewLinesMin(minNewLines);
+		formatting.setNewLinesDefault(defaultNewLines);
+		formatting.setNewLinesMax(maxNewLines);
+	}
+
+	@Override
+	public void setOnAutowrap(IAutowrapFormatter formatter) {
+		autowrap();
+		formatting.setOnAutowrap(formatter);
+	}
+
+	@Override
+	public void setPriority(int priority) {
+		formatting.setPriority(priority);
+	}
+
+	@Override
+	public void setSpace(String space) {
+		formatting.setSpace(space);
+	}
+
+}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/SinglelineCodeCommentReplacer.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/SinglelineCodeCommentReplacer.java
@@ -26,7 +26,7 @@ public class SinglelineCodeCommentReplacer extends SinglelineCommentReplacer {
 
 	@Override
 	public void configureWhitespace(WhitespaceReplacer leading, WhitespaceReplacer trailing) {
-		leading.getFormatting().asFormatter().noIndentation();
+		leading.getFormatting().setNoIndentation(true);
 	}
 
 }

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/WhitespaceReplacer.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/WhitespaceReplacer.java
@@ -77,7 +77,7 @@ public class WhitespaceReplacer implements ITextReplacer {
 		if (newLineCount == 0 && context.isAutowrap()) {
 			IAutowrapFormatter onAutowrap = formatting.getOnAutowrap();
 			if (onAutowrap != null) {
-				onAutowrap.format(formatting.asFormatter(), context.getDocument());
+				onAutowrap.format(region, formatting, context.getDocument());
 			}
 			newLineCount = 1;
 		}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/ITextRegionAccess.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/ITextRegionAccess.java
@@ -196,7 +196,7 @@ public interface ITextRegionAccess {
 	 * 
 	 * @see #leadingHiddenRegion(EObject)
 	 */
-	IHiddenRegion trailingHiddenRegion(EObject owner);
+	IHiddenRegion trailingHiddenRegion(EObject owner); // rename to nextHiddenRegion; do same with leading()
 
 	ITextRegionRewriter getRewriter();
 }


### PR DESCRIPTION
The API useed to have the methods increaseIndentation() and
decreaseIndentation(). While this is quite flexible, it is also quite
likely that the two methods are not called symmetrically.

This can happen, if
- the developer forgets to call one of the methods
- due to a bug in the code's logic that calls one of the methods
- due to an exception that's being thrown after inc() has been called
  and before dec() would be called. Exceptions are likely to be thrown
  because formatter may be executed on syntactically broken documents.
  
If inc() and dec() aren't called symmetrically, the indenteation for the
remaining part of the document will be wrong which makes any formatter
look broken. Therefore, we can consider it to be the better solution to
apply one level of intention properly or not at all. 

The new API makes use of methods from the IFormattableDocument that are
resposnsible for two HiddenRegions at the same time. Namely, the methods
are:
- surround(ISemanticRegion)
- surround(EObject)
- interior(ISemanticRegion, ISemanticRegion)
- set(IHiddenRegion, IHiddenRegion)

When calling one of these methods, IHiddenRegionFormatting#indent() can
be used to increase the level of indentation form the first HiddenRegion
to the second one.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@itemis.de>