### PR TITLE
[467565] Improved performance for case insensitive languages

### DIFF
--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/scoping/batch/ITypeImporter.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/scoping/batch/ITypeImporter.java
@@ -28,12 +28,16 @@ public interface ITypeImporter {
 	void importStatic(JvmDeclaredType type, String memberName);
 	
 	/**
-	 * Imports all static members of the given type.
+	 * Imports all static members of the given type as extensions.
+	 * If the strict flag is set to false, the members will also be available
+	 * as static imports.
 	 */
 	void importStaticExtension(JvmDeclaredType type, boolean strict);
 	
 	/**
-	 * Imports the static members of the given type with the given name.
+	 * Imports the static members of the given type with the given name as extensions.
+	 * If the strict flag is set to false, the imported members will also be available
+	 * as static imports.
 	 */
 	void importStaticExtension(JvmDeclaredType type, String memberName, boolean strict);
 	

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/DefaultBatchTypeResolver.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/DefaultBatchTypeResolver.java
@@ -23,7 +23,6 @@ import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.typesystem.IResolvedTypes;
 
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/scoping/IScope.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/scoping/IScope.java
@@ -26,8 +26,8 @@ import org.eclipse.xtext.resource.IEObjectDescription;
  * {@link org.eclipse.emf.ecore.EObject context object} and a {@link org.eclipse.emf.ecore.EReference cross reference}.</p>
  * 
  * <p>Clients can use several different query operations to select elements from a scope.
- * They are free to filter the result further to a set of valid or interesting depending on the actual use case.
- * A linker may want to create links to invalid objects to provide while content assist should filter these
+ * They are free to filter the result further to a set of valid or interesting elements depending on the actual use case.
+ * A linker may want to create links to invalid objects to provide better error messages while content assist should filter these
  * instances.</p>
  * <ul>
  * <li>Query by {@link QualifiedName name}: Scopes can be queried by name. Implementations should answer this query fast.</li>

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/scoping/IScopeProvider.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/scoping/IScopeProvider.java
@@ -28,7 +28,7 @@ public interface IScopeProvider {
 	 * @param context the element from which an element shall be referenced. It doesn't need to be the element
 	 * 		  containing the reference, it is just used to find the most inner scope for given {@link EReference}.
 	 * @param reference the reference for which to get the scope.
-	 * @return {@link IScope} representing the inner most {@link IScope} for the
+	 * @return {@link IScope} representing the innermost {@link IScope} for the
 	 *         passed context and reference. Note for implementors: The result may not be <code>null</code>.
 	 *         Return <code>IScope.NULLSCOPE</code> instead.
 	 */

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/scoping/impl/AbstractScope.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/scoping/impl/AbstractScope.java
@@ -179,9 +179,7 @@ public abstract class AbstractScope implements IScope {
 			@Override
 			public boolean apply(IEObjectDescription input) {
 				if (isIgnoreCase()) {
-					QualifiedName lowerCase = name.toLowerCase();
-					QualifiedName inputLowerCase = input.getName().toLowerCase();
-					return lowerCase.equals(inputLowerCase);
+					return name.equalsIgnoreCase(input.getName());
 				} else {
 					return name.equals(input.getName());
 				}

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/naming/QualifiedNameTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/naming/QualifiedNameTest.java
@@ -7,6 +7,14 @@
  *******************************************************************************/
 package org.eclipse.xtext.naming;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+
+import org.eclipse.emf.ecore.resource.impl.BinaryResourceImpl;
+import org.eclipse.emf.ecore.resource.impl.BinaryResourceImpl.EObjectInputStream;
+import org.eclipse.emf.ecore.resource.impl.BinaryResourceImpl.EObjectOutputStream;
 import org.eclipse.xtext.naming.IQualifiedNameConverter.DefaultImpl;
 import org.eclipse.xtext.scoping.impl.ImportNormalizer;
 import org.junit.Assert;
@@ -24,6 +32,25 @@ public class QualifiedNameTest extends Assert {
 		QualifiedName name = impl.toQualifiedName(".");
 		ImportNormalizer normalizer = new ImportNormalizer(QualifiedName.create("Test"), true, false);
 		assertNull(normalizer.resolve(name));
+	}
+	
+	@Test public void testDeserializeAsLowerCase() throws IOException {
+		QualifiedName upperCase = QualifiedName.create("A", "B");
+		QualifiedName lowerCase = upperCase.toLowerCase();
+		
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		EObjectOutputStream out = new BinaryResourceImpl.EObjectOutputStream(bos, Collections.emptyMap());
+		upperCase.writeToStream(out);
+		lowerCase.writeToStream(out);
+		out.flush();
+		
+		EObjectInputStream in = new BinaryResourceImpl.EObjectInputStream(new ByteArrayInputStream(bos.toByteArray()), Collections.emptyMap());
+		QualifiedName readUpperCase = QualifiedName.createFromStream(in);
+		QualifiedName readLowerCase = QualifiedName.createFromStream(in);
+		assertEquals(QualifiedName.class.getName(), readUpperCase.getClass().getName());
+		assertEquals(QualifiedName.class.getName() + "$QualifiedNameLowerCase", readLowerCase.getClass().getName());
+		assertEquals(upperCase, readUpperCase);
+		assertEquals(lowerCase, readLowerCase);
 	}
 
 	@Test public void testCreateNull() {


### PR DESCRIPTION
- Use QualifiedName.equalsIgnoreCase if appropriate
- Deserialize lowercase QN as lowercase instances from index

see https://bugs.eclipse.org/bugs/show_bug.cgi?id=467565