### PR TITLE
[serilizer] fixed two bugs spotted by findbugs

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/analysis/GrammarConstraintProvider.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/analysis/GrammarConstraintProvider.java
@@ -1036,7 +1036,7 @@ public class GrammarConstraintProvider implements IGrammarConstraintProvider {
 				else
 					return isOptional ? null : INVALID;
 			} else
-				new ConstraintElement(context, getConstraintElementType(ele), ele);
+				return null; //new ConstraintElement(context, getConstraintElementType(ele), ele);
 		} else if (ele instanceof RuleCall) {
 			RuleCall rc = (RuleCall) ele;
 			if (GrammarUtil.isUnassignedEObjectRuleCall(rc)) {

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/sequencer/GenericSyntacticSequencer.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/sequencer/GenericSyntacticSequencer.java
@@ -33,7 +33,7 @@ public class GenericSyntacticSequencer extends AbstractSyntacticSequencer {
 			if (rule.getAlternatives() instanceof Alternatives)
 				for (AbstractElement ele : ((Alternatives) rule.getAlternatives()).getElements())
 					if (ele instanceof Keyword)
-						((Keyword) ele).getValue();
+						return ((Keyword) ele).getValue();
 		}
 		return "";
 	}


### PR DESCRIPTION
- fixed GenericSyntacticSequencer
- didn't modify behaviour of GrammarConstraintProvider to avoid 
  regressions; I'd rather deprecate the GrammarConstraintProvider.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@itemis.de>