### PR TITLE
add createFileUri(File) helper method

### DIFF
--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/batch/XtendBatchCompiler.java
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/batch/XtendBatchCompiler.java
@@ -58,6 +58,7 @@ import org.eclipse.xtext.resource.impl.ResourceSetBasedResourceDescriptions;
 import org.eclipse.xtext.resource.persistence.StorageAwareResource;
 import org.eclipse.xtext.util.Files;
 import org.eclipse.xtext.util.Strings;
+import org.eclipse.xtext.util.UriUtil;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.IResourceValidator;
 import org.eclipse.xtext.validation.Issue;
@@ -232,7 +233,7 @@ public class XtendBatchCompiler {
 	 * @since 2.8
 	 */
 	public void setBasePath(String basePath) {
-		this.baseURI = URI.createFileURI(new File(basePath).getAbsolutePath());
+		this.baseURI = UriUtil.createFolderURI(new File(basePath));
 	}
 
 	public void setOutputPath(String outputPath) {

--- a/plugins/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/StandaloneBuilder.xtend
+++ b/plugins/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/StandaloneBuilder.xtend
@@ -36,9 +36,8 @@ import org.eclipse.xtext.resource.clustering.DynamicResourceClusteringPolicy
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsData
 import org.eclipse.xtext.resource.persistence.StorageAwareResource
 import org.eclipse.xtext.util.CancelIndicator
+import org.eclipse.xtext.util.UriUtil
 import org.eclipse.xtext.validation.CheckMode
-
-import static extension org.eclipse.emf.common.util.URI.createFileURI
 
 class StandaloneBuilder {
 	static final Logger LOG = Logger.getLogger(StandaloneBuilder);
@@ -270,9 +269,9 @@ class StandaloneBuilder {
 
 	def protected registerCurrentSource(URI uri) {
 		val fsa = uri.languageAccess.fileSystemAccess
-		val absoluteSource = sourceDirs.map[new File(it).absolutePath.createFileURI.toString].filter [
-			uri.toString.startsWith(it)
-		].reduce[longest, current|if(current.length > longest.length) current else longest]?.createFileURI
+		val absoluteSource = sourceDirs
+			.map[UriUtil.createFolderURI(new File(it))]
+			.findFirst [UriUtil.isPrefixOf(it, uri)]
 		if (absoluteSource == null) {
 			throw new IllegalStateException(
 				'''Resource «uri» is not contained in any of the known source folders «sourceDirs».''')

--- a/plugins/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/ResourceURICollector.xtend
+++ b/plugins/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/incremental/ResourceURICollector.xtend
@@ -9,7 +9,6 @@ package org.eclipse.xtext.builder.standalone.incremental
 
 import java.io.File
 import java.io.IOException
-import java.net.URLClassLoader
 import java.util.Set
 import java.util.jar.JarFile
 import java.util.jar.Manifest
@@ -62,7 +61,7 @@ import org.eclipse.xtext.util.internal.Log
 					name = name.substring(0, indexOf);
 				if (EcorePlugin.getPlatformResourceMap().containsKey(name))
 					return;
-				val String path = "archive:" + file.asURI + "!/";
+				val String path = "archive:" + URI.createFileURI(file.absolutePath) + "!/";
 				EcorePlugin.getPlatformResourceMap().put(name, URI.createURI(path));
 			}
 		} catch (ZipException e) {
@@ -77,16 +76,5 @@ import org.eclipse.xtext.util.internal.Log
 				LOG.error(jarFile, e);
 			}
 		}
-	}
-
-	/**
-	 * Unfortunately, {@link File#toURI} does not append '/' to directories, making it useless for the {@link URLClassLoader}.
-	 */
-	static def asURI(File file) {
-		val uri = URI.createFileURI(file.canonicalFile.absolutePath)
-		if(file.isDirectory)
-			uri.appendSegment('')
-		else 
-			uri
 	}
 }

--- a/plugins/org.eclipse.xtext.builder.standalone/xtend-gen/org/eclipse/xtext/builder/standalone/StandaloneBuilder.java
+++ b/plugins/org.eclipse.xtext.builder.standalone/xtend-gen/org/eclipse/xtext/builder/standalone/StandaloneBuilder.java
@@ -56,6 +56,7 @@ import org.eclipse.xtext.resource.impl.ResourceDescriptionsData;
 import org.eclipse.xtext.resource.persistence.IResourceStorageFacade;
 import org.eclipse.xtext.resource.persistence.StorageAwareResource;
 import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.util.UriUtil;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.IResourceValidator;
 import org.eclipse.xtext.validation.Issue;
@@ -63,7 +64,6 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
-import org.eclipse.xtext.xbase.lib.Functions.Function2;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.MapExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
@@ -481,45 +481,21 @@ public class StandaloneBuilder {
   protected void registerCurrentSource(final URI uri) {
     LanguageAccess _languageAccess = this.languageAccess(uri);
     final JavaIoFileSystemAccess fsa = this.getFileSystemAccess(_languageAccess);
-    final Function1<String, String> _function = new Function1<String, String>() {
+    final Function1<String, URI> _function = new Function1<String, URI>() {
       @Override
-      public String apply(final String it) {
+      public URI apply(final String it) {
         File _file = new File(it);
-        String _absolutePath = _file.getAbsolutePath();
-        URI _createFileURI = URI.createFileURI(_absolutePath);
-        return _createFileURI.toString();
+        return UriUtil.createFolderURI(_file);
       }
     };
-    Iterable<String> _map = IterableExtensions.<String, String>map(this.sourceDirs, _function);
-    final Function1<String, Boolean> _function_1 = new Function1<String, Boolean>() {
+    Iterable<URI> _map = IterableExtensions.<String, URI>map(this.sourceDirs, _function);
+    final Function1<URI, Boolean> _function_1 = new Function1<URI, Boolean>() {
       @Override
-      public Boolean apply(final String it) {
-        String _string = uri.toString();
-        return Boolean.valueOf(_string.startsWith(it));
+      public Boolean apply(final URI it) {
+        return Boolean.valueOf(UriUtil.isPrefixOf(it, uri));
       }
     };
-    Iterable<String> _filter = IterableExtensions.<String>filter(_map, _function_1);
-    final Function2<String, String, String> _function_2 = new Function2<String, String, String>() {
-      @Override
-      public String apply(final String longest, final String current) {
-        String _xifexpression = null;
-        int _length = current.length();
-        int _length_1 = longest.length();
-        boolean _greaterThan = (_length > _length_1);
-        if (_greaterThan) {
-          _xifexpression = current;
-        } else {
-          _xifexpression = longest;
-        }
-        return _xifexpression;
-      }
-    };
-    String _reduce = IterableExtensions.<String>reduce(_filter, _function_2);
-    URI _createFileURI = null;
-    if (_reduce!=null) {
-      _createFileURI=URI.createFileURI(_reduce);
-    }
-    final URI absoluteSource = _createFileURI;
+    final URI absoluteSource = IterableExtensions.<URI>findFirst(_map, _function_1);
     boolean _equals = Objects.equal(absoluteSource, null);
     if (_equals) {
       StringConcatenation _builder = new StringConcatenation();

--- a/plugins/org.eclipse.xtext.builder.standalone/xtend-gen/org/eclipse/xtext/builder/standalone/incremental/ResourceURICollector.java
+++ b/plugins/org.eclipse.xtext.builder.standalone/xtend-gen/org/eclipse/xtext/builder/standalone/incremental/ResourceURICollector.java
@@ -13,7 +13,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import java.io.File;
 import java.io.IOException;
-import java.net.URLClassLoader;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -136,8 +135,9 @@ public class ResourceURICollector {
         if (_containsKey) {
           return;
         }
-        URI _asURI = ResourceURICollector.asURI(file);
-        String _plus = ("archive:" + _asURI);
+        String _absolutePath = file.getAbsolutePath();
+        URI _createFileURI = URI.createFileURI(_absolutePath);
+        String _plus = ("archive:" + _createFileURI);
         final String path = (_plus + "!/");
         Map<String, URI> _platformResourceMap_1 = EcorePlugin.getPlatformResourceMap();
         URI _createURI = URI.createURI(path);
@@ -146,14 +146,14 @@ public class ResourceURICollector {
     } catch (final Throwable _t) {
       if (_t instanceof ZipException) {
         final ZipException e = (ZipException)_t;
-        String _absolutePath = file.getAbsolutePath();
-        String _plus_1 = ("Could not open Jar file " + _absolutePath);
+        String _absolutePath_1 = file.getAbsolutePath();
+        String _plus_1 = ("Could not open Jar file " + _absolutePath_1);
         String _plus_2 = (_plus_1 + ".");
         ResourceURICollector.LOG.info(_plus_2);
       } else if (_t instanceof Exception) {
         final Exception e_1 = (Exception)_t;
-        String _absolutePath_1 = file.getAbsolutePath();
-        ResourceURICollector.LOG.error(_absolutePath_1, e_1);
+        String _absolutePath_2 = file.getAbsolutePath();
+        ResourceURICollector.LOG.error(_absolutePath_2, e_1);
       } else {
         throw Exceptions.sneakyThrow(_t);
       }
@@ -171,31 +171,6 @@ public class ResourceURICollector {
           throw Exceptions.sneakyThrow(_t_1);
         }
       }
-    }
-  }
-  
-  /**
-   * Unfortunately, {@link File#toURI} does not append '/' to directories, making it useless for the {@link URLClassLoader}.
-   */
-  public static URI asURI(final File file) {
-    try {
-      URI _xblockexpression = null;
-      {
-        File _canonicalFile = file.getCanonicalFile();
-        String _absolutePath = _canonicalFile.getAbsolutePath();
-        final URI uri = URI.createFileURI(_absolutePath);
-        URI _xifexpression = null;
-        boolean _isDirectory = file.isDirectory();
-        if (_isDirectory) {
-          _xifexpression = uri.appendSegment("");
-        } else {
-          _xifexpression = uri;
-        }
-        _xblockexpression = _xifexpression;
-      }
-      return _xblockexpression;
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
     }
   }
   

--- a/plugins/org.eclipse.xtext.util/src/org/eclipse/xtext/util/UriUtil.java
+++ b/plugins/org.eclipse.xtext.util/src/org/eclipse/xtext/util/UriUtil.java
@@ -7,12 +7,23 @@
  *******************************************************************************/
 package org.eclipse.xtext.util;
 
+import java.io.File;
+
 import org.eclipse.emf.common.util.URI;
 
 /**
  * @noreference This class is not intended to be referenced by clients.
  */
 public class UriUtil {
+	/**
+	 * A URI is a prefix of another URI if:
+	 * <br/>
+	 * <ul>
+	 * 	<li>Both have the same scheme</li>
+	 * 	<li>The prefix ends with a trailing separator</li>
+	 * 	<li>The segments of both URIs match up to the prefix's length</li>
+	 * </ul>
+	 */
 	public static boolean isPrefixOf(URI prefix, URI uri) {
 		if (prefix.scheme() == null || !prefix.scheme().equals(uri.scheme()))
 			return false;
@@ -20,7 +31,7 @@ public class UriUtil {
 		String[] uriSeg = uri.segments();
 		if (prefixSeg.length == 0 || uriSeg.length == 0)
 			return false;
-		if (!"".equals(prefixSeg[prefixSeg.length - 1])) // this is true when the URI has a trailing slash ("/").
+		if (!prefix.hasTrailingPathSeparator())
 			return false;
 		if (uriSeg.length < prefixSeg.length - 1)
 			return false;
@@ -28,5 +39,19 @@ public class UriUtil {
 			if (!uriSeg[i].equals(prefixSeg[i]))
 				return false;
 		return true;
+	}
+
+	/**
+	 * In contrast to {@link URI#createFileURI(String)}, this appends a trailing path separator. This ensures
+	 * the resulting URI can be used with methods like {@link #isPrefixOf(URI, URI)}, {@link URI#resolve(URI)} and
+	 * {@link URI#deresolve(URI)}
+	 */
+	public static URI createFolderURI(File file) {
+		URI uri = URI.createFileURI(file.getAbsolutePath());
+		if (uri.hasTrailingPathSeparator()) {
+			return uri;
+		} else {
+			return uri.appendSegment("");
+		}
 	}
 }

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/build/BuildRequest.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/build/BuildRequest.xtend
@@ -15,6 +15,7 @@ import org.eclipse.xtext.resource.IResourceDescription
 import org.eclipse.xtext.resource.XtextResourceSet
 import org.eclipse.xtext.util.internal.Log
 import org.eclipse.xtext.validation.Issue
+import org.eclipse.xtext.util.UriUtil
 
 /**
  * @author Jan Koehnlein - Initial contribution and API
@@ -27,7 +28,7 @@ class BuildRequest {
 	def URI getBaseDir() {
 		if (baseDir == null) {
 			val userDir = System.getProperty('user.dir')
-			baseDir = URI.createFileURI(new File(userDir).canonicalFile.absolutePath) 
+			baseDir = UriUtil.createFolderURI(new File(userDir)) 
 		}
 		return baseDir
 	}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/workspace/FileWorkspaceConfig.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/workspace/FileWorkspaceConfig.xtend
@@ -14,6 +14,7 @@ import org.eclipse.emf.common.util.URI
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 
 import static extension org.eclipse.xtext.util.UriUtil.*
+import org.eclipse.xtext.util.UriUtil
 
 @FinalFieldsConstructor
 class FileWorkspaceConfig implements IWorkspaceConfig {
@@ -31,11 +32,7 @@ class FileWorkspaceConfig implements IWorkspaceConfig {
 	}
 
 	def getPath() {
-		val path = URI.createFileURI(root.path)
-		if (path.hasTrailingPathSeparator) 
-			path 
-		else 
-			path.appendSegment("")
+		UriUtil.createFolderURI(root)
 	}
 	
 	def getProjects() {

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/BuildRequest.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/BuildRequest.java
@@ -17,10 +17,10 @@ import org.eclipse.xtext.build.IndexState;
 import org.eclipse.xtext.diagnostics.Severity;
 import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.resource.XtextResourceSet;
+import org.eclipse.xtext.util.UriUtil;
 import org.eclipse.xtext.util.internal.Log;
 import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure2;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -79,20 +79,14 @@ public class BuildRequest {
   private URI baseDir;
   
   public URI getBaseDir() {
-    try {
-      boolean _equals = Objects.equal(this.baseDir, null);
-      if (_equals) {
-        final String userDir = System.getProperty("user.dir");
-        File _file = new File(userDir);
-        File _canonicalFile = _file.getCanonicalFile();
-        String _absolutePath = _canonicalFile.getAbsolutePath();
-        URI _createFileURI = URI.createFileURI(_absolutePath);
-        this.baseDir = _createFileURI;
-      }
-      return this.baseDir;
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
+    boolean _equals = Objects.equal(this.baseDir, null);
+    if (_equals) {
+      final String userDir = System.getProperty("user.dir");
+      File _file = new File(userDir);
+      URI _createFolderURI = UriUtil.createFolderURI(_file);
+      this.baseDir = _createFolderURI;
     }
+    return this.baseDir;
   }
   
   private List<URI> dirtyFiles = CollectionLiterals.<URI>newArrayList();

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/FileWorkspaceConfig.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/workspace/FileWorkspaceConfig.java
@@ -55,20 +55,7 @@ public class FileWorkspaceConfig implements IWorkspaceConfig {
   }
   
   public URI getPath() {
-    URI _xblockexpression = null;
-    {
-      String _path = this.root.getPath();
-      final URI path = URI.createFileURI(_path);
-      URI _xifexpression = null;
-      boolean _hasTrailingPathSeparator = path.hasTrailingPathSeparator();
-      if (_hasTrailingPathSeparator) {
-        _xifexpression = path;
-      } else {
-        _xifexpression = path.appendSegment("");
-      }
-      _xblockexpression = _xifexpression;
-    }
-    return _xblockexpression;
+    return UriUtil.createFolderURI(this.root);
   }
   
   public Set<FileProjectConfig> getProjects() {

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/UriUtilTest.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/util/UriUtilTest.xtend
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.util
+
+import org.eclipse.emf.common.util.URI
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+import static extension org.eclipse.xtext.util.UriUtil.*
+import java.io.File
+
+class UriUtilTest {
+	@Test
+	def void testPrefix() {
+		val prefix = URI.createURI("file:/foo/")
+		val uri = URI.createURI("file:/foo/bar")
+		assertTrue(prefix.isPrefixOf(uri))
+	}
+
+	@Test
+	def void testPrefixRequiresSameScheme() {
+		val prefix = URI.createURI("platform:/foo/")
+		val uri = URI.createURI("file:/foo/bar")
+		assertFalse(prefix.isPrefixOf(uri))
+	}
+
+	@Test
+	def void testPrefixRequiresTrailingSeparator() {
+		val prefix = URI.createURI("file:/foo")
+		val uri = URI.createURI("file:/foo/bar")
+		assertFalse(prefix.isPrefixOf(uri))
+	}
+
+	@Test
+	def void testPrefixRequiresSegmentsToMatch() {
+		val prefix = URI.createURI("file:/foo")
+		val uri = URI.createURI("file:/buzz/bar")
+		assertFalse(prefix.isPrefixOf(uri))
+	}
+
+	@Test
+	def void testFolderUriHasTrailingSeparator() {
+		val folder = new File(".")
+		val uri = folder.createFolderURI
+		assertTrue(uri.hasTrailingPathSeparator)
+		assertEquals(".", uri.segment(uri.segmentCount - 2))
+	}
+}

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/util/UriUtilTest.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/util/UriUtilTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.util;
+
+import java.io.File;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.util.UriUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+@SuppressWarnings("all")
+public class UriUtilTest {
+  @Test
+  public void testPrefix() {
+    final URI prefix = URI.createURI("file:/foo/");
+    final URI uri = URI.createURI("file:/foo/bar");
+    boolean _isPrefixOf = UriUtil.isPrefixOf(prefix, uri);
+    Assert.assertTrue(_isPrefixOf);
+  }
+  
+  @Test
+  public void testPrefixRequiresSameScheme() {
+    final URI prefix = URI.createURI("platform:/foo/");
+    final URI uri = URI.createURI("file:/foo/bar");
+    boolean _isPrefixOf = UriUtil.isPrefixOf(prefix, uri);
+    Assert.assertFalse(_isPrefixOf);
+  }
+  
+  @Test
+  public void testPrefixRequiresTrailingSeparator() {
+    final URI prefix = URI.createURI("file:/foo");
+    final URI uri = URI.createURI("file:/foo/bar");
+    boolean _isPrefixOf = UriUtil.isPrefixOf(prefix, uri);
+    Assert.assertFalse(_isPrefixOf);
+  }
+  
+  @Test
+  public void testPrefixRequiresSegmentsToMatch() {
+    final URI prefix = URI.createURI("file:/foo");
+    final URI uri = URI.createURI("file:/buzz/bar");
+    boolean _isPrefixOf = UriUtil.isPrefixOf(prefix, uri);
+    Assert.assertFalse(_isPrefixOf);
+  }
+  
+  @Test
+  public void testFolderUriHasTrailingSeparator() {
+    final File folder = new File(".");
+    final URI uri = UriUtil.createFolderURI(folder);
+    boolean _hasTrailingPathSeparator = uri.hasTrailingPathSeparator();
+    Assert.assertTrue(_hasTrailingPathSeparator);
+    int _segmentCount = uri.segmentCount();
+    int _minus = (_segmentCount - 2);
+    String _segment = uri.segment(_minus);
+    Assert.assertEquals(".", _segment);
+  }
+}


### PR DESCRIPTION
makes sure that folder URIs end with a trailing slash, so that they can
be used with isPrefix(), resolve() and deresolve()