### PR TITLE
[bug 465007] active annotations API - only copy explicit annotation values

### DIFF
--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceProviderImpl.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceProviderImpl.xtend
@@ -108,7 +108,7 @@ class AnnotationReferenceProviderImpl implements AnnotationReferenceProvider {
 				delegate = newJvmAnnotationReference
 				it.compilationUnit = this.compilationUnit
 			]
-			for (valueName : baseJvmAnnotationReference.values.map[valueName]) {
+			for (valueName : baseJvmAnnotationReference.getExplicitValues.map[valueName ?: "value"]) {
 				val value = annotationReference.getValue(valueName)
 				buildContext.set(valueName, value)
 			}

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceProviderImpl.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceProviderImpl.java
@@ -222,14 +222,21 @@ public class AnnotationReferenceProviderImpl implements AnnotationReferenceProvi
           }
         };
         final AnnotationReferenceBuildContextImpl buildContext = ObjectExtensions.<AnnotationReferenceBuildContextImpl>operator_doubleArrow(_annotationReferenceBuildContextImpl, _function);
-        EList<JvmAnnotationValue> _values = baseJvmAnnotationReference.getValues();
+        EList<JvmAnnotationValue> _explicitValues = baseJvmAnnotationReference.getExplicitValues();
         final Function1<JvmAnnotationValue, String> _function_1 = new Function1<JvmAnnotationValue, String>() {
           @Override
           public String apply(final JvmAnnotationValue it) {
-            return it.getValueName();
+            String _elvis = null;
+            String _valueName = it.getValueName();
+            if (_valueName != null) {
+              _elvis = _valueName;
+            } else {
+              _elvis = "value";
+            }
+            return _elvis;
           }
         };
-        List<String> _map = ListExtensions.<JvmAnnotationValue, String>map(_values, _function_1);
+        List<String> _map = ListExtensions.<JvmAnnotationValue, String>map(_explicitValues, _function_1);
         for (final String valueName : _map) {
           {
             final Object value = ((JvmAnnotationReferenceImpl)annotationReference).getValue(valueName);

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.xtend
@@ -22,6 +22,7 @@ import org.eclipse.xtend.lib.macro.declaration.TypeReference
 import org.eclipse.xtend.lib.macro.declaration.Visibility
 import org.junit.Test
 import org.eclipse.xtend.core.macro.ActiveAnnotationContexts
+import org.eclipse.xtend.core.macro.declaration.JvmAnnotationReferenceImpl
 
 /**
  * @author Sven Efftinge
@@ -89,6 +90,31 @@ class DeclarationsTest extends AbstractXtendTestCase {
 			])
 			typeLookup.findClass("MyClass").removeAnnotation(anno)
 			assertEquals(typeLookup.findClass("MyClass").declaredFields.head.annotations.head.annotationTypeDeclaration, (anno.getValue('annotation2Value') as AnnotationReference).annotationTypeDeclaration)
+		]
+	}
+	
+	/**
+	 * see https://bugs.eclipse.org/bugs/show_bug.cgi?id=465007
+	 */
+	@Test def testAnnotation4() {
+		validFile('''
+			class MyClass {
+				@test.Annotation2 String foo
+				@test.Annotation2("hubble") String foo2
+				@test.Annotation2(value="hubble") String foo3
+			}
+		''').asCompilationUnit [
+			val anno = typeLookup.findClass("MyClass").declaredFields.head.annotations.head
+			val copied = annotationReferenceProvider.newAnnotationReference(anno)
+			assertTrue((copied as JvmAnnotationReferenceImpl).delegate.explicitValues.empty)
+			
+			val anno2 = typeLookup.findClass("MyClass").declaredFields.get(1).annotations.head
+			val copied2 = annotationReferenceProvider.newAnnotationReference(anno2)
+			assertEquals(1, (copied2 as JvmAnnotationReferenceImpl).delegate.explicitValues.size)
+			
+			val anno3 = typeLookup.findClass("MyClass").declaredFields.get(2).annotations.head
+			val copied3 = annotationReferenceProvider.newAnnotationReference(anno3)
+			assertEquals(1, (copied3 as JvmAnnotationReferenceImpl).delegate.explicitValues.size)
 		]
 	}
 	

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.java
@@ -13,8 +13,10 @@ import com.google.inject.Provider;
 import java.lang.reflect.AccessibleObject;
 import java.util.Collections;
 import java.util.List;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.xtend.core.macro.ActiveAnnotationContexts;
 import org.eclipse.xtend.core.macro.declaration.CompilationUnitImpl;
+import org.eclipse.xtend.core.macro.declaration.JvmAnnotationReferenceImpl;
 import org.eclipse.xtend.core.macro.declaration.TypeLookupImpl;
 import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
 import org.eclipse.xtend.core.xtend.XtendFile;
@@ -46,6 +48,8 @@ import org.eclipse.xtend.lib.macro.services.AnnotationReferenceBuildContext;
 import org.eclipse.xtend.lib.macro.services.AnnotationReferenceProvider;
 import org.eclipse.xtend.lib.macro.services.TypeReferenceProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.common.types.JvmAnnotationReference;
+import org.eclipse.xtext.common.types.JvmAnnotationValue;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -205,6 +209,70 @@ public class DeclarationsTest extends AbstractXtendTestCase {
         Object _value = anno.getValue("annotation2Value");
         AnnotationTypeDeclaration _annotationTypeDeclaration_1 = ((AnnotationReference) _value).getAnnotationTypeDeclaration();
         Assert.assertEquals(_annotationTypeDeclaration, _annotationTypeDeclaration_1);
+      }
+    };
+    this.asCompilationUnit(_validFile, _function);
+  }
+  
+  /**
+   * see https://bugs.eclipse.org/bugs/show_bug.cgi?id=465007
+   */
+  @Test
+  public void testAnnotation4() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class MyClass {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@test.Annotation2 String foo");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@test.Annotation2(\"hubble\") String foo2");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@test.Annotation2(value=\"hubble\") String foo3");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    XtendFile _validFile = this.validFile(_builder);
+    final Procedure1<CompilationUnitImpl> _function = new Procedure1<CompilationUnitImpl>() {
+      @Override
+      public void apply(final CompilationUnitImpl it) {
+        TypeLookupImpl _typeLookup = it.getTypeLookup();
+        MutableClassDeclaration _findClass = _typeLookup.findClass("MyClass");
+        Iterable<? extends MutableFieldDeclaration> _declaredFields = _findClass.getDeclaredFields();
+        MutableFieldDeclaration _head = IterableExtensions.head(_declaredFields);
+        Iterable<? extends AnnotationReference> _annotations = _head.getAnnotations();
+        final AnnotationReference anno = IterableExtensions.head(_annotations);
+        AnnotationReferenceProvider _annotationReferenceProvider = it.getAnnotationReferenceProvider();
+        final AnnotationReference copied = _annotationReferenceProvider.newAnnotationReference(anno);
+        JvmAnnotationReference _delegate = ((JvmAnnotationReferenceImpl) copied).getDelegate();
+        EList<JvmAnnotationValue> _explicitValues = _delegate.getExplicitValues();
+        boolean _isEmpty = _explicitValues.isEmpty();
+        Assert.assertTrue(_isEmpty);
+        TypeLookupImpl _typeLookup_1 = it.getTypeLookup();
+        MutableClassDeclaration _findClass_1 = _typeLookup_1.findClass("MyClass");
+        Iterable<? extends MutableFieldDeclaration> _declaredFields_1 = _findClass_1.getDeclaredFields();
+        MutableFieldDeclaration _get = ((MutableFieldDeclaration[])Conversions.unwrapArray(_declaredFields_1, MutableFieldDeclaration.class))[1];
+        Iterable<? extends AnnotationReference> _annotations_1 = _get.getAnnotations();
+        final AnnotationReference anno2 = IterableExtensions.head(_annotations_1);
+        AnnotationReferenceProvider _annotationReferenceProvider_1 = it.getAnnotationReferenceProvider();
+        final AnnotationReference copied2 = _annotationReferenceProvider_1.newAnnotationReference(anno2);
+        JvmAnnotationReference _delegate_1 = ((JvmAnnotationReferenceImpl) copied2).getDelegate();
+        EList<JvmAnnotationValue> _explicitValues_1 = _delegate_1.getExplicitValues();
+        int _size = _explicitValues_1.size();
+        Assert.assertEquals(1, _size);
+        TypeLookupImpl _typeLookup_2 = it.getTypeLookup();
+        MutableClassDeclaration _findClass_2 = _typeLookup_2.findClass("MyClass");
+        Iterable<? extends MutableFieldDeclaration> _declaredFields_2 = _findClass_2.getDeclaredFields();
+        MutableFieldDeclaration _get_1 = ((MutableFieldDeclaration[])Conversions.unwrapArray(_declaredFields_2, MutableFieldDeclaration.class))[2];
+        Iterable<? extends AnnotationReference> _annotations_2 = _get_1.getAnnotations();
+        final AnnotationReference anno3 = IterableExtensions.head(_annotations_2);
+        AnnotationReferenceProvider _annotationReferenceProvider_2 = it.getAnnotationReferenceProvider();
+        final AnnotationReference copied3 = _annotationReferenceProvider_2.newAnnotationReference(anno3);
+        JvmAnnotationReference _delegate_2 = ((JvmAnnotationReferenceImpl) copied3).getDelegate();
+        EList<JvmAnnotationValue> _explicitValues_2 = _delegate_2.getExplicitValues();
+        int _size_1 = _explicitValues_2.size();
+        Assert.assertEquals(1, _size_1);
       }
     };
     this.asCompilationUnit(_validFile, _function);


### PR DESCRIPTION
Signed-off-by: Sven Efftinge <sven.efftinge@itemis.de>