### PR TITLE
[formatter] several smaller improvements

### DIFF
--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.xtend
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.xtend
@@ -39,7 +39,7 @@ class DomainmodelFormatter extends XbaseFormatter {
 		open.append[newLine]
 		interior(open, close)[indent]
 		for (AbstractElement element : pkg.elements) {
-			format(element, document);
+			element.format
 			element.append[setNewLines(1, 1, 2)]
 		}
 	}
@@ -53,14 +53,14 @@ class DomainmodelFormatter extends XbaseFormatter {
 		interior(open, close)[indent]
 		format(entity.getSuperType(), document);
 		for (Feature feature : entity.features) {
-			format(feature, document);
+			feature.format
 			feature.append[setNewLines(1, 1, 2)]
 		}
 	}
 
 	def dispatch void format(Property property, extension IFormattableDocument document) {
 		property.regionFor.keyword(":").surround[noSpace]
-		format(property.type, document);
+		property.type.format
 	}
 
 	def dispatch void format(Operation operation, extension IFormattableDocument document) {
@@ -70,16 +70,16 @@ class DomainmodelFormatter extends XbaseFormatter {
 			for (comma : operation.regionFor.keywords(","))
 				comma.prepend[noSpace].append[oneSpace]
 			for (params : operation.params)
-				format(params, document);
+				params.format
 			operation.regionFor.keyword(")").prepend[noSpace]
 		}
 		if (operation.type != null) {
 			operation.regionFor.keyword(")").append[noSpace]
 			operation.type.prepend[noSpace].append[oneSpace]
-			format(operation.type, document);
+			operation.type.format
 		} else {
 			operation.regionFor.keyword(")").append[oneSpace]
 		}
-		format(operation.body, document);
+		operation.body.format
 	}
 }

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.java
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.java
@@ -120,7 +120,7 @@ public class DomainmodelFormatter extends XbaseFormatter {
     EList<AbstractElement> _elements = pkg.getElements();
     for (final AbstractElement element : _elements) {
       {
-        this.format(element, document);
+        document.<AbstractElement>format(element);
         final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
@@ -173,7 +173,7 @@ public class DomainmodelFormatter extends XbaseFormatter {
     EList<Feature> _features = entity.getFeatures();
     for (final Feature feature : _features) {
       {
-        this.format(feature, document);
+        document.<Feature>format(feature);
         final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
           public void apply(final IHiddenRegionFormatter it) {
@@ -196,7 +196,7 @@ public class DomainmodelFormatter extends XbaseFormatter {
     };
     document.surround(_keyword, _function);
     JvmTypeReference _type = property.getType();
-    this.format(_type, document);
+    document.<JvmTypeReference>format(_type);
   }
   
   protected void _format(final Operation operation, @Extension final IFormattableDocument document) {
@@ -242,7 +242,7 @@ public class DomainmodelFormatter extends XbaseFormatter {
       }
       EList<JvmFormalParameter> _params_1 = operation.getParams();
       for (final JvmFormalParameter params : _params_1) {
-        this.format(params, document);
+        document.<JvmFormalParameter>format(params);
       }
       ISemanticRegionsFinder _regionFor_3 = this.textRegionExtensions.regionFor(operation);
       ISemanticRegion _keyword_2 = _regionFor_3.keyword(")");
@@ -282,7 +282,7 @@ public class DomainmodelFormatter extends XbaseFormatter {
       };
       document.<JvmTypeReference>append(_prepend_1, _function_7);
       JvmTypeReference _type_2 = operation.getType();
-      this.format(_type_2, document);
+      document.<JvmTypeReference>format(_type_2);
     } else {
       ISemanticRegionsFinder _regionFor_5 = this.textRegionExtensions.regionFor(operation);
       ISemanticRegion _keyword_4 = _regionFor_5.keyword(")");
@@ -295,7 +295,7 @@ public class DomainmodelFormatter extends XbaseFormatter {
       document.append(_keyword_4, _function_8);
     }
     XExpression _body = operation.getBody();
-    this.format(_body, document);
+    document.<XExpression>format(_body);
   }
   
   public void format(final Object entity, final IFormattableDocument document) {

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.xtend
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.xtend
@@ -39,8 +39,7 @@ class RuleEngineFormatter extends XbaseFormatter {
 	def dispatch void format(Model model, extension IFormattableDocument document) {
 		model.prepend[setNewLines(0, 0, 1); noSpace]
 		for (Declaration declaration : model.getDeclarations()) {
-			format(declaration, document);
-			declaration.append[setNewLines(1, 1, 2)]
+			declaration.format.append[setNewLines(1, 1, 2)]
 		}
 	}
 
@@ -48,16 +47,14 @@ class RuleEngineFormatter extends XbaseFormatter {
 		device.regionFor.feature(DEVICE__NAME).surround[oneSpace]
 		device.regionFor.keyword("be").surround[oneSpace]
 		for (State state : device.getStates()) {
-			state.immediatelyPreceding.keyword(",").prepend[noSpace].append[oneSpace]
-			format(state, document);
+			state.format.immediatelyPreceding.keyword(",").prepend[noSpace].append[oneSpace]
 		}
 	}
 
 	def dispatch void format(Rule rule, extension IFormattableDocument document) {
 		rule.regionFor.feature(RULE__DESCRIPTION).surround[oneSpace]
 		rule.regionFor.feature(RULE__DEVICE_STATE).surround[oneSpace]
-		rule.thenPart.prepend[newLine]
-		format(rule.thenPart, document);
+		rule.thenPart.format.prepend[newLine]
 	}
 
 	override dispatch void format(XBlockExpression expr, extension IFormattableDocument document) {
@@ -70,14 +67,14 @@ class RuleEngineFormatter extends XbaseFormatter {
 					sem.append[newLine]
 			} else if (child != expr.expressions.last)
 				child.append[newLine]
-			child.format(document)
+			child.format
 		}
 	}
 
 	override dispatch void format(XSwitchExpression expr, extension IFormattableDocument document) {
 		set(expr.^switch.previousHiddenRegion, expr.nextHiddenRegion)[indent]
 		expr.regionFor.keyword("switch").append[oneSpace]
-		expr.^switch.append[newLine].format(document)
+		expr.^switch.append[newLine].format
 		for (c : expr.cases) {
 			if (c.typeGuard != null && c.^case != null) {
 				c.typeGuard.append[oneSpace]
@@ -88,7 +85,7 @@ class RuleEngineFormatter extends XbaseFormatter {
 				c.^case.prepend[oneSpace].append[noSpace]
 			}
 			c.regionFor.feature(XCASE_PART__FALL_THROUGH).prepend[noSpace].append[newLine]
-			c.^case.format(document)
+			c.^case.format
 			if (c == expr.cases.last && expr.^default == null)
 				c.then.formatBody(true, document)
 			else
@@ -110,7 +107,7 @@ class RuleEngineFormatter extends XbaseFormatter {
 		} else {
 			expr.prepend[oneSpace]
 		}
-		expr.format(doc)
+		expr.format
 	}
 
 	override protected void formatBodyInline(XExpression expr, boolean forceMultiline,
@@ -124,7 +121,7 @@ class RuleEngineFormatter extends XbaseFormatter {
 		} else {
 			expr.surround[oneSpace]
 		}
-		expr.format(doc)
+		expr.format
 	}
 
 	override protected void formatBodyParagraph(XExpression expr, extension IFormattableDocument doc) {
@@ -135,7 +132,7 @@ class RuleEngineFormatter extends XbaseFormatter {
 		} else {
 			expr.surround[oneSpace]
 		}
-		expr.format(doc)
+		expr.format
 	}
 
 }

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.java
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.java
@@ -88,16 +88,14 @@ public class RuleEngineFormatter extends XbaseFormatter {
     document.<Model>prepend(model, _function);
     EList<Declaration> _declarations = model.getDeclarations();
     for (final Declaration declaration : _declarations) {
-      {
-        this.format(declaration, document);
-        final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.setNewLines(1, 1, 2);
-          }
-        };
-        document.<Declaration>append(declaration, _function_1);
-      }
+      Declaration _format = document.<Declaration>format(declaration);
+      final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
+        @Override
+        public void apply(final IHiddenRegionFormatter it) {
+          it.setNewLines(1, 1, 2);
+        }
+      };
+      document.<Declaration>append(_format, _function_1);
     }
   }
   
@@ -122,25 +120,23 @@ public class RuleEngineFormatter extends XbaseFormatter {
     document.surround(_keyword, _function_1);
     EList<State> _states = device.getStates();
     for (final State state : _states) {
-      {
-        ISemanticRegionFinder _immediatelyPreceding = this.textRegionExtensions.immediatelyPreceding(state);
-        ISemanticRegion _keyword_1 = _immediatelyPreceding.keyword(",");
-        final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.noSpace();
-          }
-        };
-        ISemanticRegion _prepend = document.prepend(_keyword_1, _function_2);
-        final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.oneSpace();
-          }
-        };
-        document.append(_prepend, _function_3);
-        this.format(state, document);
-      }
+      State _format = document.<State>format(state);
+      ISemanticRegionFinder _immediatelyPreceding = this.textRegionExtensions.immediatelyPreceding(_format);
+      ISemanticRegion _keyword_1 = _immediatelyPreceding.keyword(",");
+      final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
+        @Override
+        public void apply(final IHiddenRegionFormatter it) {
+          it.noSpace();
+        }
+      };
+      ISemanticRegion _prepend = document.prepend(_keyword_1, _function_2);
+      final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
+        @Override
+        public void apply(final IHiddenRegionFormatter it) {
+          it.oneSpace();
+        }
+      };
+      document.append(_prepend, _function_3);
     }
   }
   
@@ -164,15 +160,14 @@ public class RuleEngineFormatter extends XbaseFormatter {
     };
     document.surround(_feature_1, _function_1);
     XExpression _thenPart = rule.getThenPart();
+    XExpression _format = document.<XExpression>format(_thenPart);
     final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
       @Override
       public void apply(final IHiddenRegionFormatter it) {
         it.newLine();
       }
     };
-    document.<XExpression>prepend(_thenPart, _function_2);
-    XExpression _thenPart_1 = rule.getThenPart();
-    this.format(_thenPart_1, document);
+    document.<XExpression>prepend(_format, _function_2);
   }
   
   @Override
@@ -224,7 +219,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
             document.<XExpression>append(child, _function_3);
           }
         }
-        this.format(child, document);
+        document.<XExpression>format(child);
       }
     }
   }
@@ -258,7 +253,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
       }
     };
     XExpression _append = document.<XExpression>append(_switch_1, _function_2);
-    this.format(_append, document);
+    document.<XExpression>format(_append);
     EList<XCasePart> _cases = expr.getCases();
     for (final XCasePart c : _cases) {
       {
@@ -340,7 +335,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
         };
         document.append(_prepend_1, _function_9);
         XExpression _case_4 = c.getCase();
-        this.format(_case_4, document);
+        document.<XExpression>format(_case_4);
         boolean _and_1 = false;
         EList<XCasePart> _cases_1 = expr.getCases();
         XCasePart _last = IterableExtensions.<XCasePart>last(_cases_1);
@@ -426,7 +421,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
         doc.<XExpression>prepend(expr, _function_3);
       }
     }
-    this.format(expr, doc);
+    doc.<XExpression>format(expr);
   }
   
   @Override
@@ -484,7 +479,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
         doc.<XExpression>surround(expr, _function_4);
       }
     }
-    this.format(expr, doc);
+    doc.<XExpression>format(expr);
   }
   
   @Override
@@ -510,7 +505,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
       };
       doc.<XExpression>surround(expr, _function_1);
     }
-    this.format(expr, doc);
+    doc.<XExpression>format(expr);
   }
   
   public void format(final Object device, final IFormattableDocument document) {

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/XtendFormatter.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/XtendFormatter.xtend
@@ -57,9 +57,9 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 				pkg.append(blankLinesAfterPackageDecl)
 			}
 		}
-		xtendFile.importSection?.format(format)
+		xtendFile.importSection?.format
 		for (clazz : xtendFile.xtendTypes) {
-			clazz.format(format)
+			clazz.format
 			if (clazz != xtendFile.xtendTypes.last)
 				clazz.append(blankLinesBetweenClasses)
 		}
@@ -71,7 +71,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		if (target.annotations.isEmpty)
 			return;
 		for (a : target.annotations) {
-			a.format(document)
+			a.format
 			a.append(configKey)
 		}
 	}
@@ -82,11 +82,11 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		formatTypeParameters(clazz, clazz.typeParameters, format)
 		clazz.regionFor.keyword("class").append[oneSpace]
 		clazz.regionFor.keyword("extends").surround[oneSpace]
-		clazz.^extends.format(format)
+		clazz.^extends.format
 		clazz.regionFor.keyword("implements").surround[oneSpace]
 		for (imp : clazz.^implements) {
 			imp.immediatelyFollowing.keyword(",").prepend[noSpace].append[oneSpace]
-			imp.format(format)
+			imp.format
 		}
 		formatBody(clazz, format)
 	}
@@ -96,7 +96,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		if (!typeParameters.empty) {
 			member.regionFor.keyword("<").surround[noSpace]
 			for (arg : typeParameters) {
-				arg.format(format)
+				arg.format
 				arg.immediatelyFollowing.keyword(",").prepend[noSpace].append[oneSpace]
 			}
 			member.regionFor.keyword(">").prepend[noSpace]
@@ -112,7 +112,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 			open.append(blankLinesBeforeFirstMember)
 			for (i : 0 .. (type.members.size - 1)) {
 				val current = type.members.get(i)
-				current.format(format)
+				current.format
 				if (i < type.members.size - 1) {
 					val next = type.members.get(i + 1)
 					if (current instanceof XtendField && next instanceof XtendField)
@@ -139,7 +139,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		interfaze.regionFor.keyword("extends").surround[oneSpace]
 		for (imp : interfaze.extends) {
 			imp.immediatelyFollowing.keyword(",").prepend[noSpace].append[oneSpace]
-			imp.format(format)
+			imp.format
 		}
 		formatBody(interfaze, format)
 	}
@@ -163,7 +163,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 			open.append(blankLinesBeforeFirstMember)
 			for (i : 0 .. (enumeration.members.size - 1)) {
 				val current = enumeration.members.get(i)
-				current.format(format)
+				current.format
 				if (i < enumeration.members.size - 1) {
 					current.immediatelyFollowing.keyword(",").prepend[noSpace].append(blankLinesBetweenEnumLiterals)
 				} else {
@@ -182,7 +182,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		if (!func.typeParameters.empty) {
 			func.regionFor.keyword("<").append[noSpace]
 			for (arg : func.typeParameters) {
-				arg.format(format)
+				arg.format
 				arg.immediatelyFollowing.keyword(",").prepend[noSpace].append[oneSpace]
 			}
 			func.regionFor.keyword(">").surround([noSpace])
@@ -192,7 +192,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		close.append(bracesInNewLine)
 		formatCommaSeparatedList(func.parameters, open, close, format)
 
-		func.expression.format(format)
+		func.expression.format
 	}
 
 	def dispatch void format(XtendFunction func, extension IFormattableDocument format) {
@@ -201,7 +201,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		if (!func.typeParameters.empty) {
 			func.regionFor.keyword("<").append[noSpace]
 			for (arg : func.typeParameters) {
-				arg.format(format)
+				arg.format
 				arg.immediatelyFollowing.keyword(",").prepend[noSpace].append[oneSpace]
 			}
 			func.regionFor.keyword(">").prepend[noSpace].append[oneSpace]
@@ -214,8 +214,8 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		if (func.expression != null)
 			close.append(bracesInNewLine)
 		formatCommaSeparatedList(func.parameters, open, close, format)
-		func.returnType.format(format)
-		func.expression.format(format)
+		func.returnType.format
+		func.expression.format
 	}
 
 	def dispatch void format(XtendField field, extension IFormattableDocument document) {
@@ -224,13 +224,13 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		if (field.name != null)
 			field.type.append[oneSpace]
 		field.regionFor.keyword("=").prepend[oneSpace].append[oneSpace]
-		field.type.format(document)
-		field.initialValue.format(document)
+		field.type.format
+		field.initialValue.format
 	}
 
 	def dispatch void format(XtendParameter param, extension IFormattableDocument format) {
 		formatAnnotations(param, format, newLineAfterParameterAnnotations)
-		param.parameterType.format(format)
+		param.parameterType.format
 		val nameNode = param.regionFor.feature(XTEND_PARAMETER__NAME)
 		nameNode.prepend[oneSpace]
 	}

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
@@ -133,12 +133,12 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     }
     XImportSection _importSection = xtendFile.getImportSection();
     if (_importSection!=null) {
-      this.format(_importSection, format);
+      format.<XImportSection>format(_importSection);
     }
     EList<XtendTypeDeclaration> _xtendTypes = xtendFile.getXtendTypes();
     for (final XtendTypeDeclaration clazz : _xtendTypes) {
       {
-        this.format(clazz, format);
+        format.<XtendTypeDeclaration>format(clazz);
         EList<XtendTypeDeclaration> _xtendTypes_1 = xtendFile.getXtendTypes();
         XtendTypeDeclaration _last = IterableExtensions.<XtendTypeDeclaration>last(_xtendTypes_1);
         boolean _notEquals_2 = (!Objects.equal(clazz, _last));
@@ -165,7 +165,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     EList<XAnnotation> _annotations_1 = target.getAnnotations();
     for (final XAnnotation a : _annotations_1) {
       {
-        this.format(a, document);
+        document.<XAnnotation>format(a);
         document.<XAnnotation>append(a, configKey);
       }
     }
@@ -195,7 +195,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     };
     format.surround(_keyword_1, _function_1);
     JvmTypeReference _extends = clazz.getExtends();
-    this.format(_extends, format);
+    format.<JvmTypeReference>format(_extends);
     ISemanticRegionsFinder _regionFor_2 = this.textRegionExtensions.regionFor(clazz);
     ISemanticRegion _keyword_2 = _regionFor_2.keyword("implements");
     final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
@@ -224,7 +224,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
           }
         };
         format.append(_prepend, _function_4);
-        this.format(imp, format);
+        format.<JvmTypeReference>format(imp);
       }
     }
     this.formatBody(clazz, format);
@@ -248,7 +248,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
         format.surround(_keyword, _function);
         for (final JvmTypeParameter arg : typeParameters) {
           {
-            this.format(arg, format);
+            format.<JvmTypeParameter>format(arg);
             ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(arg);
             ISemanticRegion _keyword_1 = _immediatelyFollowing.keyword(",");
             final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
@@ -311,7 +311,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
           {
             EList<XtendMember> _members_2 = type.getMembers();
             final XtendMember current = _members_2.get((i).intValue());
-            this.format(current, format);
+            format.<XtendMember>format(current);
             EList<XtendMember> _members_3 = type.getMembers();
             int _size_1 = _members_3.size();
             int _minus_1 = (_size_1 - 1);
@@ -403,7 +403,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
           }
         };
         format.append(_prepend, _function_3);
-        this.format(imp, format);
+        format.<JvmTypeReference>format(imp);
       }
     }
     this.formatBody(interfaze, format);
@@ -461,7 +461,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
         {
           EList<XtendMember> _members_2 = enumeration.getMembers();
           final XtendMember current = _members_2.get((i).intValue());
-          this.format(current, format);
+          format.<XtendMember>format(current);
           EList<XtendMember> _members_3 = enumeration.getMembers();
           int _size_1 = _members_3.size();
           int _minus_1 = (_size_1 - 1);
@@ -521,7 +521,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
       EList<JvmTypeParameter> _typeParameters_1 = func.getTypeParameters();
       for (final JvmTypeParameter arg : _typeParameters_1) {
         {
-          this.format(arg, format);
+          format.<JvmTypeParameter>format(arg);
           ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(arg);
           ISemanticRegion _keyword_2 = _immediatelyFollowing.keyword(",");
           final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
@@ -558,7 +558,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     EList<XtendParameter> _parameters = func.getParameters();
     this.formatCommaSeparatedList(_parameters, open, close, format);
     XExpression _expression = func.getExpression();
-    this.format(_expression, format);
+    format.<XExpression>format(_expression);
   }
   
   protected void _format(final XtendFunction func, @Extension final IFormattableDocument format) {
@@ -580,7 +580,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
       EList<JvmTypeParameter> _typeParameters_1 = func.getTypeParameters();
       for (final JvmTypeParameter arg : _typeParameters_1) {
         {
-          this.format(arg, format);
+          format.<JvmTypeParameter>format(arg);
           ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(arg);
           ISemanticRegion _keyword_1 = _immediatelyFollowing.keyword(",");
           final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
@@ -652,9 +652,9 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     EList<XtendParameter> _parameters = func.getParameters();
     this.formatCommaSeparatedList(_parameters, open, close, format);
     JvmTypeReference _returnType_1 = func.getReturnType();
-    this.format(_returnType_1, format);
+    format.<JvmTypeReference>format(_returnType_1);
     XExpression _expression_1 = func.getExpression();
-    this.format(_expression_1, format);
+    format.<XExpression>format(_expression_1);
   }
   
   protected void _format(final XtendField field, @Extension final IFormattableDocument document) {
@@ -689,15 +689,15 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     };
     document.append(_prepend, _function_2);
     JvmTypeReference _type_1 = field.getType();
-    this.format(_type_1, document);
+    document.<JvmTypeReference>format(_type_1);
     XExpression _initialValue = field.getInitialValue();
-    this.format(_initialValue, document);
+    document.<XExpression>format(_initialValue);
   }
   
   protected void _format(final XtendParameter param, @Extension final IFormattableDocument format) {
     this.formatAnnotations(param, format, XbaseFormatterPreferenceKeys.newLineAfterParameterAnnotations);
     JvmTypeReference _parameterType = param.getParameterType();
-    this.format(_parameterType, format);
+    format.<JvmTypeReference>format(_parameterType);
     ISemanticRegionsFinder _regionFor = this.textRegionExtensions.regionFor(param);
     final ISemanticRegion nameNode = _regionFor.feature(XtendPackage.Literals.XTEND_PARAMETER__NAME);
     final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/annotations/formatting2/XbaseWithAnnotationsFormatter.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/annotations/formatting2/XbaseWithAnnotationsFormatter.xtend
@@ -20,12 +20,12 @@ class XbaseWithAnnotationsFormatter extends XbaseFormatter {
 		ann.regionFor.keyword("@").append[noSpace]
 		ann.regionFor.keyword("(").surround[noSpace]
 		if (ann.value != null) {
-			ann.value.format(document)
+			ann.value.format
 			ann.regionFor.keyword(")").prepend[noSpace]
 		} else if (!ann.elementValuePairs.empty) {
 			for (pair : ann.elementValuePairs) {
 				pair.regionFor.keyword("=").surround[noSpace]
-				pair.value.format(document)
+				pair.value.format
 				pair.immediatelyFollowing.keyword(",").prepend[noSpace].append[oneSpace]
 			}
 			ann.regionFor.keyword(")").prepend[noSpace]

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
@@ -79,7 +79,7 @@ class XbaseFormatter extends XtypeFormatter {
 		} else if (close.previousHiddenRegion.multiline) {
 			open.append[newLine]
 			for (elem : elements) {
-				elem.format(format)
+				elem.format
 				elem.immediatelyFollowing.keyword(",").prepend[noSpace].append[newLine]
 			}
 			elements.last.append[newLine]
@@ -101,7 +101,7 @@ class XbaseFormatter extends XtypeFormatter {
 					sep.append[oneSpace]
 				}
 				sep.prepend[noSpace]
-				ele.object.format(format)
+				ele.object.format
 			}
 			close.prepend[noSpace]
 		}
@@ -109,11 +109,11 @@ class XbaseFormatter extends XtypeFormatter {
 
 	def dispatch void format(JvmGenericArrayTypeReference array, extension IFormattableDocument document) {
 		addReplacer(new ArrayBracketsFormattingReplacer(array.regionFor.ruleCallTo(arrayBracketsRule)))
-		array.componentType.format(document)
+		array.componentType.format
 	}
 
 	def dispatch void format(JvmTypeConstraint constraint, extension IFormattableDocument document) {
-		constraint.typeReference.prepend[oneSpace].format(document)
+		constraint.typeReference.prepend[oneSpace].format
 	}
 
 	def dispatch void format(XVariableDeclaration expr, extension IFormattableDocument format) {
@@ -121,15 +121,15 @@ class XbaseFormatter extends XtypeFormatter {
 		expr.regionFor.keyword("var").append[oneSpace]
 		expr.type.append[oneSpace]
 		expr.regionFor.keyword("=").surround[oneSpace]
-		expr.type.format(format)
-		expr.right.format(format)
+		expr.type.format
+		expr.right.format
 	}
 
 	def dispatch void format(XAssignment expr, extension IFormattableDocument format) {
 		expr.regionFor.ruleCallTo(opSingleAssignRule).surround[oneSpace]
 		expr.regionFor.keyword(if(expr.explicitStatic) '::' else '.').surround[noSpace]
-		expr.assignable.format(format)
-		expr.value.format(format)
+		expr.assignable.format
+		expr.value.format
 	}
 
 	// def protected void formatStaticQualifier(INode node, extension IFormattableDocument document) {
@@ -158,10 +158,10 @@ class XbaseFormatter extends XtypeFormatter {
 			formatConditionally(offset, length, [ doc |
 				val extension it = doc.requireFitsInLine
 				closure.prepend[noSpace]
-				closure.format(it)
+				closure.format
 			], [ extension it |
 				closure.prepend[oneSpace]
-				closure.format(it)
+				closure.format
 			])
 		}
 	}
@@ -186,7 +186,7 @@ class XbaseFormatter extends XtypeFormatter {
 		if (!expr.typeArguments.empty) {
 			expr.regionFor.keyword("<").surround[noSpace]
 			for (arg : expr.typeArguments) {
-				arg.format(format)
+				arg.format
 				arg.immediatelyFollowing.keyword(",").prepend[noSpace].append[oneSpace]
 			}
 			expr.regionFor.keyword(">").prepend[noSpace]
@@ -202,7 +202,7 @@ class XbaseFormatter extends XtypeFormatter {
 		if (!expr.typeArguments.empty) {
 			expr.regionFor.keyword("<").append[noSpace]
 			for (arg : expr.typeArguments) {
-				arg.format(format)
+				arg.format
 				arg.immediatelyFollowing.keyword(",").prepend[noSpace].append[oneSpace]
 			}
 			expr.regionFor.keyword(">").surround[noSpace]
@@ -229,7 +229,7 @@ class XbaseFormatter extends XtypeFormatter {
 			calls.prependWithLeadingSeparator(top, separator)
 			top = top.memberCallTarget
 		}
-		top.format(format)
+		top.format
 		val indentOnce = new IndentOnceAutowrapFormatter(expr.nextHiddenRegion)
 		for (entry : calls) {
 			val call = entry.object
@@ -276,7 +276,7 @@ class XbaseFormatter extends XtypeFormatter {
 				sep.append[oneSpace]
 
 			sep.prepend[oneSpace]
-			ele.object.rightOperand.format(format)
+			ele.object.rightOperand.format
 		}
 	}
 
@@ -299,7 +299,7 @@ class XbaseFormatter extends XtypeFormatter {
 			expr.regionFor.keyword("synchronized").append(whitespaceBetweenKeywordAndParenthesisML)
 		else
 			expr.regionFor.keyword("synchronized").append(whitespaceBetweenKeywordAndParenthesisSL)
-		expr.param.format(format)
+		expr.param.format
 		expr.expression.formatBody(false, format)
 	}
 
@@ -313,14 +313,14 @@ class XbaseFormatter extends XtypeFormatter {
 			expr.regionFor.keyword("if").append(whitespaceBetweenKeywordAndParenthesisML)
 		else
 			expr.regionFor.keyword("if").append(whitespaceBetweenKeywordAndParenthesisSL)
-		expr.^if.format(format)
+		expr.^if.format
 		if (expr.^else == null) {
 			expr.then.formatBody(multiline, format)
 		} else {
 			expr.then.formatBodyInline(multiline, format)
 			if (expr.^else instanceof XIfExpression || !multiline) {
 				expr.^else.prepend[oneSpace]
-				expr.^else.format(format)
+				expr.^else.format
 			} else {
 				expr.^else.formatBody(multiline, format)
 			}
@@ -330,7 +330,7 @@ class XbaseFormatter extends XtypeFormatter {
 	def dispatch void format(XForLoopExpression expr, extension IFormattableDocument format) {
 		expr.regionFor.keyword("for").append[oneSpace]
 		expr.declaredParam.prepend[noSpace].append[oneSpace]
-		expr.forExpression.prepend[oneSpace].append[noSpace].format(format)
+		expr.forExpression.prepend[oneSpace].append[noSpace].format
 		expr.eachExpression.formatBody(true, format)
 	}
 
@@ -340,23 +340,23 @@ class XbaseFormatter extends XtypeFormatter {
 		expr.regionFor.keywords(";").forEach[prepend[noSpace].append[noSpace lowPriority]]
 		expr.regionFor.keywords(",").forEach[prepend[noSpace].append[oneSpace]]
 		expr.regionFor.keyword(")").prepend[noSpace]
-		expr.initExpressions.forEach[it.format(format)]
+		expr.initExpressions.forEach[it.format]
 		expr.expression.prepend[oneSpace]
-		expr.expression.format(format)
+		expr.expression.format
 		expr.updateExpressions.head.prepend[oneSpace]
-		expr.updateExpressions.forEach[it.format(format)]
+		expr.updateExpressions.forEach[it.format]
 		expr.eachExpression.formatBody(true, format)
 	}
 
 	def dispatch void format(XWhileExpression expr, extension IFormattableDocument format) {
 		expr.regionFor.keyword("while").append(whitespaceBetweenKeywordAndParenthesisML)
-		expr.predicate.prepend[noSpace].append[noSpace].format(format)
+		expr.predicate.prepend[noSpace].append[noSpace].format
 		expr.body.formatBody(true, format)
 	}
 
 	def dispatch void format(XDoWhileExpression expr, extension IFormattableDocument format) {
 		expr.regionFor.keyword("while").append(whitespaceBetweenKeywordAndParenthesisML)
-		expr.predicate.prepend[noSpace].append[noSpace].format(format)
+		expr.predicate.prepend[noSpace].append[noSpace].format
 		expr.body.formatBodyInline(true, format)
 	}
 
@@ -393,19 +393,19 @@ class XbaseFormatter extends XtypeFormatter {
 
 	def dispatch void format(XThrowExpression expr, extension IFormattableDocument format) {
 		expr.expression.prepend[oneSpace]
-		expr.expression.format(format)
+		expr.expression.format
 	}
 
 	def dispatch void format(XReturnExpression expr, extension IFormattableDocument format) {
 		expr.expression.prepend[oneSpace]
-		expr.expression.format(format)
+		expr.expression.format
 	}
 
 	def dispatch void format(XTryCatchFinallyExpression expr, extension IFormattableDocument format) {
 		expr.expression.formatBodyInline(true, format)
 		for (cc : expr.catchClauses) {
 			cc.regionFor.keyword("catch").append(whitespaceBetweenKeywordAndParenthesisML)
-			cc.declaredParam.prepend[noSpace].append[noSpace].format(format)
+			cc.declaredParam.prepend[noSpace].append[noSpace].format
 			if (cc != expr.catchClauses.last || expr.finallyExpression != null)
 				cc.expression.formatBodyInline(true, format)
 			else
@@ -416,13 +416,13 @@ class XbaseFormatter extends XtypeFormatter {
 
 	def dispatch void format(JvmFormalParameter expr, extension IFormattableDocument format) {
 		expr.parameterType?.append[oneSpace]
-		expr.parameterType.format(format)
+		expr.parameterType.format
 	}
 
 	def dispatch void format(XExpression expr, extension IFormattableDocument format) {
 		for (obj : expr.eContents)
 			switch (obj) {
-				XExpression: obj.format(format)
+				XExpression: obj.format
 			}
 	}
 
@@ -438,8 +438,8 @@ class XbaseFormatter extends XtypeFormatter {
 			open.prepend[oneSpace]
 			open.append[oneSpace]
 			for (c : expr.cases) {
-				c.^case.format(format)
-				c.then.format(format)
+				c.^case.format
+				c.then.format
 				if (c.then == null) {
 					c.append[oneSpace]
 				} else {
@@ -448,7 +448,7 @@ class XbaseFormatter extends XtypeFormatter {
 			}
 			if (expr.^default != null) {
 				expr.regionFor.keyword("default").append[noSpace]
-				expr.^default.surround[oneSpace].format(format)
+				expr.^default.surround[oneSpace].format
 			}
 		} else if (caseSL) {
 			open.prepend(bracesInNewLine)
@@ -457,15 +457,15 @@ class XbaseFormatter extends XtypeFormatter {
 			}
 			interior(open, close)[indent]
 			for (c : expr.cases) {
-				c.^case.format(format)
-				c.then.format(format)
+				c.^case.format
+				c.then.format
 				c.then.prepend[oneSpace]
 				if (c != expr.cases.last)
 					c.append[newLine]
 			}
 			if (expr.^default != null) {
 				expr.regionFor.keyword("default").prepend[newLine].append[noSpace]
-				expr.^default.prepend[oneSpace].format(format)
+				expr.^default.prepend[oneSpace].format
 			}
 			close.prepend[newLine]
 		} else {
@@ -474,7 +474,7 @@ class XbaseFormatter extends XtypeFormatter {
 				interior(open, close)[indent]
 			}
 			for (c : expr.cases) {
-				c.^case.format(format)
+				c.^case.format
 				c.then.formatBodyParagraph(format)
 				c.regionFor.feature(XCASE_PART__FALL_THROUGH).prepend[noSpace].append[newLine]
 			}
@@ -503,7 +503,7 @@ class XbaseFormatter extends XtypeFormatter {
 				open.append[noSpace]
 			} else {
 				for (param : expr.declaredFormalParameters) {
-					param.format(format)
+					param.format
 					param.immediatelyFollowing.keyword(",").prepend[noSpace].append[oneSpace]
 				}
 				open.append(init)
@@ -540,7 +540,7 @@ class XbaseFormatter extends XtypeFormatter {
 				val last = expr.formatClosureParams(open, it)[noSpace]
 				last.append[noSpace]
 				for (c : children) {
-					c.format(it)
+					c.format
 					val semicolon = c.immediatelyFollowing.keyword(";")
 					if (semicolon != null)
 						semicolon.prepend[noSpace].append[if(c == children.last) noSpace else oneSpace]
@@ -564,7 +564,7 @@ class XbaseFormatter extends XtypeFormatter {
 		} else {
 			expr.prepend[oneSpace]
 		}
-		expr.format(doc)
+		expr.format
 	}
 
 	def protected void formatBodyInline(XExpression expr, boolean forceMultiline, extension IFormattableDocument doc) {
@@ -577,7 +577,7 @@ class XbaseFormatter extends XtypeFormatter {
 		} else {
 			expr.surround[oneSpace]
 		}
-		expr.format(doc)
+		expr.format
 	}
 
 	def protected void formatBodyParagraph(XExpression expr, extension IFormattableDocument doc) {
@@ -588,13 +588,13 @@ class XbaseFormatter extends XtypeFormatter {
 		} else {
 			expr.prepend[newLine].surround[indent].append[newLine]
 		}
-		expr.format(doc)
+		expr.format
 	}
 
 	def dispatch void format(XInstanceOfExpression expr, extension IFormattableDocument doc) {
 		expr.regionFor.keyword("instanceof").surround[oneSpace]
-		expr.expression.format(doc)
-		expr.type.format(doc)
+		expr.expression.format
+		expr.type.format
 	}
 
 	def protected void formatExpressionsMultiline(Collection<? extends XExpression> expressions, ISemanticRegion open,
@@ -605,7 +605,7 @@ class XbaseFormatter extends XtypeFormatter {
 		} else {
 			open.append(blankLinesAroundExpression)
 			for (child : expressions) {
-				child.format(format)
+				child.format
 				val sem = child.immediatelyFollowing.keyword(";")
 				if (sem != null)
 					sem.prepend[noSpace].append(blankLinesAroundExpression)
@@ -622,7 +622,7 @@ class XbaseFormatter extends XtypeFormatter {
 		} else {
 			open.append[oneSpace]
 			for (child : expressions) {
-				child.format(format)
+				child.format
 				val sem = child.immediatelyFollowing.keyword(";")
 				if (sem != null)
 					sem.prepend[noSpace].append[oneSpace]

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XtypeFormatter.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XtypeFormatter.xtend
@@ -27,18 +27,18 @@ class XtypeFormatter extends AbstractFormatter2 {
 	def dispatch void format(XFunctionTypeRef func, extension IFormattableDocument document) {
 		func.regionFor.keyword("(").append[noSpace]
 		for (param : func.paramTypes) {
-			param.format(document)
+			param.format
 			param.immediatelyFollowing.keyword(",").prepend[noSpace].append[oneSpace]
 		}
 		func.regionFor.keyword(")").prepend[if(!func.paramTypes.empty) noSpace].append[noSpace]
 		func.regionFor.keyword("=>").append[noSpace]
-		func.returnType.format(document)
+		func.returnType.format
 	}
 
 	def dispatch void format(JvmParameterizedTypeReference ref, extension IFormattableDocument document) {
 		ref.regionFor.keyword("<").surround[noSpace]
 		for (arg : ref.arguments) {
-			arg.format(document)
+			arg.format
 			arg.immediatelyFollowing.keyword(",").prepend[noSpace].append[oneSpace]
 		}
 		if (!ref.arguments.empty)
@@ -49,19 +49,19 @@ class XtypeFormatter extends AbstractFormatter2 {
 		if (!ref.constraints.empty)
 			ref.regionFor.keyword("?").append[oneSpace]
 		for (c : ref.constraints)
-			c.format(document)
+			c.format
 	}
 
 	def dispatch void format(JvmTypeParameter ref, extension IFormattableDocument document) {
 		for (c : ref.constraints) {
 			c.prepend[oneSpace]
-			c.format(document)
+			c.format
 		}
 	}
 
 	def dispatch format(XImportSection section, extension IFormattableDocument format) {
 		for (imp : section.importDeclarations) {
-			imp.format(format)
+			imp.format
 			if (imp != section.importDeclarations.last)
 				imp.append(blankLinesBetweenImports)
 			else

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/annotations/formatting2/XbaseWithAnnotationsFormatter.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/annotations/formatting2/XbaseWithAnnotationsFormatter.java
@@ -81,7 +81,7 @@ public class XbaseWithAnnotationsFormatter extends XbaseFormatter {
     boolean _notEquals = (!Objects.equal(_value, null));
     if (_notEquals) {
       XExpression _value_1 = ann.getValue();
-      this.format(_value_1, document);
+      document.<XExpression>format(_value_1);
       ISemanticRegionsFinder _regionFor_2 = this.textRegionExtensions.regionFor(ann);
       ISemanticRegion _keyword_2 = _regionFor_2.keyword(")");
       final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
@@ -109,7 +109,7 @@ public class XbaseWithAnnotationsFormatter extends XbaseFormatter {
             };
             document.surround(_keyword_3, _function_3);
             XExpression _value_2 = pair.getValue();
-            this.format(_value_2, document);
+            document.<XExpression>format(_value_2);
             ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(pair);
             ISemanticRegion _keyword_4 = _immediatelyFollowing.keyword(",");
             final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
@@ -163,7 +163,7 @@ public class XbaseFormatter extends XtypeFormatter {
           format.append(open, _function_1);
           for (final EObject elem : elements) {
             {
-              this.format(elem, format);
+              format.<EObject>format(elem);
               ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(elem);
               ISemanticRegion _keyword = _immediatelyFollowing.keyword(",");
               final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
@@ -266,7 +266,7 @@ public class XbaseFormatter extends XtypeFormatter {
               };
               format.prepend(sep, _function_7);
               EObject _object_1 = ele_1.getObject();
-              this.format(_object_1, format);
+              format.<EObject>format(_object_1);
             }
           }
           final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {
@@ -288,7 +288,7 @@ public class XbaseFormatter extends XtypeFormatter {
     ArrayBracketsFormattingReplacer _arrayBracketsFormattingReplacer = new ArrayBracketsFormattingReplacer(_ruleCallTo);
     document.addReplacer(_arrayBracketsFormattingReplacer);
     JvmTypeReference _componentType = array.getComponentType();
-    this.format(_componentType, document);
+    document.<JvmTypeReference>format(_componentType);
   }
   
   protected void _format(final JvmTypeConstraint constraint, @Extension final IFormattableDocument document) {
@@ -300,7 +300,7 @@ public class XbaseFormatter extends XtypeFormatter {
       }
     };
     JvmTypeReference _prepend = document.<JvmTypeReference>prepend(_typeReference, _function);
-    this.format(_prepend, document);
+    document.<JvmTypeReference>format(_prepend);
   }
   
   protected void _format(final XVariableDeclaration expr, @Extension final IFormattableDocument format) {
@@ -340,9 +340,9 @@ public class XbaseFormatter extends XtypeFormatter {
     };
     format.surround(_keyword_2, _function_3);
     JvmTypeReference _type_1 = expr.getType();
-    this.format(_type_1, format);
+    format.<JvmTypeReference>format(_type_1);
     XExpression _right = expr.getRight();
-    this.format(_right, format);
+    format.<XExpression>format(_right);
   }
   
   protected void _format(final XAssignment expr, @Extension final IFormattableDocument format) {
@@ -373,9 +373,9 @@ public class XbaseFormatter extends XtypeFormatter {
     };
     format.surround(_keyword, _function_1);
     XExpression _assignable = expr.getAssignable();
-    this.format(_assignable, format);
+    format.<XExpression>format(_assignable);
     XExpression _value = expr.getValue();
-    this.format(_value, format);
+    format.<XExpression>format(_value);
   }
   
   protected void formatFeatureCallParams(final List<XExpression> params, final ISemanticRegion open, final ISemanticRegion close, @Extension final IFormattableDocument format) {
@@ -406,7 +406,7 @@ public class XbaseFormatter extends XtypeFormatter {
             }
           };
           it.<XClosure>prepend(closure, _function);
-          XbaseFormatter.this.format(closure, it);
+          it.<XClosure>format(closure);
         }
       };
       final ISubFormatter _function_1 = new ISubFormatter() {
@@ -419,7 +419,7 @@ public class XbaseFormatter extends XtypeFormatter {
             }
           };
           it.<XClosure>prepend(closure, _function);
-          XbaseFormatter.this.format(closure, it);
+          it.<XClosure>format(closure);
         }
       };
       format.formatConditionally(offset, length, _function, _function_1);
@@ -512,7 +512,7 @@ public class XbaseFormatter extends XtypeFormatter {
       EList<JvmTypeReference> _typeArguments_1 = expr.getTypeArguments();
       for (final JvmTypeReference arg : _typeArguments_1) {
         {
-          this.format(arg, format);
+          format.<JvmTypeReference>format(arg);
           ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(arg);
           ISemanticRegion _keyword_1 = _immediatelyFollowing.keyword(",");
           final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
@@ -573,7 +573,7 @@ public class XbaseFormatter extends XtypeFormatter {
       EList<JvmTypeReference> _typeArguments_1 = expr.getTypeArguments();
       for (final JvmTypeReference arg : _typeArguments_1) {
         {
-          this.format(arg, format);
+          format.<JvmTypeReference>format(arg);
           ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(arg);
           ISemanticRegion _keyword_1 = _immediatelyFollowing.keyword(",");
           final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
@@ -663,7 +663,7 @@ public class XbaseFormatter extends XtypeFormatter {
         top = _memberCallTarget;
       }
     }
-    this.format(top, format);
+    format.<EObject>format(top);
     IHiddenRegion _nextHiddenRegion = this.textRegionExtensions.nextHiddenRegion(expr);
     final IndentOnceAutowrapFormatter indentOnce = new IndentOnceAutowrapFormatter(_nextHiddenRegion);
     for (final ObjectEntry<XMemberFeatureCall, ISemanticRegion> entry : calls) {
@@ -802,7 +802,7 @@ public class XbaseFormatter extends XtypeFormatter {
         format.prepend(sep, _function_2);
         XBinaryOperation _object_1 = ele.getObject();
         XExpression _rightOperand = _object_1.getRightOperand();
-        this.format(_rightOperand, format);
+        format.<XExpression>format(_rightOperand);
       }
     }
   }
@@ -884,7 +884,7 @@ public class XbaseFormatter extends XtypeFormatter {
       format.append(_keyword_1, XbaseFormatterPreferenceKeys.whitespaceBetweenKeywordAndParenthesisSL);
     }
     XExpression _param_1 = expr.getParam();
-    this.format(_param_1, format);
+    format.<XExpression>format(_param_1);
     XExpression _expression_3 = expr.getExpression();
     this.formatBody(_expression_3, false, format);
   }
@@ -936,7 +936,7 @@ public class XbaseFormatter extends XtypeFormatter {
       format.append(_keyword_1, XbaseFormatterPreferenceKeys.whitespaceBetweenKeywordAndParenthesisSL);
     }
     XExpression _if_1 = expr.getIf();
-    this.format(_if_1, format);
+    format.<XExpression>format(_if_1);
     XExpression _else_1 = expr.getElse();
     boolean _equals = Objects.equal(_else_1, null);
     if (_equals) {
@@ -962,7 +962,7 @@ public class XbaseFormatter extends XtypeFormatter {
         };
         format.<XExpression>prepend(_else_3, _function_2);
         XExpression _else_4 = expr.getElse();
-        this.format(_else_4, format);
+        format.<XExpression>format(_else_4);
       } else {
         XExpression _else_5 = expr.getElse();
         this.formatBody(_else_5, multiline, format);
@@ -1010,7 +1010,7 @@ public class XbaseFormatter extends XtypeFormatter {
       }
     };
     XExpression _append = format.<XExpression>append(_prepend_1, _function_4);
-    this.format(_append, format);
+    format.<XExpression>format(_append);
     XExpression _eachExpression = expr.getEachExpression();
     this.formatBody(_eachExpression, true, format);
   }
@@ -1092,7 +1092,7 @@ public class XbaseFormatter extends XtypeFormatter {
     final Procedure1<XExpression> _function_5 = new Procedure1<XExpression>() {
       @Override
       public void apply(final XExpression it) {
-        XbaseFormatter.this.format(it, format);
+        format.<XExpression>format(it);
       }
     };
     IterableExtensions.<XExpression>forEach(_initExpressions, _function_5);
@@ -1105,7 +1105,7 @@ public class XbaseFormatter extends XtypeFormatter {
     };
     format.<XExpression>prepend(_expression, _function_6);
     XExpression _expression_1 = expr.getExpression();
-    this.format(_expression_1, format);
+    format.<XExpression>format(_expression_1);
     EList<XExpression> _updateExpressions = expr.getUpdateExpressions();
     XExpression _head = IterableExtensions.<XExpression>head(_updateExpressions);
     final Procedure1<IHiddenRegionFormatter> _function_7 = new Procedure1<IHiddenRegionFormatter>() {
@@ -1119,7 +1119,7 @@ public class XbaseFormatter extends XtypeFormatter {
     final Procedure1<XExpression> _function_8 = new Procedure1<XExpression>() {
       @Override
       public void apply(final XExpression it) {
-        XbaseFormatter.this.format(it, format);
+        format.<XExpression>format(it);
       }
     };
     IterableExtensions.<XExpression>forEach(_updateExpressions_1, _function_8);
@@ -1146,7 +1146,7 @@ public class XbaseFormatter extends XtypeFormatter {
       }
     };
     XExpression _append = format.<XExpression>append(_prepend, _function_1);
-    this.format(_append, format);
+    format.<XExpression>format(_append);
     XExpression _body = expr.getBody();
     this.formatBody(_body, true, format);
   }
@@ -1170,7 +1170,7 @@ public class XbaseFormatter extends XtypeFormatter {
       }
     };
     XExpression _append = format.<XExpression>append(_prepend, _function_1);
-    this.format(_append, format);
+    format.<XExpression>format(_append);
     XExpression _body = expr.getBody();
     this.formatBodyInline(_body, true, format);
   }
@@ -1283,7 +1283,7 @@ public class XbaseFormatter extends XtypeFormatter {
     };
     format.<XExpression>prepend(_expression, _function);
     XExpression _expression_1 = expr.getExpression();
-    this.format(_expression_1, format);
+    format.<XExpression>format(_expression_1);
   }
   
   protected void _format(final XReturnExpression expr, @Extension final IFormattableDocument format) {
@@ -1296,7 +1296,7 @@ public class XbaseFormatter extends XtypeFormatter {
     };
     format.<XExpression>prepend(_expression, _function);
     XExpression _expression_1 = expr.getExpression();
-    this.format(_expression_1, format);
+    format.<XExpression>format(_expression_1);
   }
   
   protected void _format(final XTryCatchFinallyExpression expr, @Extension final IFormattableDocument format) {
@@ -1323,7 +1323,7 @@ public class XbaseFormatter extends XtypeFormatter {
           }
         };
         JvmFormalParameter _append = format.<JvmFormalParameter>append(_prepend, _function_1);
-        this.format(_append, format);
+        format.<JvmFormalParameter>format(_append);
         boolean _or = false;
         EList<XCatchClause> _catchClauses_1 = expr.getCatchClauses();
         XCatchClause _last = IterableExtensions.<XCatchClause>last(_catchClauses_1);
@@ -1360,7 +1360,7 @@ public class XbaseFormatter extends XtypeFormatter {
       format.<JvmTypeReference>append(_parameterType, _function);
     }
     JvmTypeReference _parameterType_1 = expr.getParameterType();
-    this.format(_parameterType_1, format);
+    format.<JvmTypeReference>format(_parameterType_1);
   }
   
   protected void _format(final XExpression expr, @Extension final IFormattableDocument format) {
@@ -1370,7 +1370,7 @@ public class XbaseFormatter extends XtypeFormatter {
       if (!_matched) {
         if (obj instanceof XExpression) {
           _matched=true;
-          this.format(obj, format);
+          format.<XExpression>format(((XExpression)obj));
         }
       }
     }
@@ -1469,9 +1469,9 @@ public class XbaseFormatter extends XtypeFormatter {
       for (final XCasePart c : _cases_3) {
         {
           XExpression _case = c.getCase();
-          this.format(_case, format);
+          format.<XExpression>format(_case);
           XExpression _then = c.getThen();
-          this.format(_then, format);
+          format.<XExpression>format(_then);
           XExpression _then_1 = c.getThen();
           boolean _equals = Objects.equal(_then_1, null);
           if (_equals) {
@@ -1521,7 +1521,7 @@ public class XbaseFormatter extends XtypeFormatter {
           }
         };
         XExpression _surround = format.<XExpression>surround(_default_3, _function_6);
-        this.format(_surround, format);
+        format.<XExpression>format(_surround);
       }
     } else {
       if (caseSL) {
@@ -1549,9 +1549,9 @@ public class XbaseFormatter extends XtypeFormatter {
         for (final XCasePart c_1 : _cases_5) {
           {
             XExpression _case = c_1.getCase();
-            this.format(_case, format);
+            format.<XExpression>format(_case);
             XExpression _then = c_1.getThen();
-            this.format(_then, format);
+            format.<XExpression>format(_then);
             XExpression _then_1 = c_1.getThen();
             final Procedure1<IHiddenRegionFormatter> _function_9 = new Procedure1<IHiddenRegionFormatter>() {
               @Override
@@ -1601,7 +1601,7 @@ public class XbaseFormatter extends XtypeFormatter {
             }
           };
           XExpression _prepend_1 = format.<XExpression>prepend(_default_5, _function_11);
-          this.format(_prepend_1, format);
+          format.<XExpression>format(_prepend_1);
         }
         final Procedure1<IHiddenRegionFormatter> _function_12 = new Procedure1<IHiddenRegionFormatter>() {
           @Override
@@ -1643,7 +1643,7 @@ public class XbaseFormatter extends XtypeFormatter {
         for (final XCasePart c_2 : _cases_7) {
           {
             XExpression _case = c_2.getCase();
-            this.format(_case, format);
+            format.<XExpression>format(_case);
             XExpression _then = c_2.getThen();
             this.formatBodyParagraph(_then, format);
             ISemanticRegionsFinder _regionFor_5 = this.textRegionExtensions.regionFor(c_2);
@@ -1773,7 +1773,7 @@ public class XbaseFormatter extends XtypeFormatter {
         EList<JvmFormalParameter> _declaredFormalParameters_1 = expr.getDeclaredFormalParameters();
         for (final JvmFormalParameter param : _declaredFormalParameters_1) {
           {
-            this.format(param, format);
+            format.<JvmFormalParameter>format(param);
             ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(param);
             ISemanticRegion _keyword = _immediatelyFollowing.keyword(",");
             final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
@@ -1913,7 +1913,7 @@ public class XbaseFormatter extends XtypeFormatter {
               it.append(last, _function_1);
               for (final XExpression c : children) {
                 {
-                  XbaseFormatter.this.format(c, it);
+                  it.<XExpression>format(c);
                   ISemanticRegionFinder _immediatelyFollowing = XbaseFormatter.this.textRegionExtensions.immediatelyFollowing(c);
                   final ISemanticRegion semicolon = _immediatelyFollowing.keyword(";");
                   boolean _notEquals = (!Objects.equal(semicolon, null));
@@ -2017,7 +2017,7 @@ public class XbaseFormatter extends XtypeFormatter {
         doc.<XExpression>prepend(expr, _function_2);
       }
     }
-    this.format(expr, doc);
+    doc.<XExpression>format(expr);
   }
   
   protected void formatBodyInline(final XExpression expr, final boolean forceMultiline, @Extension final IFormattableDocument doc) {
@@ -2069,7 +2069,7 @@ public class XbaseFormatter extends XtypeFormatter {
         doc.<XExpression>surround(expr, _function_3);
       }
     }
-    this.format(expr, doc);
+    doc.<XExpression>format(expr);
   }
   
   protected void formatBodyParagraph(final XExpression expr, @Extension final IFormattableDocument doc) {
@@ -2109,7 +2109,7 @@ public class XbaseFormatter extends XtypeFormatter {
       };
       doc.<XExpression>append(_surround, _function_3);
     }
-    this.format(expr, doc);
+    doc.<XExpression>format(expr);
   }
   
   protected void _format(final XInstanceOfExpression expr, @Extension final IFormattableDocument doc) {
@@ -2123,9 +2123,9 @@ public class XbaseFormatter extends XtypeFormatter {
     };
     doc.surround(_keyword, _function);
     XExpression _expression = expr.getExpression();
-    this.format(_expression, doc);
+    doc.<XExpression>format(_expression);
     JvmTypeReference _type = expr.getType();
-    this.format(_type, doc);
+    doc.<JvmTypeReference>format(_type);
   }
   
   protected void formatExpressionsMultiline(final Collection<? extends XExpression> expressions, final ISemanticRegion open, final ISemanticRegion close, @Extension final IFormattableDocument format) {
@@ -2149,7 +2149,7 @@ public class XbaseFormatter extends XtypeFormatter {
       format.append(open, XbaseFormatterPreferenceKeys.blankLinesAroundExpression);
       for (final XExpression child : expressions) {
         {
-          this.format(child, format);
+          format.<XExpression>format(child);
           ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(child);
           final ISemanticRegion sem = _immediatelyFollowing.keyword(";");
           boolean _notEquals = (!Objects.equal(sem, null));
@@ -2190,7 +2190,7 @@ public class XbaseFormatter extends XtypeFormatter {
       format.append(open, _function_1);
       for (final XExpression child : expressions) {
         {
-          this.format(child, format);
+          format.<XExpression>format(child);
           ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(child);
           final ISemanticRegion sem = _immediatelyFollowing.keyword(";");
           boolean _notEquals = (!Objects.equal(sem, null));

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XtypeFormatter.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XtypeFormatter.java
@@ -50,7 +50,7 @@ public class XtypeFormatter extends AbstractFormatter2 {
     EList<JvmTypeReference> _paramTypes = func.getParamTypes();
     for (final JvmTypeReference param : _paramTypes) {
       {
-        this.format(param, document);
+        document.<JvmTypeReference>format(param);
         ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(param);
         ISemanticRegion _keyword_1 = _immediatelyFollowing.keyword(",");
         final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
@@ -100,7 +100,7 @@ public class XtypeFormatter extends AbstractFormatter2 {
     };
     document.append(_keyword_2, _function_3);
     JvmTypeReference _returnType = func.getReturnType();
-    this.format(_returnType, document);
+    document.<JvmTypeReference>format(_returnType);
   }
   
   protected void _format(final JvmParameterizedTypeReference ref, @Extension final IFormattableDocument document) {
@@ -116,7 +116,7 @@ public class XtypeFormatter extends AbstractFormatter2 {
     EList<JvmTypeReference> _arguments = ref.getArguments();
     for (final JvmTypeReference arg : _arguments) {
       {
-        this.format(arg, document);
+        document.<JvmTypeReference>format(arg);
         ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(arg);
         ISemanticRegion _keyword_1 = _immediatelyFollowing.keyword(",");
         final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
@@ -168,7 +168,7 @@ public class XtypeFormatter extends AbstractFormatter2 {
     }
     EList<JvmTypeConstraint> _constraints_1 = ref.getConstraints();
     for (final JvmTypeConstraint c : _constraints_1) {
-      this.format(c, document);
+      document.<JvmTypeConstraint>format(c);
     }
   }
   
@@ -183,7 +183,7 @@ public class XtypeFormatter extends AbstractFormatter2 {
           }
         };
         document.<JvmTypeConstraint>prepend(c, _function);
-        this.format(c, document);
+        document.<JvmTypeConstraint>format(c);
       }
     }
   }
@@ -192,7 +192,7 @@ public class XtypeFormatter extends AbstractFormatter2 {
     EList<XImportDeclaration> _importDeclarations = section.getImportDeclarations();
     for (final XImportDeclaration imp : _importDeclarations) {
       {
-        this.format(imp, format);
+        format.<XImportDeclaration>format(imp);
         EList<XImportDeclaration> _importDeclarations_1 = section.getImportDeclarations();
         XImportDeclaration _last = IterableExtensions.<XImportDeclaration>last(_importDeclarations_1);
         boolean _notEquals = (!Objects.equal(imp, _last));

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/IFormattableDocument.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/IFormattableDocument.java
@@ -161,4 +161,8 @@ public interface IFormattableDocument {
 
 	<T1 extends ISemanticRegion, T2 extends ISemanticRegion> // 
 	Pair<T1, T2> interior(Pair<T1, T2> pair, Procedure1<? super IHiddenRegionFormatter> init);
+
+	<T extends EObject> T interior(T object, Procedure1<? super IHiddenRegionFormatter> init);
+
+	<T> T format(T obj);
 }


### PR DESCRIPTION
- on exception, only cancel formatting of the current subtree
- don't format EObjects located outside the requested regions
- introduce document.interior(EObject, )
- introduce document.format for convenience
- introduce formatter.shouldFormat()

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@itemis.de>