### PR TITLE
[465080] Unpack classpath containers when scanning projects

### DIFF
--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JdtClasspathUriResolver.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JdtClasspathUriResolver.java
@@ -128,7 +128,7 @@ public class JdtClasspathUriResolver implements IClasspathUriResolver {
 			if (resourceFromProjectRoot != null && resourceFromProjectRoot.exists()) {
 				return createPlatformResourceURI(resourceFromProjectRoot);
 			}
-			for(IClasspathEntry entry: javaProject.getRawClasspath()) {
+			for(IClasspathEntry entry: javaProject.getResolvedClasspath(true)) {
 				if (entry.getEntryKind() == IClasspathEntry.CPE_PROJECT) {
 					if (includeAll || entry.isExported()) {
 						IResource referencedProject = project.getWorkspace().getRoot().findMember(entry.getPath());


### PR DESCRIPTION
During classpath URI resolution, we may need to check project
roots if the file is not in a source folder but will be packaged.
Therefore we need to check the current project and all referenced
projects for a resource in the project root. To determine the
referenced projects, we need to unfold classpath containers like
the plugin classpath container.

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=465080