### PR TITLE
[idea] executing tests causes a deadlock in rare cases. (see thread dump below)

### DIFF
--- a/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/build/BuildProgressReporter.xtend
+++ b/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/build/BuildProgressReporter.xtend
@@ -34,15 +34,18 @@ class BuildProgressReporter implements BuildRequest.IPostValidationCallback {
 	val affectedScope = new AffectedScope
 
 	Project project
-
-	ProblemsView problemsView
-
+	
 	def void setProject(Project project) {
 		this.project = project
-		problemsView = ProblemsView.SERVICE.getInstance(project)
+	}
+	
+	protected def getProblemsView() {
+		ProblemsView.SERVICE.getInstance(project)		
 	}
 
 	def void clearProgress() {
+		if (project.isDisposed)
+			return;
 		problemsView.clearProgress
 		problemsView.clearOldMessages(affectedScope, sessionId)
 	}
@@ -60,6 +63,8 @@ class BuildProgressReporter implements BuildRequest.IPostValidationCallback {
 	}
 
 	protected def reportIssue(URI validated, Issue issue) {
+		if (project.isDisposed)
+			return;
 		val compilerMessage = getCompilerMessage(validated, issue)
 		problemsView.addMessage(compilerMessage, sessionId)
 	}

--- a/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/build/BuildProgressReporter.java
+++ b/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/build/BuildProgressReporter.java
@@ -34,17 +34,23 @@ public class BuildProgressReporter implements BuildRequest.IPostValidationCallba
   
   private Project project;
   
-  private ProblemsView problemsView;
-  
   public void setProject(final Project project) {
     this.project = project;
-    ProblemsView _instance = ProblemsView.SERVICE.getInstance(project);
-    this.problemsView = _instance;
+  }
+  
+  protected ProblemsView getProblemsView() {
+    return ProblemsView.SERVICE.getInstance(this.project);
   }
   
   public void clearProgress() {
-    this.problemsView.clearProgress();
-    this.problemsView.clearOldMessages(this.affectedScope, this.sessionId);
+    boolean _isDisposed = this.project.isDisposed();
+    if (_isDisposed) {
+      return;
+    }
+    ProblemsView _problemsView = this.getProblemsView();
+    _problemsView.clearProgress();
+    ProblemsView _problemsView_1 = this.getProblemsView();
+    _problemsView_1.clearOldMessages(this.affectedScope, this.sessionId);
   }
   
   public void markAsAffected(final URI uri) {
@@ -62,8 +68,13 @@ public class BuildProgressReporter implements BuildRequest.IPostValidationCallba
   }
   
   protected void reportIssue(final URI validated, final Issue issue) {
+    boolean _isDisposed = this.project.isDisposed();
+    if (_isDisposed) {
+      return;
+    }
     final CompilerMessage compilerMessage = this.getCompilerMessage(validated, issue);
-    this.problemsView.addMessage(compilerMessage, this.sessionId);
+    ProblemsView _problemsView = this.getProblemsView();
+    _problemsView.addMessage(compilerMessage, this.sessionId);
   }
   
   protected CompilerMessage getCompilerMessage(final URI validated, final Issue issue) {


### PR DESCRIPTION
I couldn’t reproduce it, but it could be that we hold a reference to a problemsView that was disposed (or even the project was already disposed) and keep adding messages. I changed the code to always go through getContainer() which internally checks for cancellation and dispose.


"AWT-EventQueue-0 14.1.3#IC-141.SNAPSHOT, eap:true 14.1.3#IC-141.SNAPSHOT, eap:true":
        at com.intellij.ide.util.treeView.AbstractTreeUpdater.cancelAllRequests(AbstractTreeUpdater.java:326)
        - waiting to lock <0x00000007eb866038> (a com.intellij.ide.util.treeView.AbstractTreeUpdater)
        at com.intellij.ide.util.treeView.AbstractTreeUi.releaseNow(AbstractTreeUi.java:467)
        at com.intellij.ide.util.treeView.AbstractTreeUi.access$1400(AbstractTreeUi.java:62)
        at com.intellij.ide.util.treeView.AbstractTreeUi$12.perform(AbstractTreeUi.java:448)
        at com.intellij.ide.util.treeView.TreeRunnable.run(TreeRunnable.java:33)
        at com.intellij.openapi.util.ExecutionCallback.doWhenExecuted(ExecutionCallback.java:101)
        at com.intellij.openapi.util.ActionCallback.doWhenDone(ActionCallback.java:108)
        at com.intellij.ide.util.treeView.AbstractTreeUi.requestRelease(AbstractTreeUi.java:445)
        at com.intellij.ide.util.treeView.AbstractTreeBuilder.dispose(AbstractTreeBuilder.java:577)
        at com.intellij.openapi.util.Disposer$1.execute(Disposer.java:47)
        at com.intellij.openapi.util.Disposer$1.execute(Disposer.java:44)
        at com.intellij.openapi.util.objectTree.ObjectNode$1.execute(ObjectNode.java:132)
        at com.intellij.openapi.util.objectTree.ObjectNode$1.execute(ObjectNode.java:106)
        at com.intellij.openapi.util.objectTree.ObjectTree.executeActionWithRecursiveGuard(ObjectTree.java:146)
        at com.intellij.openapi.util.objectTree.ObjectNode.execute(ObjectNode.java:106)
        at com.intellij.openapi.util.objectTree.ObjectTree.executeAll(ObjectTree.java:132)
        at com.intellij.openapi.util.Disposer.dispose(Disposer.java:108)
        at com.intellij.openapi.util.Disposer.dispose(Disposer.java:104)
        at com.intellij.ide.errorTreeView.NewErrorTreeViewPanel.dispose(NewErrorTreeViewPanel.java:188)
        at com.intellij.openapi.util.Disposer$1.execute(Disposer.java:47)
        at com.intellij.openapi.util.Disposer$1.execute(Disposer.java:44)
        at com.intellij.openapi.util.objectTree.ObjectTree.executeActionWithRecursiveGuard(ObjectTree.java:146)
        at com.intellij.openapi.util.objectTree.ObjectTree.executeUnregistered(ObjectTree.java:158)
        at com.intellij.openapi.util.objectTree.ObjectTree.executeAll(ObjectTree.java:125)
        at com.intellij.openapi.util.Disposer.dispose(Disposer.java:108)
        at com.intellij.openapi.util.Disposer.dispose(Disposer.java:104)
        at com.intellij.ui.content.impl.ContentImpl.dispose(ContentImpl.java:310)
        at com.intellij.openapi.util.Disposer$1.execute(Disposer.java:47)
        at com.intellij.openapi.util.Disposer$1.execute(Disposer.java:44)
        at com.intellij.openapi.util.objectTree.ObjectTree.executeActionWithRecursiveGuard(ObjectTree.java:146)
        at com.intellij.openapi.util.objectTree.ObjectTree.executeUnregistered(ObjectTree.java:158)
        at com.intellij.openapi.util.objectTree.ObjectTree.executeAll(ObjectTree.java:125)
        at com.intellij.openapi.util.Disposer.dispose(Disposer.java:108)
        at com.intellij.openapi.util.Disposer.dispose(Disposer.java:104)
        at com.intellij.openapi.wm.impl.ToolWindowHeadlessManagerImpl$MockContentManager.removeContent(ToolWindowHeadlessManagerImpl.java:656)
        at com.intellij.openapi.wm.impl.ToolWindowHeadlessManagerImpl$MockContentManager.removeAllContents(ToolWindowHeadlessManagerImpl.java:644)
        at com.intellij.compiler.impl.ProblemsViewImpl$2$1.dispose(ProblemsViewImpl.java:81)
        at com.intellij.openapi.util.Disposer$1.execute(Disposer.java:47)
        at com.intellij.openapi.util.Disposer$1.execute(Disposer.java:44)
        at com.intellij.openapi.util.objectTree.ObjectNode$1.execute(ObjectNode.java:132)
        at com.intellij.openapi.util.objectTree.ObjectNode$1.execute(ObjectNode.java:106)
        at com.intellij.openapi.util.objectTree.ObjectTree.executeActionWithRecursiveGuard(ObjectTree.java:146)
        at com.intellij.openapi.util.objectTree.ObjectNode.execute(ObjectNode.java:106)
        at com.intellij.openapi.util.objectTree.ObjectNode$1.execute(ObjectNode.java:122)
        at com.intellij.openapi.util.objectTree.ObjectNode$1.execute(ObjectNode.java:106)
        at com.intellij.openapi.util.objectTree.ObjectTree.executeActionWithRecursiveGuard(ObjectTree.java:146)
        at com.intellij.openapi.util.objectTree.ObjectNode.execute(ObjectNode.java:106)
        at com.intellij.openapi.util.objectTree.ObjectTree.executeAll(ObjectTree.java:132)
        at com.intellij.openapi.util.Disposer.dispose(Disposer.java:108)
        at com.intellij.openapi.util.Disposer.dispose(Disposer.java:104)
        at com.intellij.testFramework.LightPlatformTestCase.closeAndDeleteProject(LightPlatformTestCase.java:827)
        - locked <0x00000007e0e849a0> (a java.lang.Class for com.intellij.testFramework.LightPlatformTestCase)
        at com.intellij.testFramework.LightPlatformTestCase$2.run(LightPlatformTestCase.java:241)
        at com.intellij.openapi.command.WriteCommandAction$Simple.run(WriteCommandAction.java:166)


"ApplicationImpl pooled thread 5":
        at sun.misc.Unsafe.park(Native Method)
        - parking to wait for  <0x00000007eb865eb8> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:834)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:867)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1197)
        at java.util.concurrent.locks.ReentrantLock$NonfairSync.lock(ReentrantLock.java:214)
        at java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:290)
        at com.intellij.ide.util.treeView.AbstractTreeUi.acquireLock(AbstractTreeUi.java:2476)
        at com.intellij.ide.util.treeView.AbstractTreeUi.setCancelRequested(AbstractTreeUi.java:2454)
        at com.intellij.ide.util.treeView.AbstractTreeUi.execute(AbstractTreeUi.java:1838)
        at com.intellij.ide.util.treeView.AbstractTreeUi.access$2500(AbstractTreeUi.java:62)
        at com.intellij.ide.util.treeView.AbstractTreeUi$26.perform(AbstractTreeUi.java:1179)
        at com.intellij.ide.util.treeView.TreeRunnable.run(TreeRunnable.java:33)
        at com.intellij.openapi.util.ExecutionCallback.doWhenExecuted(ExecutionCallback.java:101)
        at com.intellij.openapi.util.ActionCallback.doWhenDone(ActionCallback.java:108)
        at com.intellij.ide.util.treeView.AbstractTreeUi.updateNodeChildren(AbstractTreeUi.java:1174)
        at com.intellij.ide.util.treeView.AbstractTreeUi.updateSubtreeNow(AbstractTreeUi.java:1080)
        at com.intellij.ide.util.treeView.AbstractTreeUpdater$3.perform(AbstractTreeUpdater.java:258)
        at com.intellij.ide.util.treeView.TreeRunnable.run(TreeRunnable.java:33)
        at com.intellij.openapi.util.ExecutionCallback.doWhenExecuted(ExecutionCallback.java:101)
        at com.intellij.openapi.util.ActionCallback.doWhenDone(ActionCallback.java:108)
        at com.intellij.ide.util.treeView.AbstractTreeUpdater.performUpdate(AbstractTreeUpdater.java:254)
        - locked <0x00000007eb866038> (a com.intellij.ide.util.treeView.AbstractTreeUpdater)
        at com.intellij.ide.util.treeView.AbstractTreeUpdater$2.run(AbstractTreeUpdater.java:215)
        at com.intellij.util.ui.update.MergingUpdateQueue.queue(MergingUpdateQueue.java:332)
        at com.intellij.ide.util.treeView.AbstractTreeUpdater.queue(AbstractTreeUpdater.java:230)
        at com.intellij.ide.util.treeView.AbstractTreeUpdater.reQueueViewUpdate(AbstractTreeUpdater.java:196)
        at com.intellij.ide.util.treeView.AbstractTreeUpdater.addSubtreeToUpdate(AbstractTreeUpdater.java:186)
        - locked <0x00000007eb866038> (a com.intellij.ide.util.treeView.AbstractTreeUpdater)
        at com.intellij.ide.util.treeView.AbstractTreeUpdater.addSubtreeToUpdate(AbstractTreeUpdater.java:103)
        - locked <0x00000007eb866038> (a com.intellij.ide.util.treeView.AbstractTreeUpdater)
        at com.intellij.ide.errorTreeView.ErrorViewTreeBuilder.updateTree(ErrorViewTreeBuilder.java:46)
        at com.intellij.ide.errorTreeView.NewErrorTreeViewPanel.addMessage(NewErrorTreeViewPanel.java:322)
        at com.intellij.compiler.impl.ProblemsViewImpl$4.run(ProblemsViewImpl.java:142)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
        at java.util.concurrent.FutureTask.run(FutureTask.java:262)
        at com.intellij.util.concurrency.BoundedTaskExecutor$1.run(BoundedTaskExecutor.java:37)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
        at org.jetbrains.ide.PooledThreadExecutor$1$1.run(PooledThreadExecutor.java:56)