### PR TITLE
Fix IssueUtil Since default value for offset was -1 and default value fo...

### DIFF
--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/IssueUtil.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/IssueUtil.java
@@ -57,7 +57,7 @@ public class IssueUtil {
 				issue.setLength((Integer) endOffset - (Integer) offset); 
 			} else {
 				issue.setOffset(-1);
-				issue.setLength(-1);
+				issue.setLength(0);
 			}
 			Object code = attributes.get(Issue.CODE_KEY);
 			issue.setCode(code instanceof String ? (String) code:null);


### PR DESCRIPTION
...r end offset -1 so the default value for length is -1 - -1 = 0 so we change that to 0 as the code in setLength checks for length < 0 and logs an error for that. Then it sets the value to 0.

Signed-off-by: Holger Schill <holger.schill@itemis.de>