### PR TITLE
[467477] Guard against the internal NoValue: java.lang.Object

### DIFF
--- a/plugins/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtBasedTypeFactory.java
+++ b/plugins/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtBasedTypeFactory.java
@@ -789,11 +789,11 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 			InternalEList<JvmAnnotationReference> values = (InternalEList<JvmAnnotationReference>)annotationValue.getValues();
 			if (value instanceof Object[]) {
 				for (Object element : (Object[])value) {
-					if (element != null) {
+					if (element instanceof IAnnotationBinding) {
 						values.addUnique(createAnnotationReference((IAnnotationBinding)element));
 					}
 				}
-			} else {
+			} else if (value instanceof IAnnotationBinding) {
 				values.addUnique(createAnnotationReference((IAnnotationBinding)value));
 			}
 		}
@@ -807,7 +807,7 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 			InternalEList<Object> values = (InternalEList<Object>)(InternalEList<?>)annotationValue.getValues();
 			if (value instanceof Object[]) {
 				for (Object element : (Object[])value) {
-					if (element != null) {
+					if (element instanceof Character) {
 						values.addUnique(element);
 					}
 				}
@@ -833,7 +833,7 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 				}
 			} else if (value instanceof Double) {
 				values.addUnique(value);
-			} else {
+			} else if (value instanceof Number) {
 				values.addUnique(((Number)value).doubleValue());
 			}
 		}
@@ -855,7 +855,7 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 				}
 			} else if (value instanceof Float) {
 				values.addUnique(value);
-			} else {
+			} else if (value instanceof Number) {
 				values.addUnique(((Number)value).floatValue());
 			}
 		}
@@ -877,7 +877,7 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 				}
 			} else if (value instanceof Short) {
 				values.addUnique(value);
-			} else {
+			} else if (value instanceof Number) {
 				values.addUnique(((Number)value).shortValue());
 			}
 		}
@@ -899,7 +899,7 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 				}
 			} else if (value instanceof Byte) {
 				values.addUnique(value);
-			} else {
+			} else if (value instanceof Number) {
 				values.addUnique(((Number)value).byteValue());
 			}
 		}
@@ -921,7 +921,7 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 				}
 			} else if (value instanceof Long) {
 				values.addUnique(value);
-			} else {
+			} else if (value instanceof Number) {
 				values.addUnique(((Number)value).longValue());
 			}
 		}
@@ -935,7 +935,7 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 			InternalEList<Object> values = (InternalEList<Object>)(InternalEList<?>)annotationValue.getValues();
 			if (value instanceof Object[]) {
 				for (Object element : (Object[])value) {
-					if (element != null) {
+					if (element instanceof Boolean) {
 						values.addUnique(element);
 					}
 				}
@@ -961,7 +961,7 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 				}
 			} else if (value instanceof Integer) {
 				values.addUnique(value);
-			} else {
+			} else if (value instanceof Number) {
 				values.addUnique(((Number)value).intValue());
 			}
 		}
@@ -974,11 +974,11 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 			InternalEList<JvmTypeReference> values = (InternalEList<JvmTypeReference>)annotationValue.getValues();
 			if (value instanceof Object[]) {
 				for (Object element : (Object[])value) {
-					if (element != null) {
+					if (element instanceof ITypeBinding) {
 						values.addUnique(createTypeReference((ITypeBinding)element));
 					}
 				}
-			} else {
+			} else if (value instanceof ITypeBinding) {
 				values.addUnique(createTypeReference((ITypeBinding)value));
 			}
 		}
@@ -992,7 +992,7 @@ public class JdtBasedTypeFactory implements ITypeFactory<IType, JvmDeclaredType>
 			InternalEList<Object> values = (InternalEList<Object>)(InternalEList<?>)annotationValue.getValues();
 			if (value instanceof Object[]) {
 				for (Object element : (Object[])value) {
-					if (element != null) {
+					if (element instanceof String) {
 						values.addUnique(element);
 					}
 				}

--- a/tests/org.eclipse.xtext.common.types.tests/tests/org/eclipse/xtext/common/types/access/jdt/SourceBasedJdtTypeProviderTest.java
+++ b/tests/org.eclipse.xtext.common.types.tests/tests/org/eclipse/xtext/common/types/access/jdt/SourceBasedJdtTypeProviderTest.java
@@ -13,7 +13,6 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
@@ -163,6 +162,32 @@ public class SourceBasedJdtTypeProviderTest extends AbstractJdtTypeProviderTest 
 			assertTrue(value instanceof JvmTypeAnnotationValue);
 			List<JvmTypeReference> typeLiterals = ((JvmTypeAnnotationValue) value).getValues();
 			assertEquals(2, typeLiterals.size());
+		} finally {
+			javaFile.setContents(new StringInputStream(content), IResource.NONE, new NullProgressMonitor());
+		}
+	}
+	
+	@Test public void testClassAnnotationValue_09() throws Exception {
+		IJavaProject project = projectProvider.getJavaProject(null);
+		String typeName = EmptyAbstractClass.class.getName();
+		IFile javaFile = (IFile) project.getProject().findMember(new Path("src/" + typeName.replace('.', '/') + ".java"));
+		assertNotNull(javaFile);
+		String content = Files.readStreamIntoString(javaFile.getContents());
+		try {
+			String newContent = content.replace(
+					"public abstract ", 
+					"@TestAnnotation( classArray = ) public abstract ");
+			javaFile.setContents(new StringInputStream(newContent), IResource.NONE, new NullProgressMonitor());
+			
+			JvmDeclaredType type = (JvmDeclaredType) getTypeProvider().findTypeByName(typeName);
+			List<JvmAnnotationReference> annotations = type.getAnnotations();
+			assertEquals(1, annotations.size());
+			JvmAnnotationReference annotation = annotations.get(0);
+			assertEquals(1, annotation.getExplicitValues().size());
+			JvmAnnotationValue value = annotation.getExplicitValues().get(0);
+			assertTrue(value instanceof JvmTypeAnnotationValue);
+			List<JvmTypeReference> typeLiterals = ((JvmTypeAnnotationValue) value).getValues();
+			assertEquals(0, typeLiterals.size());
 		} finally {
 			javaFile.setContents(new StringInputStream(content), IResource.NONE, new NullProgressMonitor());
 		}


### PR DESCRIPTION
JDT may expose an internal represenation of a missing annotation
value wrapped in an array.

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=467477

Signed-off-by: szarnekow <Sebastian.Zarnekow@itemis.de>