### PR TITLE
[web] handle operation canceled in async background process, use cancel-manager to check whether an exception is an operation-canceled-exception.

### DIFF
--- a/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/model/DocumentSynchronizer.xtend
+++ b/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/model/DocumentSynchronizer.xtend
@@ -21,6 +21,7 @@ package class DocumentSynchronizer implements CancelIndicator {
 	
     val waitingPriorityJobs = new AtomicInteger
 
+	@Accessors(PUBLIC_GETTER)
     @Inject OperationCanceledManager operationCanceledManager
     
     @Accessors(PUBLIC_GETTER)

--- a/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/model/XtextWebDocumentAccess.java
+++ b/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/model/XtextWebDocumentAccess.java
@@ -91,8 +91,14 @@ public class XtextWebDocumentAccess {
 						public void run() {
 							try {
 								asynchronousWork.exec(asyncAccess);
-							} catch (Exception exception) {
-								LOG.error("Error during asynchronous service processing.", exception);
+							} catch (VirtualMachineError exception) {
+								throw exception;
+							} catch (Throwable exception) {
+								if (!synchronizer.getOperationCanceledManager().isOperationCanceledException(exception)) {
+									LOG.error("Error during asynchronous service processing.", exception);
+								} else {
+									LOG.trace("Canceling background process.");
+								}
 							} finally {
 								synchronizer.releaseLock();
 							}

--- a/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/model/DocumentSynchronizer.java
+++ b/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/model/DocumentSynchronizer.java
@@ -24,6 +24,7 @@ class DocumentSynchronizer implements CancelIndicator {
   
   private final AtomicInteger waitingPriorityJobs = new AtomicInteger();
   
+  @Accessors(AccessorType.PUBLIC_GETTER)
   @Inject
   private OperationCanceledManager operationCanceledManager;
   
@@ -70,6 +71,11 @@ class DocumentSynchronizer implements CancelIndicator {
       throw new IllegalStateException("Cannot release a lock without acquiring it first.");
     }
     this.semaphore.release();
+  }
+  
+  @Pure
+  public OperationCanceledManager getOperationCanceledManager() {
+    return this.operationCanceledManager;
   }
   
   @Pure


### PR DESCRIPTION
Signed-off-by: Sven Efftinge <sven.efftinge@itemis.de>