### PR TITLE
[468430] Move the initialization of Storage2URIMapperJavaImpl to the JavaCoreRegistrar, which gets called on Activator.start. Run the initialization in its own thread.

### DIFF
--- a/plugins/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/JavaCoreListenerRegistrar.java
+++ b/plugins/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/JavaCoreListenerRegistrar.java
@@ -28,6 +28,13 @@ public class JavaCoreListenerRegistrar implements IEagerContribution {
 	@Override
 	public void initialize() {
 		JavaCore.addElementChangedListener(classpathChangeListener);
+		new Thread(new Runnable() {
+			@Override
+			public void run() {
+				storage2UriMapperJavaImpl.initializeCache();
+				JavaCore.addElementChangedListener(storage2UriMapperJavaImpl);
+			}
+		}).start();
 	}
 
 	@Override

--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/Storage2UriMapperJavaImpl.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/Storage2UriMapperJavaImpl.java
@@ -453,14 +453,17 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 	@Override
 	public void initializeCache() {
 		if(!isInitialized) {
-			for(IProject project: workspace.getRoot().getProjects()) {
-				if(project.isAccessible() && JavaProject.hasJavaNature(project)) {
-					IJavaProject javaProject = JavaCore.create(project);
-					updateCache(javaProject);
+			synchronized (this) {
+				if(!isInitialized) {
+					for(IProject project: workspace.getRoot().getProjects()) {
+						if(project.isAccessible() && JavaProject.hasJavaNature(project)) {
+							IJavaProject javaProject = JavaCore.create(project);
+							updateCache(javaProject);
+						}
+					}
+					isInitialized = true;
 				}
 			}
-			JavaCore.addElementChangedListener(this, ElementChangedEvent.POST_CHANGE);
-			isInitialized = true;
 		}
 	}
 	


### PR DESCRIPTION
Signed-off-by: Sven Efftinge <sven.efftinge@itemis.de>