### PR TITLE
[287082] Fix: Don’t loose information about bogus cardinality

### DIFF
--- a/maven/org.eclipse.xtext.parent/pom.xml
+++ b/maven/org.eclipse.xtext.parent/pom.xml
@@ -242,6 +242,23 @@
 										<ignore></ignore>
 									</action>
 								</pluginExecution>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											org.apache.maven.plugins
+										</groupId>
+										<artifactId>
+											maven-enforcer-plugin
+										</artifactId>
+										<versionRange>[1.0,)</versionRange>
+										<goals>
+											<goal>enforce</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
 							</pluginExecutions>
 						</lifecycleMappingMetadata>
 					</configuration>

--- a/plugins/org.eclipse.xtend.lib/.settings/.api_filters
+++ b/plugins/org.eclipse.xtend.lib/.settings/.api_filters
@@ -4,28 +4,7 @@
         <filter id="927989779">
             <message_arguments>
                 <message_argument value="2.9.0"/>
-                <message_argument value="2.7.0"/>
                 <message_argument value="org.eclipse.xtext.xbase.lib"/>
-            </message_arguments>
-        </filter>
-        <filter id="927989779">
-            <message_arguments>
-                <message_argument value="2.9.0"/>
-                <message_argument value="org.eclipse.xtext.xbase.lib"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="xtend-gen/org/eclipse/xtend/lib/annotations/EqualsHashCodeProcessor.java" type="org.eclipse.xtend.lib.annotations.EqualsHashCodeProcessor$Util">
-        <filter id="338792546">
-            <message_arguments>
-                <message_argument value="org.eclipse.xtend.lib.annotations.EqualsHashCodeProcessor.Util"/>
-                <message_argument value="contributeToEquals(FieldDeclaration)"/>
-            </message_arguments>
-        </filter>
-        <filter id="338792546">
-            <message_arguments>
-                <message_argument value="org.eclipse.xtend.lib.annotations.EqualsHashCodeProcessor.Util"/>
-                <message_argument value="contributeToHashCode(FieldDeclaration)"/>
             </message_arguments>
         </filter>
     </resource>

--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/CompositeGeneratorFragment.java
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/CompositeGeneratorFragment.java
@@ -355,7 +355,7 @@ public class CompositeGeneratorFragment implements IGeneratorFragment, IGenerato
 												""+binding.getContributedBy()+" and "+entry.getContributedBy());
 									} else {
 										LOG.warn("Cannot override final binding '" + binding + "'. " +
-												"Ignoring binding from fragment '"+module.getClass().getSimpleName() +"'");
+												"Ignoring binding from fragment '"+getModuleClassName(module) +"'");
 									}
 								} else {
 									if (LOG.isDebugEnabled()) {
@@ -373,6 +373,14 @@ public class CompositeGeneratorFragment implements IGeneratorFragment, IGenerato
 			}
 		}
 		return bindings;
+	}
+
+	private String getModuleClassName(IGeneratorFragment module) {
+		String result = module.getClass().getSimpleName();
+		if (result.isEmpty()) {
+			return module.getClass().getName();
+		}
+		return result;
 	}
 	
 	@Override

--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/LanguageConfig.java
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/LanguageConfig.java
@@ -169,7 +169,7 @@ public class LanguageConfig extends CompositeGeneratorFragment {
 			String lowerCase = GrammarUtil.getName(g).toLowerCase();
 			if (LOG.isInfoEnabled())
 				LOG.info("No explicit fileExtensions configured. Using '*." + lowerCase + "'.");
-			return Collections.singletonList(lowerCase);
+			return fileExtensions = Collections.singletonList(lowerCase);
 		}
 		return fileExtensions;
 	}

--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/grammarAccess/GrammarAccessUtil.java
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/grammarAccess/GrammarAccessUtil.java
@@ -42,6 +42,28 @@ import com.google.inject.Module;
  */
 public class GrammarAccessUtil {
 
+	/**
+	 * @since 2.9
+	 */
+	protected static class LineSeparatorModule extends XtextRuntimeModule {
+		private final ILineSeparatorInformation lineSeparatorInformation;
+
+		protected LineSeparatorModule(ILineSeparatorInformation lineSeparatorInformation) {
+			this.lineSeparatorInformation = lineSeparatorInformation;
+		}
+
+		@Override
+		public void configure(Binder binder) {
+			// avoid duplicate registration of the validator
+			Module compound = getBindings();
+			compound.configure(binder);
+		}
+
+		public ILineSeparatorInformation bindILineSeparatorInformation() {
+			return lineSeparatorInformation;
+		}
+	}
+
 	public static String getClassName(EObject obj) {
 		return obj.eClass().getName();
 	}
@@ -118,18 +140,7 @@ public class GrammarAccessUtil {
 				return delimiter;
 			}
 		};
-		Injector injector = Guice.createInjector(new XtextRuntimeModule() {
-			@Override
-			public void configure(Binder binder) {
-				// avoid duplicate registration of the validator
-				Module compound = getBindings();
-				compound.configure(binder);
-			}
-			@SuppressWarnings("unused")
-			public ILineSeparatorInformation bindILineSeparatorInformation() {
-				return lineSeparatorInformation;
-			}
-		});
+		Injector injector = Guice.createInjector(new LineSeparatorModule(lineSeparatorInformation));
 		result = injector.getInstance(ISerializer.class);
 		xtextSerializerByLineDelimiter.put(delimiter, result);
 		return result;

--- a/plugins/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/antlr/AbstractPartialContentAssistParser.java
+++ b/plugins/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/antlr/AbstractPartialContentAssistParser.java
@@ -110,8 +110,7 @@ public abstract class AbstractPartialContentAssistParser extends AbstractContent
 				}
 			} else {
 				if (!skipOptional) {
-					if (appendTextToParse((ICompositeNode) child, offset, skipOptional
-							|| child.getTotalEndOffset() < offset, result)) {
+					if (appendTextToParse((ICompositeNode) child, offset, child.getTotalEndOffset() < offset, result)) {
 						return true;
 					}
 				} else {
@@ -119,7 +118,7 @@ public abstract class AbstractPartialContentAssistParser extends AbstractContent
 					if (skippedAs != null) {
 						result.append(skippedAs);
 					} else {
-						if (appendTextToParse((ICompositeNode) child, offset, skipOptional, result)) {
+						if (appendTextToParse((ICompositeNode) child, offset, true, result)) {
 							return true;
 						}
 					}

--- a/plugins/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/AbstractXtextTests.java
+++ b/plugins/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/AbstractXtextTests.java
@@ -269,17 +269,12 @@ public abstract class AbstractXtextTests extends Assert implements ResourceLoadH
 			if (d instanceof ExceptionDiagnostic)
 				fail(d.getMessage());
 		}
-
-		for(Diagnostic d: resource.getWarnings())
-			System.out.println("Resource Warning: "+d);
-				
 		if (expectedErrors == 0 && resource.getContents().size() > 0 && shouldTestSerializer(resource)) {
 			SerializerTester tester = get(SerializerTester.class);
 			EObject obj = resource.getContents().get(0);
 			tester.assertSerializeWithNodeModel(obj);
 			tester.assertSerializeWithoutNodeModel(obj);
 		}
-
 		return resource;
 	}
 

--- a/plugins/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/logging/LoggingTester.xtend
+++ b/plugins/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/logging/LoggingTester.xtend
@@ -97,7 +97,7 @@ import org.junit.Assert
 			logger.level = level
 			action.run
 			val events = appender.events.toList.sortWith(TEMPORAL_ORDER)
-			new LogCapture(events)
+			return new LogCapture(events)
 		} finally {
 			logger.removeAppender(appender)
 			allAppenders.forEach[removeFilter(filter)]
@@ -114,10 +114,16 @@ import org.junit.Assert
 	}
 
 	private static def removeFilter(Appender appender, Filter filter) {
-		for (var current = appender.filter; current != null; current = current.getNext) {
-			if (current.getNext == filter) {
-				current.setNext(null)
-			}
+		if (appender.filter == filter) {
+			appender.clearFilters
+			appender.addFilter(filter.getNext)
+		} else {
+			for (var current = appender.filter; current != null; current = current.getNext) {
+				if (current.getNext == filter) {
+					current.setNext(filter.getNext)
+					return
+				}
+			}	
 		}
 	}
 

--- a/plugins/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/logging/LoggingTester.java
+++ b/plugins/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/logging/LoggingTester.java
@@ -373,46 +373,36 @@ public class LoggingTester {
   }
   
   public static LoggingTester.LogCapture captureLogging(final Level level, final Class<?> source, final Runnable action) {
-    LoggingTester.LogCapture _xblockexpression = null;
-    {
-      final Logger logger = Logger.getLogger(source);
-      final LoggingTester.QueueAppender appender = new LoggingTester.QueueAppender();
-      final Level oldLevel = logger.getLevel();
-      final ArrayList<Appender> allAppenders = LoggingTester.appenderHierarchy(logger);
-      final LoggingTester.SourceFilter filter = new LoggingTester.SourceFilter(logger);
-      LoggingTester.LogCapture _xtrycatchfinallyexpression = null;
-      try {
-        LoggingTester.LogCapture _xblockexpression_1 = null;
-        {
-          final Procedure1<Appender> _function = new Procedure1<Appender>() {
-            @Override
-            public void apply(final Appender it) {
-              it.addFilter(filter);
-            }
-          };
-          IterableExtensions.<Appender>forEach(allAppenders, _function);
-          logger.addAppender(appender);
-          logger.setLevel(level);
-          action.run();
-          List<LoggingTester.LogEntry> _list = IterableExtensions.<LoggingTester.LogEntry>toList(appender.events);
-          final List<LoggingTester.LogEntry> events = IterableExtensions.<LoggingTester.LogEntry>sortWith(_list, LoggingTester.TEMPORAL_ORDER);
-          _xblockexpression_1 = new LoggingTester.LogCapture(events);
+    final Logger logger = Logger.getLogger(source);
+    final LoggingTester.QueueAppender appender = new LoggingTester.QueueAppender();
+    final Level oldLevel = logger.getLevel();
+    final ArrayList<Appender> allAppenders = LoggingTester.appenderHierarchy(logger);
+    final LoggingTester.SourceFilter filter = new LoggingTester.SourceFilter(logger);
+    try {
+      final Procedure1<Appender> _function = new Procedure1<Appender>() {
+        @Override
+        public void apply(final Appender it) {
+          it.addFilter(filter);
         }
-        _xtrycatchfinallyexpression = _xblockexpression_1;
-      } finally {
-        logger.removeAppender(appender);
-        final Procedure1<Appender> _function = new Procedure1<Appender>() {
-          @Override
-          public void apply(final Appender it) {
-            LoggingTester.removeFilter(it, filter);
-          }
-        };
-        IterableExtensions.<Appender>forEach(allAppenders, _function);
-        logger.setLevel(oldLevel);
-      }
-      _xblockexpression = _xtrycatchfinallyexpression;
+      };
+      IterableExtensions.<Appender>forEach(allAppenders, _function);
+      logger.addAppender(appender);
+      logger.setLevel(level);
+      action.run();
+      List<LoggingTester.LogEntry> _list = IterableExtensions.<LoggingTester.LogEntry>toList(appender.events);
+      final List<LoggingTester.LogEntry> events = IterableExtensions.<LoggingTester.LogEntry>sortWith(_list, LoggingTester.TEMPORAL_ORDER);
+      return new LoggingTester.LogCapture(events);
+    } finally {
+      logger.removeAppender(appender);
+      final Procedure1<Appender> _function_1 = new Procedure1<Appender>() {
+        @Override
+        public void apply(final Appender it) {
+          LoggingTester.removeFilter(it, filter);
+        }
+      };
+      IterableExtensions.<Appender>forEach(allAppenders, _function_1);
+      logger.setLevel(oldLevel);
     }
-    return _xblockexpression;
   }
   
   private static ArrayList<Appender> appenderHierarchy(final Logger logger) {
@@ -430,11 +420,21 @@ public class LoggingTester {
   }
   
   private static void removeFilter(final Appender appender, final Filter filter) {
-    for (Filter current = appender.getFilter(); (!Objects.equal(current, null)); current = current.getNext()) {
-      Filter _next = current.getNext();
-      boolean _equals = Objects.equal(_next, filter);
-      if (_equals) {
-        current.setNext(null);
+    Filter _filter = appender.getFilter();
+    boolean _equals = Objects.equal(_filter, filter);
+    if (_equals) {
+      appender.clearFilters();
+      Filter _next = filter.getNext();
+      appender.addFilter(_next);
+    } else {
+      for (Filter current = appender.getFilter(); (!Objects.equal(current, null)); current = current.getNext()) {
+        Filter _next_1 = current.getNext();
+        boolean _equals_1 = Objects.equal(_next_1, filter);
+        if (_equals_1) {
+          Filter _next_2 = filter.getNext();
+          current.setNext(_next_2);
+          return;
+        }
       }
     }
   }

--- a/plugins/org.eclipse.xtext.ui/.settings/.api_filters
+++ b/plugins/org.eclipse.xtext.ui/.settings/.api_filters
@@ -107,21 +107,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="deprecated/org/eclipse/xtext/ui/editor/syntaxcoloring/ISemanticHighlightingCalculator.java" type="org.eclipse.xtext.ui.editor.syntaxcoloring.ISemanticHighlightingCalculator$OldToNewDelegate">
-        <filter id="576725006">
-            <message_arguments>
-                <message_argument value="ISemanticHighlightingCalculator"/>
-                <message_argument value="OldToNewDelegate"/>
-            </message_arguments>
-        </filter>
-        <filter id="643846161">
-            <message_arguments>
-                <message_argument value="IHighlightedPositionAcceptor"/>
-                <message_argument value="OldToNewDelegate"/>
-                <message_argument value="provideHighlightingFor(XtextResource, IHighlightedPositionAcceptor)"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="deprecated/org/eclipse/xtext/ui/editor/syntaxcoloring/LightweightPosition.java" type="org.eclipse.xtext.ui.editor.syntaxcoloring.LightweightPosition">
         <filter id="338792546">
             <message_arguments>

--- a/plugins/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/AbstractPartialContentAssistParser.java
+++ b/plugins/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/AbstractPartialContentAssistParser.java
@@ -106,8 +106,7 @@ public abstract class AbstractPartialContentAssistParser extends AbstractContent
 				}
 			} else {
 				if (!skipOptional) {
-					if (appendTextToParse((ICompositeNode) child, offset, skipOptional
-							|| child.getTotalEndOffset() < offset, result)) {
+					if (appendTextToParse((ICompositeNode) child, offset, child.getTotalEndOffset() < offset, result)) {
 						return true;
 					}
 				} else {
@@ -115,8 +114,7 @@ public abstract class AbstractPartialContentAssistParser extends AbstractContent
 					if (skippedAs != null) {
 						result.append(skippedAs);
 					} else {
-						if (appendTextToParse((ICompositeNode) child, offset, skipOptional
-								|| child.getTotalEndOffset() < offset, result)) {
+						if (appendTextToParse((ICompositeNode) child, offset, true, result)) {
 							return true;
 						}
 					}

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/interpreter/AbstractConstantExpressionsInterpreter.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/interpreter/AbstractConstantExpressionsInterpreter.xtend
@@ -101,7 +101,7 @@ class AbstractConstantExpressionsInterpreter {
 	}
 
 	def dispatch Object internalEvaluate(XBinaryOperation it, Context ctx) {
-		val context = if (ctx == null) null else ctx.cloneWithExpectation(null) 
+		val context = ctx.cloneWithExpectation(null)
 		 
 		val left = leftOperand.evaluate(context) 
 		val right = rightOperand.evaluate(context)

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/interpreter/AbstractConstantExpressionsInterpreter.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/interpreter/AbstractConstantExpressionsInterpreter.java
@@ -143,14 +143,7 @@ public class AbstractConstantExpressionsInterpreter {
   protected Object _internalEvaluate(final XBinaryOperation it, final Context ctx) {
     Object _xblockexpression = null;
     {
-      Context _xifexpression = null;
-      boolean _equals = Objects.equal(ctx, null);
-      if (_equals) {
-        _xifexpression = null;
-      } else {
-        _xifexpression = ctx.cloneWithExpectation(null);
-      }
-      final Context context = _xifexpression;
+      final Context context = ctx.cloneWithExpectation(null);
       XExpression _leftOperand = it.getLeftOperand();
       final Object left = this.evaluate(_leftOperand, context);
       XExpression _rightOperand = it.getRightOperand();

--- a/plugins/org.eclipse.xtext/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.xtext/META-INF/MANIFEST.MF
@@ -80,7 +80,8 @@ Export-Package: org.eclipse.xtext,
  org.eclipse.xtext.validation.impl,
  org.eclipse.xtext.workspace;x-friends:="org.eclipse.xtext.xbase.ui",
  org.eclipse.xtext.xtext;x-friends:="org.eclipse.xtext.xtext.ui",
- org.eclipse.xtext.xtext.ecoreInference;x-internal:=true
+ org.eclipse.xtext.xtext.ecoreInference;x-internal:=true,
+ org.eclipse.xtext.xtext.parser;x-friends:="org.eclipse.xtext.tests"
 Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.10.2";visibility:=reexport,
  org.eclipse.emf.ecore;bundle-version="2.10.2";visibility:=reexport,
  org.eclipse.emf.codegen;bundle-version="2.10.0";resolution:=optional;x-installation:=greedy,

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/Xtext.xtext
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/Xtext.xtext
@@ -62,6 +62,7 @@ AbstractToken returns AbstractElement:
 	Action
 ;
 
+/* Suppress[potentialOverride]: Handled in CardinalityAwareEcoreFactory */
 AbstractTokenWithCardinality returns AbstractElement:
 	(Assignment | AbstractTerminal) (cardinality=('?'|'*'|'+'))?
 ;
@@ -148,6 +149,7 @@ TerminalGroup returns AbstractElement:
 	TerminalToken ({Group.elements+=current} (elements+=TerminalToken)+)?
 ;
 
+/* Suppress[potentialOverride]: Handled in CardinalityAwareEcoreFactory */
 TerminalToken returns AbstractElement:
 	TerminalTokenElement (cardinality=('?'|'*'|'+'))?
 ;

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/Xtext.xtext
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/Xtext.xtext
@@ -62,7 +62,7 @@ AbstractToken returns AbstractElement:
 	Action
 ;
 
-/* Suppress[potentialOverride]: Handled in CardinalityAwareEcoreFactory */
+/* SuppressWarnings[potentialOverride]: Handled in CardinalityAwareEcoreFactory */
 AbstractTokenWithCardinality returns AbstractElement:
 	(Assignment | AbstractTerminal) (cardinality=('?'|'*'|'+'))?
 ;
@@ -149,7 +149,7 @@ TerminalGroup returns AbstractElement:
 	TerminalToken ({Group.elements+=current} (elements+=TerminalToken)+)?
 ;
 
-/* Suppress[potentialOverride]: Handled in CardinalityAwareEcoreFactory */
+/* SuppressWarnings[potentialOverride]: Handled in CardinalityAwareEcoreFactory */
 TerminalToken returns AbstractElement:
 	TerminalTokenElement (cardinality=('?'|'*'|'+'))?
 ;

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/XtextRuntimeModule.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/XtextRuntimeModule.java
@@ -14,7 +14,9 @@ import org.eclipse.xtext.linking.ILinker;
 import org.eclipse.xtext.linking.ILinkingDiagnosticMessageProvider;
 import org.eclipse.xtext.linking.ILinkingService;
 import org.eclipse.xtext.naming.IQualifiedNameConverter;
+import org.eclipse.xtext.parser.DefaultEcoreElementFactory;
 import org.eclipse.xtext.parser.antlr.IReferableElementsUnloader;
+import org.eclipse.xtext.parser.antlr.SyntaxErrorMessageProvider;
 import org.eclipse.xtext.parsetree.reconstr.ITokenSerializer.ICrossReferenceSerializer;
 import org.eclipse.xtext.parsetree.reconstr.ITransientValueService;
 import org.eclipse.xtext.resource.DerivedStateAwareResourceDescriptionManager;
@@ -48,6 +50,8 @@ import org.eclipse.xtext.xtext.XtextValidator;
 import org.eclipse.xtext.xtext.XtextValueConverters;
 import org.eclipse.xtext.xtext.ecoreInference.IXtext2EcorePostProcessor;
 import org.eclipse.xtext.xtext.ecoreInference.XtendXtext2EcorePostProcessor;
+import org.eclipse.xtext.xtext.parser.CardinalityAwareEcoreFactory;
+import org.eclipse.xtext.xtext.parser.CardinalityAwareSyntaxErrorMessageProvider;
 
 import com.google.inject.Binder;
 
@@ -163,5 +167,19 @@ public class XtextRuntimeModule extends AbstractXtextRuntimeModule {
 	 */
 	public Class<? extends ConfigurableIssueCodesProvider> bindConfigurableIssueCodesProvider() {
 		return XtextConfigurableIssueCodes.class;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public Class<? extends DefaultEcoreElementFactory> bindCardinalityAwareFactory() {
+		return CardinalityAwareEcoreFactory.class;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public Class<? extends SyntaxErrorMessageProvider> bindSyntaxErrorMessageProvider() {
+		return CardinalityAwareSyntaxErrorMessageProvider.class;
 	}
 }

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/GrammarResource.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/GrammarResource.java
@@ -7,10 +7,16 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext;
 
+import java.util.List;
+
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.SyntaxErrorMessage;
 import org.eclipse.xtext.parser.IParseResult;
 import org.eclipse.xtext.resource.DerivedStateAwareResource;
 import org.eclipse.xtext.resource.IDerivedStateComputer;
+import org.eclipse.xtext.resource.XtextSyntaxDiagnostic;
+import org.eclipse.xtext.xtext.parser.CardinalityAwareSyntaxErrorMessageProvider;
 
 /**
  * Resource implementation that instantiates the infered packages as part of the
@@ -60,6 +66,19 @@ public class GrammarResource extends DerivedStateAwareResource {
 		// trigger derived state computation
 		getContents();
 		return super.getWarnings();
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	@Override
+	protected void addSyntaxDiagnostic(List<Diagnostic> diagnostics, INode node) {
+		SyntaxErrorMessage syntaxErrorMessage = node.getSyntaxErrorMessage();
+		if (CardinalityAwareSyntaxErrorMessageProvider.CARDINALITY_ISSUE.equals(syntaxErrorMessage.getIssueCode())) {
+			super.getWarnings().add(new XtextSyntaxDiagnostic(node));
+		} else {
+			super.addSyntaxDiagnostic(diagnostics, node);
+		}
 	}
 	
 	/**

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/OverriddenValueInspector.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/OverriddenValueInspector.java
@@ -34,6 +34,8 @@ import com.google.common.collect.Sets;
  */
 public class OverriddenValueInspector extends XtextRuleInspector<Boolean, ParserRule> {
 
+	public static final String ISSUE_CODE = "OverriddenValueInspector.potentialOverride";
+	
 	private Multimap<String, AbstractElement> assignedFeatures;
 	
 	/**
@@ -46,6 +48,11 @@ public class OverriddenValueInspector extends XtextRuleInspector<Boolean, Parser
 		super(acceptor);
 		assignedFeatures = newMultimap();
 		permanentlyVisited = Sets.newHashSet();
+	}
+	
+	@Override
+	protected String getIssueCode() {
+		return ISSUE_CODE;
 	}
 	
 	@Override

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/RuleWithoutInstantiationInspector.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/RuleWithoutInstantiationInspector.java
@@ -27,8 +27,15 @@ import org.eclipse.xtext.validation.ValidationMessageAcceptor;
  */
 public class RuleWithoutInstantiationInspector extends XtextRuleInspector<Boolean, ParserRule> {
 
+	public static final String ISSUE_CODE = "RuleWithoutInstantiationInspector.noInstantiation";
+	
 	public RuleWithoutInstantiationInspector(ValidationMessageAcceptor acceptor) {
 		super(acceptor);
+	}
+	
+	@Override
+	protected String getIssueCode() {
+		return ISSUE_CODE;
 	}
 	
 	@Override

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextDiagnosticConverter.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextDiagnosticConverter.java
@@ -24,10 +24,8 @@ import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.ILeafNode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.ILocationInFileProvider;
-import org.eclipse.xtext.util.IAcceptor;
 import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.validation.DiagnosticConverterImpl;
-import org.eclipse.xtext.validation.Issue;
 
 import com.google.common.base.Splitter;
 import com.google.inject.Inject;

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextDiagnosticConverter.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextDiagnosticConverter.java
@@ -7,9 +7,17 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.AbstractRule;
+import org.eclipse.xtext.GrammarUtil;
+import org.eclipse.xtext.diagnostics.Severity;
+import org.eclipse.xtext.documentation.IEObjectDocumentationProvider;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.ILeafNode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
@@ -27,6 +35,9 @@ public class XtextDiagnosticConverter extends DiagnosticConverterImpl{
 	@Inject
 	private ILocationInFileProvider locationInFileProvider;
 	
+	@Inject
+	private IEObjectDocumentationProvider documentationProvider;
+	
 	@Override
 	protected IssueLocation getLocationData(EObject obj, EStructuralFeature structuralFeature, int index) {
 		if (NodeModelUtils.getNode(obj) == null) {
@@ -42,6 +53,44 @@ public class XtextDiagnosticConverter extends DiagnosticConverterImpl{
 			}
 		}
 		return super.getLocationData(obj, structuralFeature, index);
+	}
+	
+	@Override
+	protected Severity getSeverity(Diagnostic diagnostic) {
+		Severity result = super.getSeverity(diagnostic);
+		String issueCode = getIssueCode(diagnostic);
+		if (result == Severity.WARNING && issueCode != null) {
+			// only warnings can be suppressed
+			EObject causer = getCauser(diagnostic);
+			if (causer != null) {
+				if (isMarkedAsIgnored(causer, issueCode)) {
+					return null;
+				}
+				if (!(causer instanceof AbstractRule)) {
+					AbstractRule rule = GrammarUtil.containingRule(causer);
+					if (rule != null && isMarkedAsIgnored(rule, issueCode)) {
+						return null;
+					}
+				}
+			}
+		}
+		return result;
+	}
+	
+	private final Pattern afterLastDot = Pattern.compile(".*\\W(\\w+)$");
+	
+	protected boolean isMarkedAsIgnored(EObject object, String code) {
+		String documentation = documentationProvider.getDocumentation(object);
+		if (documentation != null) {
+			Matcher matcher = afterLastDot.matcher(code);
+			if (matcher.matches()) {
+				String suffix = matcher.group(1);
+				if (documentation.contains("Suppress[" + suffix + "]")) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 	
 }

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextRuleInspector.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextRuleInspector.java
@@ -34,6 +34,13 @@ public class XtextRuleInspector<Result, RuleType extends AbstractRule> extends X
 		visitedRules = Sets.newHashSet();
 	}
 	
+	/**
+	 * @since 2.9
+	 */
+	protected String getIssueCode() {
+		return null;
+	}
+	
 	public void inspect(RuleType rule) {
 		if (!canInspect(rule))
 			return;
@@ -57,11 +64,11 @@ public class XtextRuleInspector<Result, RuleType extends AbstractRule> extends X
 	}
 
 	public void acceptError(String message, EObject object, EStructuralFeature feature) {
-		acceptor.acceptError(message, object, feature, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, null);
+		acceptor.acceptError(message, object, feature, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, getIssueCode());
 	}
 
 	public void acceptWarning(String message, EObject object, EStructuralFeature feature) {
-		acceptor.acceptWarning(message, object, feature, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, null);
+		acceptor.acceptWarning(message, object, feature, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, getIssueCode());
 	}
 	
 	public boolean addVisited(AbstractRule rule) {

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/parser/CardinalityAwareEcoreFactory.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/parser/CardinalityAwareEcoreFactory.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xtext.parser;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.XtextPackage;
+import org.eclipse.xtext.conversion.ValueConverterException;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.parser.DefaultEcoreElementFactory;
+
+/**
+ * The Xtext grammar allows to override the cardinality value by using patterns like
+ * {@code (feature+=RuleCall+)?}. Usually the '?' would override the '+' and the information
+ * about the '+' is completely lost. This factory will flag such patterns with a warning. 
+ * 
+ * @author Sebastian Zarnekow - Initial contribution and API
+ * @since 2.9
+ */
+public class CardinalityAwareEcoreFactory extends DefaultEcoreElementFactory {
+
+	@Override
+	public void set(EObject object, String feature, Object value, String ruleName, INode node) throws ValueConverterException {
+		if (object instanceof AbstractElement && XtextPackage.Literals.ABSTRACT_ELEMENT__CARDINALITY.getName().equals(feature)) {
+			AbstractElement casted = (AbstractElement) object;
+			String knownCardinality = casted.getCardinality();
+			if (knownCardinality != null) {
+				String newCardinality = String.valueOf(getTokenAsStringIfPossible(value));
+				if ("*".equals(newCardinality)) {
+					casted.setCardinality("*");
+				} else if ("*".equals(knownCardinality)) {
+					// nothing to do
+				} else if ("+".equals(knownCardinality)) {
+					if ("?".equals(newCardinality)) {
+						casted.setCardinality("*");	
+					}
+				} else if ("?".equals(knownCardinality)) {
+					if ("+".equals(newCardinality)) {
+						casted.setCardinality("*");
+					}
+				}
+				throw new MoreThanOneCardinalityException(newCardinality, casted.getCardinality(), node);
+			}
+		} 
+		super.set(object, feature, value, ruleName, node);
+	}
+	
+}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/parser/CardinalityAwareSyntaxErrorMessageProvider.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/parser/CardinalityAwareSyntaxErrorMessageProvider.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xtext.parser;
+
+import org.eclipse.xtext.conversion.ValueConverterException;
+import org.eclipse.xtext.nodemodel.SyntaxErrorMessage;
+import org.eclipse.xtext.parser.antlr.SyntaxErrorMessageProvider;
+
+/**
+ * @author Sebastian Zarnekow - Initial contribution and API
+ * @since 2.9
+ */
+public class CardinalityAwareSyntaxErrorMessageProvider extends SyntaxErrorMessageProvider {
+
+	public static final String CARDINALITY_ISSUE = "CardinalityAwareSyntaxErrorMessageProvider.overriddenCardinality";
+	
+	@Override
+	public SyntaxErrorMessage getSyntaxErrorMessage(IValueConverterErrorContext context) {
+		ValueConverterException cause = context.getValueConverterException();
+		if (cause instanceof MoreThanOneCardinalityException) {
+			return new SyntaxErrorMessage(context.getDefaultMessage(), CARDINALITY_ISSUE);
+		}
+		return super.getSyntaxErrorMessage(context);
+	}
+	
+}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/parser/MoreThanOneCardinalityException.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/parser/MoreThanOneCardinalityException.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xtext.parser;
+
+import org.eclipse.xtext.conversion.ValueConverterException;
+import org.eclipse.xtext.nodemodel.INode;
+
+/**
+ * @author Sebastian Zarnekow - Initial contribution and API
+ * @since 2.9
+ */
+public class MoreThanOneCardinalityException extends ValueConverterException {
+
+	private static final long serialVersionUID = 1L;
+
+	public MoreThanOneCardinalityException(String newCardinality, String mergedCardinality, INode node) {
+		super(String.format("More than one cardinality was set. Merging '%s' with previously assigned cardinality to '%s'.", newCardinality, mergedCardinality),
+						node, null);
+	}
+	
+}

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/parseTreeConstruction/AbstractTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/parseTreeConstruction/AbstractTestLanguageParsetreeConstructor.java
@@ -139,7 +139,7 @@ protected class InheritedParserRule_NameAssignment_1 extends AssignmentToken  {
 
 /************ begin Rule AbstractCallOverridenParserRule ****************
  *
- * / * Suppress[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
+ * / * SuppressWarnings[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
  * 	"overridemodel" elements+=OverridableParserRule*;
  *
  **/
@@ -438,7 +438,7 @@ protected class OverridableParserRule2_NameAssignment_1 extends AssignmentToken 
 
 /************ begin Rule AbstractCallExtendedParserRule ****************
  *
- * / * Suppress[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
+ * / * SuppressWarnings[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
  * 	"extendedmodel" elements+=ExtendableParserRule*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/parseTreeConstruction/AbstractTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/parseTreeConstruction/AbstractTestLanguageParsetreeConstructor.java
@@ -139,7 +139,7 @@ protected class InheritedParserRule_NameAssignment_1 extends AssignmentToken  {
 
 /************ begin Rule AbstractCallOverridenParserRule ****************
  *
- * AbstractCallOverridenParserRule returns mm::AModel:
+ * / * Suppress[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
  * 	"overridemodel" elements+=OverridableParserRule*;
  *
  **/
@@ -438,7 +438,7 @@ protected class OverridableParserRule2_NameAssignment_1 extends AssignmentToken 
 
 /************ begin Rule AbstractCallExtendedParserRule ****************
  *
- * AbstractCallExtendedParserRule returns mm::AModel:
+ * / * Suppress[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
  * 	"extendedmodel" elements+=ExtendableParserRule*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/parseTreeConstruction/ConcreteTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/parseTreeConstruction/ConcreteTestLanguageParsetreeConstructor.java
@@ -1404,7 +1404,7 @@ protected class InheritedParserRule_NameAssignment_1 extends AssignmentToken  {
 
 /************ begin Rule AbstractCallOverridenParserRule ****************
  *
- * / * Suppress[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
+ * / * SuppressWarnings[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
  * 	"overridemodel" elements+=OverridableParserRule*;
  *
  **/
@@ -1513,7 +1513,7 @@ protected class AbstractCallOverridenParserRule_ElementsAssignment_1 extends Ass
 
 /************ begin Rule AbstractCallExtendedParserRule ****************
  *
- * / * Suppress[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
+ * / * SuppressWarnings[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
  * 	"extendedmodel" elements+=ExtendableParserRule*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/parseTreeConstruction/ConcreteTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/parseTreeConstruction/ConcreteTestLanguageParsetreeConstructor.java
@@ -1404,7 +1404,7 @@ protected class InheritedParserRule_NameAssignment_1 extends AssignmentToken  {
 
 /************ begin Rule AbstractCallOverridenParserRule ****************
  *
- * AbstractCallOverridenParserRule returns mm::AModel:
+ * / * Suppress[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
  * 	"overridemodel" elements+=OverridableParserRule*;
  *
  **/
@@ -1513,7 +1513,7 @@ protected class AbstractCallOverridenParserRule_ElementsAssignment_1 extends Ass
 
 /************ begin Rule AbstractCallExtendedParserRule ****************
  *
- * AbstractCallExtendedParserRule returns mm::AModel:
+ * / * Suppress[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
  * 	"extendedmodel" elements+=ExtendableParserRule*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/parser/antlr/internal/InternalConcreteTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/parser/antlr/internal/InternalConcreteTestLanguageParser.java
@@ -27,8 +27,8 @@ public class InternalConcreteTestLanguageParser extends AbstractInternalAntlrPar
     public static final int RULE_ANY_OTHER=11;
     public static final int T__21=21;
     public static final int T__20=20;
-    public static final int RULE_SL_COMMENT=9;
     public static final int EOF=-1;
+    public static final int RULE_SL_COMMENT=9;
     public static final int RULE_ML_COMMENT=8;
     public static final int T__19=19;
     public static final int RULE_STRING=7;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/services/AbstractTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/services/AbstractTestLanguageGrammarAccess.java
@@ -49,7 +49,7 @@ public class AbstractTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		private final Assignment cElementsAssignment_1 = (Assignment)cGroup.eContents().get(1);
 		private final RuleCall cElementsOverridableParserRuleParserRuleCall_1_0 = (RuleCall)cElementsAssignment_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
+		/// * SuppressWarnings[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
 		//	"overridemodel" elements+=OverridableParserRule*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -121,7 +121,7 @@ public class AbstractTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		private final Assignment cElementsAssignment_1 = (Assignment)cGroup.eContents().get(1);
 		private final RuleCall cElementsExtendableParserRuleParserRuleCall_1_0 = (RuleCall)cElementsAssignment_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
+		/// * SuppressWarnings[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
 		//	"extendedmodel" elements+=ExtendableParserRule*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -228,7 +228,7 @@ public class AbstractTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		return getInheritedParserRuleAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
+	/// * SuppressWarnings[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
 	//	"overridemodel" elements+=OverridableParserRule*;
 	public AbstractCallOverridenParserRuleElements getAbstractCallOverridenParserRuleAccess() {
 		return pAbstractCallOverridenParserRule;
@@ -258,7 +258,7 @@ public class AbstractTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		return getOverridableParserRule2Access().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
+	/// * SuppressWarnings[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
 	//	"extendedmodel" elements+=ExtendableParserRule*;
 	public AbstractCallExtendedParserRuleElements getAbstractCallExtendedParserRuleAccess() {
 		return pAbstractCallExtendedParserRule;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/services/AbstractTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/services/AbstractTestLanguageGrammarAccess.java
@@ -49,7 +49,7 @@ public class AbstractTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		private final Assignment cElementsAssignment_1 = (Assignment)cGroup.eContents().get(1);
 		private final RuleCall cElementsOverridableParserRuleParserRuleCall_1_0 = (RuleCall)cElementsAssignment_1.eContents().get(0);
 		
-		//AbstractCallOverridenParserRule returns mm::AModel:
+		/// * Suppress[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
 		//	"overridemodel" elements+=OverridableParserRule*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -121,7 +121,7 @@ public class AbstractTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		private final Assignment cElementsAssignment_1 = (Assignment)cGroup.eContents().get(1);
 		private final RuleCall cElementsExtendableParserRuleParserRuleCall_1_0 = (RuleCall)cElementsAssignment_1.eContents().get(0);
 		
-		//AbstractCallExtendedParserRule returns mm::AModel:
+		/// * Suppress[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
 		//	"extendedmodel" elements+=ExtendableParserRule*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -228,7 +228,7 @@ public class AbstractTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		return getInheritedParserRuleAccess().getRule();
 	}
 
-	//AbstractCallOverridenParserRule returns mm::AModel:
+	/// * Suppress[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
 	//	"overridemodel" elements+=OverridableParserRule*;
 	public AbstractCallOverridenParserRuleElements getAbstractCallOverridenParserRuleAccess() {
 		return pAbstractCallOverridenParserRule;
@@ -258,7 +258,7 @@ public class AbstractTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		return getOverridableParserRule2Access().getRule();
 	}
 
-	//AbstractCallExtendedParserRule returns mm::AModel:
+	/// * Suppress[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
 	//	"extendedmodel" elements+=ExtendableParserRule*;
 	public AbstractCallExtendedParserRuleElements getAbstractCallExtendedParserRuleAccess() {
 		return pAbstractCallExtendedParserRule;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/services/ConcreteTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/services/ConcreteTestLanguageGrammarAccess.java
@@ -472,7 +472,7 @@ public class ConcreteTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		return getInheritedParserRuleAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
+	/// * SuppressWarnings[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
 	//	"overridemodel" elements+=OverridableParserRule*;
 	public AbstractTestLanguageGrammarAccess.AbstractCallOverridenParserRuleElements getAbstractCallOverridenParserRuleAccess() {
 		return gaAbstractTestLanguage.getAbstractCallOverridenParserRuleAccess();
@@ -482,7 +482,7 @@ public class ConcreteTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		return getAbstractCallOverridenParserRuleAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
+	/// * SuppressWarnings[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
 	//	"extendedmodel" elements+=ExtendableParserRule*;
 	public AbstractTestLanguageGrammarAccess.AbstractCallExtendedParserRuleElements getAbstractCallExtendedParserRuleAccess() {
 		return gaAbstractTestLanguage.getAbstractCallExtendedParserRuleAccess();

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/services/ConcreteTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/grammarinheritance/services/ConcreteTestLanguageGrammarAccess.java
@@ -472,7 +472,7 @@ public class ConcreteTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		return getInheritedParserRuleAccess().getRule();
 	}
 
-	//AbstractCallOverridenParserRule returns mm::AModel:
+	/// * Suppress[noInstantiation] * / AbstractCallOverridenParserRule returns mm::AModel:
 	//	"overridemodel" elements+=OverridableParserRule*;
 	public AbstractTestLanguageGrammarAccess.AbstractCallOverridenParserRuleElements getAbstractCallOverridenParserRuleAccess() {
 		return gaAbstractTestLanguage.getAbstractCallOverridenParserRuleAccess();
@@ -482,7 +482,7 @@ public class ConcreteTestLanguageGrammarAccess extends AbstractGrammarElementFin
 		return getAbstractCallOverridenParserRuleAccess().getRule();
 	}
 
-	//AbstractCallExtendedParserRule returns mm::AModel:
+	/// * Suppress[noInstantiation] * / AbstractCallExtendedParserRule returns mm::AModel:
 	//	"extendedmodel" elements+=ExtendableParserRule*;
 	public AbstractTestLanguageGrammarAccess.AbstractCallExtendedParserRuleElements getAbstractCallExtendedParserRuleAccess() {
 		return gaAbstractTestLanguage.getAbstractCallExtendedParserRuleAccess();

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/lexer/parser/antlr/internal/InternalBacktrackingLexerTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/lexer/parser/antlr/internal/InternalBacktrackingLexerTestLanguageParser.java
@@ -33,8 +33,8 @@ public class InternalBacktrackingLexerTestLanguageParser extends AbstractInterna
     public static final int RULE_WS=12;
     public static final int RULE_CHARA=6;
     public static final int RULE_SL_COMMENT=13;
-    public static final int RULE_CHARB=7;
     public static final int EOF=-1;
+    public static final int RULE_CHARB=7;
     public static final int RULE_CHARC=11;
 
     // delegates

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/lexer/parser/antlr/internal/InternalIgnoreCaseLexerTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/lexer/parser/antlr/internal/InternalIgnoreCaseLexerTestLanguageParser.java
@@ -26,8 +26,8 @@ public class InternalIgnoreCaseLexerTestLanguageParser extends AbstractInternalA
     public static final int Foo=5;
     public static final int Case=4;
     public static final int RULE_WS=6;
-    public static final int RULE_SL_COMMENT=7;
     public static final int EOF=-1;
+    public static final int RULE_SL_COMMENT=7;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/lexer/parser/antlr/lexer/InternalIgnoreCaseLexerTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/lexer/parser/antlr/lexer/InternalIgnoreCaseLexerTestLanguageLexer.java
@@ -15,8 +15,8 @@ public class InternalIgnoreCaseLexerTestLanguageLexer extends Lexer {
     public static final int Foo=5;
     public static final int Case=4;
     public static final int RULE_WS=6;
-    public static final int RULE_SL_COMMENT=7;
     public static final int EOF=-1;
+    public static final int RULE_SL_COMMENT=7;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/parseTreeConstruction/LazyLinkingTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/parseTreeConstruction/LazyLinkingTestLanguageParsetreeConstructor.java
@@ -99,8 +99,8 @@ protected class Model_TypesAssignment extends AssignmentToken  {
 /************ begin Rule Type ****************
  *
  * / * 
- *  * Suppress[BidirectionalReference]
- *  * Suppress[potentialOverride]
+ *  * SuppressWarnings[BidirectionalReference]
+ *  * SuppressWarnings[potentialOverride]
  *  * / Type:
  * 	"type" name=ID ("extends" extends=[Type] "." parentId=[Property])? ("for" parentId=[Property] "in" extends=[Type])?
  * 	"{" properties+=Property* unresolvedProxyProperty+=UnresolvedProxyProperty* "}";

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/parseTreeConstruction/LazyLinkingTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/parseTreeConstruction/LazyLinkingTestLanguageParsetreeConstructor.java
@@ -98,7 +98,10 @@ protected class Model_TypesAssignment extends AssignmentToken  {
 
 /************ begin Rule Type ****************
  *
- * Type:
+ * / * 
+ *  * Suppress[BidirectionalReference]
+ *  * Suppress[potentialOverride]
+ *  * / Type:
  * 	"type" name=ID ("extends" extends=[Type] "." parentId=[Property])? ("for" parentId=[Property] "in" extends=[Type])?
  * 	"{" properties+=Property* unresolvedProxyProperty+=UnresolvedProxyProperty* "}";
  *

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/parser/antlr/internal/InternalLazyLinkingTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/parser/antlr/internal/InternalLazyLinkingTestLanguageLexer.java
@@ -12,8 +12,12 @@ import java.util.ArrayList;
 
 @SuppressWarnings("all")
 public class InternalLazyLinkingTestLanguageLexer extends Lexer {
-    public static final int T__19=19;
     public static final int RULE_ID=4;
+    public static final int RULE_ANY_OTHER=10;
+    public static final int RULE_SL_COMMENT=8;
+    public static final int EOF=-1;
+    public static final int RULE_ML_COMMENT=7;
+    public static final int T__19=19;
     public static final int RULE_STRING=6;
     public static final int T__16=16;
     public static final int T__15=15;
@@ -23,12 +27,8 @@ public class InternalLazyLinkingTestLanguageLexer extends Lexer {
     public static final int T__11=11;
     public static final int T__14=14;
     public static final int T__13=13;
-    public static final int RULE_ANY_OTHER=10;
     public static final int RULE_INT=5;
     public static final int RULE_WS=9;
-    public static final int RULE_SL_COMMENT=8;
-    public static final int EOF=-1;
-    public static final int RULE_ML_COMMENT=7;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/parser/antlr/internal/InternalLazyLinkingTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/parser/antlr/internal/InternalLazyLinkingTestLanguageParser.java
@@ -23,8 +23,12 @@ public class InternalLazyLinkingTestLanguageParser extends AbstractInternalAntlr
     public static final String[] tokenNames = new String[] {
         "<invalid>", "<EOR>", "<DOWN>", "<UP>", "RULE_ID", "RULE_INT", "RULE_STRING", "RULE_ML_COMMENT", "RULE_SL_COMMENT", "RULE_WS", "RULE_ANY_OTHER", "'type'", "'extends'", "'.'", "'for'", "'in'", "'{'", "'}'", "';'", "'unresolved'"
     };
-    public static final int T__19=19;
     public static final int RULE_ID=4;
+    public static final int RULE_ANY_OTHER=10;
+    public static final int EOF=-1;
+    public static final int RULE_SL_COMMENT=8;
+    public static final int RULE_ML_COMMENT=7;
+    public static final int T__19=19;
     public static final int RULE_STRING=6;
     public static final int T__16=16;
     public static final int T__15=15;
@@ -34,12 +38,8 @@ public class InternalLazyLinkingTestLanguageParser extends AbstractInternalAntlr
     public static final int T__11=11;
     public static final int T__14=14;
     public static final int T__13=13;
-    public static final int RULE_ANY_OTHER=10;
     public static final int RULE_INT=5;
     public static final int RULE_WS=9;
-    public static final int RULE_SL_COMMENT=8;
-    public static final int EOF=-1;
-    public static final int RULE_ML_COMMENT=7;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/services/LazyLinkingTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/services/LazyLinkingTestLanguageGrammarAccess.java
@@ -66,8 +66,8 @@ public class LazyLinkingTestLanguageGrammarAccess extends AbstractGrammarElement
 		private final Keyword cRightCurlyBracketKeyword_7 = (Keyword)cGroup.eContents().get(7);
 		
 		/// * 
-		// * Suppress[BidirectionalReference]
-		// * Suppress[potentialOverride]
+		// * SuppressWarnings[BidirectionalReference]
+		// * SuppressWarnings[potentialOverride]
 		// * / Type:
 		//	"type" name=ID ("extends" extends=[Type] "." parentId=[Property])? ("for" parentId=[Property] "in" extends=[Type])?
 		//	"{" properties+=Property* unresolvedProxyProperty+=UnresolvedProxyProperty* "}";
@@ -294,8 +294,8 @@ public class LazyLinkingTestLanguageGrammarAccess extends AbstractGrammarElement
 	}
 
 	/// * 
-	// * Suppress[BidirectionalReference]
-	// * Suppress[potentialOverride]
+	// * SuppressWarnings[BidirectionalReference]
+	// * SuppressWarnings[potentialOverride]
 	// * / Type:
 	//	"type" name=ID ("extends" extends=[Type] "." parentId=[Property])? ("for" parentId=[Property] "in" extends=[Type])?
 	//	"{" properties+=Property* unresolvedProxyProperty+=UnresolvedProxyProperty* "}";

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/services/LazyLinkingTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/lazy/services/LazyLinkingTestLanguageGrammarAccess.java
@@ -65,7 +65,10 @@ public class LazyLinkingTestLanguageGrammarAccess extends AbstractGrammarElement
 		private final RuleCall cUnresolvedProxyPropertyUnresolvedProxyPropertyParserRuleCall_6_0 = (RuleCall)cUnresolvedProxyPropertyAssignment_6.eContents().get(0);
 		private final Keyword cRightCurlyBracketKeyword_7 = (Keyword)cGroup.eContents().get(7);
 		
-		//Type:
+		/// * 
+		// * Suppress[BidirectionalReference]
+		// * Suppress[potentialOverride]
+		// * / Type:
 		//	"type" name=ID ("extends" extends=[Type] "." parentId=[Property])? ("for" parentId=[Property] "in" extends=[Type])?
 		//	"{" properties+=Property* unresolvedProxyProperty+=UnresolvedProxyProperty* "}";
 		@Override public ParserRule getRule() { return rule; }
@@ -290,7 +293,10 @@ public class LazyLinkingTestLanguageGrammarAccess extends AbstractGrammarElement
 		return getModelAccess().getRule();
 	}
 
-	//Type:
+	/// * 
+	// * Suppress[BidirectionalReference]
+	// * Suppress[potentialOverride]
+	// * / Type:
 	//	"type" name=ID ("extends" extends=[Type] "." parentId=[Property])? ("for" parentId=[Property] "in" extends=[Type])?
 	//	"{" properties+=Property* unresolvedProxyProperty+=UnresolvedProxyProperty* "}";
 	public TypeElements getTypeAccess() {

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/parseTreeConstruction/Bug287988TestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/parseTreeConstruction/Bug287988TestLanguageParsetreeConstructor.java
@@ -51,7 +51,7 @@ protected class ThisRootNode extends RootToken {
 
 /************ begin Rule Model ****************
  *
- * Model:
+ * / * Suppress[noInstantiation] * / Model:
  * 	"actions" attributes+=BaseAttribute* | "simple" attributes+=SimpleAttribute* | "rulecall"
  * 	attributes+=RuleCallAttribute* | "rulecall2" attributes+=RuleCallAttribute2* | "rulecall3"
  * 	attributes+=RuleCallAttribute3* | "inlinedActions" attributes+=ActionAttribute*;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/parseTreeConstruction/Bug287988TestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/parseTreeConstruction/Bug287988TestLanguageParsetreeConstructor.java
@@ -51,7 +51,7 @@ protected class ThisRootNode extends RootToken {
 
 /************ begin Rule Model ****************
  *
- * / * Suppress[noInstantiation] * / Model:
+ * / * SuppressWarnings[noInstantiation] * / Model:
  * 	"actions" attributes+=BaseAttribute* | "simple" attributes+=SimpleAttribute* | "rulecall"
  * 	attributes+=RuleCallAttribute* | "rulecall2" attributes+=RuleCallAttribute2* | "rulecall3"
  * 	attributes+=RuleCallAttribute3* | "inlinedActions" attributes+=ActionAttribute*;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/parser/antlr/internal/InternalBug287988TestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/parser/antlr/internal/InternalBug287988TestLanguageLexer.java
@@ -14,8 +14,8 @@ import java.util.ArrayList;
 public class InternalBug287988TestLanguageLexer extends Lexer {
     public static final int RULE_ID=4;
     public static final int T__22=22;
-    public static final int RULE_ANY_OTHER=10;
     public static final int T__21=21;
+    public static final int RULE_ANY_OTHER=10;
     public static final int T__20=20;
     public static final int EOF=-1;
     public static final int RULE_SL_COMMENT=8;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/services/Bug287988TestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/services/Bug287988TestLanguageGrammarAccess.java
@@ -46,7 +46,7 @@ public class Bug287988TestLanguageGrammarAccess extends AbstractGrammarElementFi
 		private final Assignment cAttributesAssignment_5_1 = (Assignment)cGroup_5.eContents().get(1);
 		private final RuleCall cAttributesActionAttributeParserRuleCall_5_1_0 = (RuleCall)cAttributesAssignment_5_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / Model:
+		/// * SuppressWarnings[noInstantiation] * / Model:
 		//	"actions" attributes+=BaseAttribute* | "simple" attributes+=SimpleAttribute* | "rulecall"
 		//	attributes+=RuleCallAttribute* | "rulecall2" attributes+=RuleCallAttribute2* | "rulecall3"
 		//	attributes+=RuleCallAttribute3* | "inlinedActions" attributes+=ActionAttribute*;
@@ -672,7 +672,7 @@ public class Bug287988TestLanguageGrammarAccess extends AbstractGrammarElementFi
 	}
 
 	
-	/// * Suppress[noInstantiation] * / Model:
+	/// * SuppressWarnings[noInstantiation] * / Model:
 	//	"actions" attributes+=BaseAttribute* | "simple" attributes+=SimpleAttribute* | "rulecall"
 	//	attributes+=RuleCallAttribute* | "rulecall2" attributes+=RuleCallAttribute2* | "rulecall3"
 	//	attributes+=RuleCallAttribute3* | "inlinedActions" attributes+=ActionAttribute*;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/services/Bug287988TestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/linking/services/Bug287988TestLanguageGrammarAccess.java
@@ -46,7 +46,7 @@ public class Bug287988TestLanguageGrammarAccess extends AbstractGrammarElementFi
 		private final Assignment cAttributesAssignment_5_1 = (Assignment)cGroup_5.eContents().get(1);
 		private final RuleCall cAttributesActionAttributeParserRuleCall_5_1_0 = (RuleCall)cAttributesAssignment_5_1.eContents().get(0);
 		
-		//Model:
+		/// * Suppress[noInstantiation] * / Model:
 		//	"actions" attributes+=BaseAttribute* | "simple" attributes+=SimpleAttribute* | "rulecall"
 		//	attributes+=RuleCallAttribute* | "rulecall2" attributes+=RuleCallAttribute2* | "rulecall3"
 		//	attributes+=RuleCallAttribute3* | "inlinedActions" attributes+=ActionAttribute*;
@@ -672,7 +672,7 @@ public class Bug287988TestLanguageGrammarAccess extends AbstractGrammarElementFi
 	}
 
 	
-	//Model:
+	/// * Suppress[noInstantiation] * / Model:
 	//	"actions" attributes+=BaseAttribute* | "simple" attributes+=SimpleAttribute* | "rulecall"
 	//	attributes+=RuleCallAttribute* | "rulecall2" attributes+=RuleCallAttribute2* | "rulecall3"
 	//	attributes+=RuleCallAttribute3* | "inlinedActions" attributes+=ActionAttribute*;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parseTreeConstruction/XtextGrammarTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parseTreeConstruction/XtextGrammarTestLanguageParsetreeConstructor.java
@@ -2544,7 +2544,7 @@ protected class AbstractToken_ActionParserRuleCall_1 extends RuleCallToken {
 
 /************ begin Rule AbstractTokenWithCardinality ****************
  *
- * / * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
+ * / * SuppressWarnings[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
  * 	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
  *
  **/
@@ -5485,7 +5485,7 @@ protected class TerminalGroup_TokensAssignment_1_1 extends AssignmentToken  {
 
 /************ begin Rule TerminalToken ****************
  *
- * / * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
+ * / * SuppressWarnings[potentialOverride] * / TerminalToken returns AbstractElement:
  * 	TerminalTokenElement cardinality=("?" | "*" | "+")?;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parseTreeConstruction/XtextGrammarTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parseTreeConstruction/XtextGrammarTestLanguageParsetreeConstructor.java
@@ -2544,7 +2544,7 @@ protected class AbstractToken_ActionParserRuleCall_1 extends RuleCallToken {
 
 /************ begin Rule AbstractTokenWithCardinality ****************
  *
- * AbstractTokenWithCardinality returns AbstractElement:
+ * / * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
  * 	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
  *
  **/
@@ -5485,7 +5485,7 @@ protected class TerminalGroup_TokensAssignment_1_1 extends AssignmentToken  {
 
 /************ begin Rule TerminalToken ****************
  *
- * TerminalToken returns AbstractElement:
+ * / * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
  * 	TerminalTokenElement cardinality=("?" | "*" | "+")?;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parseTreeConstruction/Bug296889ExTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parseTreeConstruction/Bug296889ExTestLanguageParsetreeConstructor.java
@@ -43,7 +43,7 @@ protected class ThisRootNode extends RootToken {
 
 /************ begin Rule Model ****************
  *
- * / * Suppress[noInstantiation] * / Model:
+ * / * SuppressWarnings[noInstantiation] * / Model:
  * 	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parseTreeConstruction/Bug296889ExTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parseTreeConstruction/Bug296889ExTestLanguageParsetreeConstructor.java
@@ -43,7 +43,7 @@ protected class ThisRootNode extends RootToken {
 
 /************ begin Rule Model ****************
  *
- * Model:
+ * / * Suppress[noInstantiation] * / Model:
  * 	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parseTreeConstruction/Bug296889TestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parseTreeConstruction/Bug296889TestLanguageParsetreeConstructor.java
@@ -43,7 +43,7 @@ protected class ThisRootNode extends RootToken {
 
 /************ begin Rule Model ****************
  *
- * / * Suppress[noInstantiation] * / Model:
+ * / * SuppressWarnings[noInstantiation] * / Model:
  * 	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parseTreeConstruction/Bug296889TestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parseTreeConstruction/Bug296889TestLanguageParsetreeConstructor.java
@@ -43,7 +43,7 @@ protected class ThisRootNode extends RootToken {
 
 /************ begin Rule Model ****************
  *
- * Model:
+ * / * Suppress[noInstantiation] * / Model:
  * 	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/internal/InternalBug289515TestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/internal/InternalBug289515TestLanguageLexer.java
@@ -12,8 +12,12 @@ import java.util.ArrayList;
 
 @SuppressWarnings("all")
 public class InternalBug289515TestLanguageLexer extends Lexer {
-    public static final int T__19=19;
     public static final int RULE_ID=4;
+    public static final int RULE_ANY_OTHER=10;
+    public static final int RULE_SL_COMMENT=8;
+    public static final int EOF=-1;
+    public static final int RULE_ML_COMMENT=7;
+    public static final int T__19=19;
     public static final int RULE_STRING=6;
     public static final int T__16=16;
     public static final int T__15=15;
@@ -23,12 +27,8 @@ public class InternalBug289515TestLanguageLexer extends Lexer {
     public static final int T__11=11;
     public static final int T__14=14;
     public static final int T__13=13;
-    public static final int RULE_ANY_OTHER=10;
     public static final int RULE_INT=5;
     public static final int RULE_WS=9;
-    public static final int RULE_SL_COMMENT=8;
-    public static final int EOF=-1;
-    public static final int RULE_ML_COMMENT=7;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/internal/InternalBug289515TestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/internal/InternalBug289515TestLanguageParser.java
@@ -23,8 +23,12 @@ public class InternalBug289515TestLanguageParser extends AbstractInternalAntlrPa
     public static final String[] tokenNames = new String[] {
         "<invalid>", "<EOR>", "<DOWN>", "<UP>", "RULE_ID", "RULE_INT", "RULE_STRING", "RULE_ML_COMMENT", "RULE_SL_COMMENT", "RULE_WS", "RULE_ANY_OTHER", "'1'", "'%'", "'2'", "'3'", "'\\\\%'", "'4'", "'5'", "'%%'", "'6'"
     };
-    public static final int T__19=19;
     public static final int RULE_ID=4;
+    public static final int RULE_ANY_OTHER=10;
+    public static final int EOF=-1;
+    public static final int RULE_SL_COMMENT=8;
+    public static final int RULE_ML_COMMENT=7;
+    public static final int T__19=19;
     public static final int RULE_STRING=6;
     public static final int T__16=16;
     public static final int T__15=15;
@@ -34,12 +38,8 @@ public class InternalBug289515TestLanguageParser extends AbstractInternalAntlrPa
     public static final int T__11=11;
     public static final int T__14=14;
     public static final int T__13=13;
-    public static final int RULE_ANY_OTHER=10;
     public static final int RULE_INT=5;
     public static final int RULE_WS=9;
-    public static final int RULE_SL_COMMENT=8;
-    public static final int EOF=-1;
-    public static final int RULE_ML_COMMENT=7;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/internal/InternalBug289524ExTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/internal/InternalBug289524ExTestLanguageParser.java
@@ -25,8 +25,8 @@ public class InternalBug289524ExTestLanguageParser extends AbstractInternalAntlr
         "<invalid>", "<EOR>", "<DOWN>", "<UP>", "Containment", "Reference", "Model", "DollarSign", "RULE_ID", "RULE_INT", "RULE_STRING", "RULE_ML_COMMENT", "RULE_SL_COMMENT", "RULE_WS", "RULE_ANY_OTHER"
     };
     public static final int RULE_ID=8;
-    public static final int Model=6;
     public static final int RULE_STRING=10;
+    public static final int Model=6;
     public static final int DollarSign=7;
     public static final int RULE_ANY_OTHER=14;
     public static final int RULE_INT=9;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/internal/InternalBug296889ExTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/internal/InternalBug296889ExTestLanguageParser.java
@@ -25,9 +25,9 @@ public class InternalBug296889ExTestLanguageParser extends AbstractInternalAntlr
         "<invalid>", "<EOR>", "<DOWN>", "<UP>", "DataType", "Model", "HyphenMinusHyphenMinus", "RULE_ID", "RULE_INT", "RULE_STRING", "RULE_ML_COMMENT", "RULE_SL_COMMENT", "RULE_WS", "RULE_ANY_OTHER"
     };
     public static final int RULE_ID=7;
-    public static final int Model=5;
     public static final int RULE_STRING=9;
     public static final int DataType=4;
+    public static final int Model=5;
     public static final int HyphenMinusHyphenMinus=6;
     public static final int RULE_ANY_OTHER=13;
     public static final int RULE_INT=8;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/internal/InternalBug301935ExTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/internal/InternalBug301935ExTestLanguageParser.java
@@ -24,11 +24,11 @@ public class InternalBug301935ExTestLanguageParser extends AbstractInternalAntlr
         "<invalid>", "<EOR>", "<DOWN>", "<UP>", "Control000a", "Control000d", "RULE_ID", "RULE_WS", "RULE_ANY_OTHER"
     };
     public static final int RULE_ID=6;
+    public static final int Control000d=5;
+    public static final int RULE_ANY_OTHER=8;
     public static final int Control000a=4;
     public static final int RULE_WS=7;
     public static final int EOF=-1;
-    public static final int Control000d=5;
-    public static final int RULE_ANY_OTHER=8;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/lexer/InternalBug289524ExTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/lexer/InternalBug289524ExTestLanguageLexer.java
@@ -14,8 +14,8 @@ import java.util.ArrayList;
 public class InternalBug289524ExTestLanguageLexer extends Lexer {
     public static final int RULE_ID=8;
     public static final int RULE_STRING=10;
-    public static final int DollarSign=7;
     public static final int Model=6;
+    public static final int DollarSign=7;
     public static final int RULE_ANY_OTHER=14;
     public static final int RULE_INT=9;
     public static final int RULE_WS=13;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/lexer/InternalBug301935ExTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/parser/antlr/lexer/InternalBug301935ExTestLanguageLexer.java
@@ -13,11 +13,11 @@ import java.util.ArrayList;
 @SuppressWarnings("all")
 public class InternalBug301935ExTestLanguageLexer extends Lexer {
     public static final int RULE_ID=6;
+    public static final int Control000d=5;
+    public static final int RULE_ANY_OTHER=8;
     public static final int Control000a=4;
     public static final int RULE_WS=7;
     public static final int EOF=-1;
-    public static final int Control000d=5;
-    public static final int RULE_ANY_OTHER=8;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/services/Bug296889ExTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/services/Bug296889ExTestLanguageGrammarAccess.java
@@ -30,7 +30,7 @@ public class Bug296889ExTestLanguageGrammarAccess extends AbstractGrammarElement
 		private final Assignment cValuesAssignment_1_1 = (Assignment)cGroup_1.eContents().get(1);
 		private final RuleCall cValuesDataTypeExpressionParserRuleCall_1_1_0 = (RuleCall)cValuesAssignment_1_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / Model:
+		/// * SuppressWarnings[noInstantiation] * / Model:
 		//	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -300,7 +300,7 @@ public class Bug296889ExTestLanguageGrammarAccess extends AbstractGrammarElement
 	}
 
 	
-	/// * Suppress[noInstantiation] * / Model:
+	/// * SuppressWarnings[noInstantiation] * / Model:
 	//	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
 	public ModelElements getModelAccess() {
 		return pModel;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/services/Bug296889ExTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/services/Bug296889ExTestLanguageGrammarAccess.java
@@ -30,7 +30,7 @@ public class Bug296889ExTestLanguageGrammarAccess extends AbstractGrammarElement
 		private final Assignment cValuesAssignment_1_1 = (Assignment)cGroup_1.eContents().get(1);
 		private final RuleCall cValuesDataTypeExpressionParserRuleCall_1_1_0 = (RuleCall)cValuesAssignment_1_1.eContents().get(0);
 		
-		//Model:
+		/// * Suppress[noInstantiation] * / Model:
 		//	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -300,7 +300,7 @@ public class Bug296889ExTestLanguageGrammarAccess extends AbstractGrammarElement
 	}
 
 	
-	//Model:
+	/// * Suppress[noInstantiation] * / Model:
 	//	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
 	public ModelElements getModelAccess() {
 		return pModel;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/services/Bug296889TestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/services/Bug296889TestLanguageGrammarAccess.java
@@ -30,7 +30,7 @@ public class Bug296889TestLanguageGrammarAccess extends AbstractGrammarElementFi
 		private final Assignment cValuesAssignment_1_1 = (Assignment)cGroup_1.eContents().get(1);
 		private final RuleCall cValuesDataTypeExpressionParserRuleCall_1_1_0 = (RuleCall)cValuesAssignment_1_1.eContents().get(0);
 		
-		//Model:
+		/// * Suppress[noInstantiation] * / Model:
 		//	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -300,7 +300,7 @@ public class Bug296889TestLanguageGrammarAccess extends AbstractGrammarElementFi
 	}
 
 	
-	//Model:
+	/// * Suppress[noInstantiation] * / Model:
 	//	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
 	public ModelElements getModelAccess() {
 		return pModel;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/services/Bug296889TestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/antlr/services/Bug296889TestLanguageGrammarAccess.java
@@ -30,7 +30,7 @@ public class Bug296889TestLanguageGrammarAccess extends AbstractGrammarElementFi
 		private final Assignment cValuesAssignment_1_1 = (Assignment)cGroup_1.eContents().get(1);
 		private final RuleCall cValuesDataTypeExpressionParserRuleCall_1_1_0 = (RuleCall)cValuesAssignment_1_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / Model:
+		/// * SuppressWarnings[noInstantiation] * / Model:
 		//	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -300,7 +300,7 @@ public class Bug296889TestLanguageGrammarAccess extends AbstractGrammarElementFi
 	}
 
 	
-	/// * Suppress[noInstantiation] * / Model:
+	/// * SuppressWarnings[noInstantiation] * / Model:
 	//	"Model" expressions+=Expression* | "DataType" values+=DataTypeExpression*;
 	public ModelElements getModelAccess() {
 		return pModel;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/datatyperules/parser/antlr/internal/InternalDatatypeRulesTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/datatyperules/parser/antlr/internal/InternalDatatypeRulesTestLanguageLexer.java
@@ -14,8 +14,8 @@ import java.util.ArrayList;
 public class InternalDatatypeRulesTestLanguageLexer extends Lexer {
     public static final int RULE_ID=4;
     public static final int T__22=22;
-    public static final int RULE_ANY_OTHER=10;
     public static final int T__21=21;
+    public static final int RULE_ANY_OTHER=10;
     public static final int T__20=20;
     public static final int EOF=-1;
     public static final int RULE_SL_COMMENT=8;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parseTreeConstruction/XtextTerminalsTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parseTreeConstruction/XtextTerminalsTestLanguageParsetreeConstructor.java
@@ -2542,7 +2542,7 @@ protected class AbstractToken_ActionParserRuleCall_1 extends RuleCallToken {
 
 /************ begin Rule AbstractTokenWithCardinality ****************
  *
- * AbstractTokenWithCardinality returns AbstractElement:
+ * / * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
  * 	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
  *
  **/
@@ -5099,7 +5099,7 @@ protected class TerminalGroup_TokensAssignment_1_1 extends AssignmentToken  {
 
 /************ begin Rule TerminalToken ****************
  *
- * TerminalToken returns AbstractElement:
+ * / * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
  * 	TerminalTokenElement cardinality=("?" | "*" | "+")?;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parseTreeConstruction/XtextTerminalsTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parseTreeConstruction/XtextTerminalsTestLanguageParsetreeConstructor.java
@@ -2542,7 +2542,7 @@ protected class AbstractToken_ActionParserRuleCall_1 extends RuleCallToken {
 
 /************ begin Rule AbstractTokenWithCardinality ****************
  *
- * / * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
+ * / * SuppressWarnings[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
  * 	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
  *
  **/
@@ -5099,7 +5099,7 @@ protected class TerminalGroup_TokensAssignment_1_1 extends AssignmentToken  {
 
 /************ begin Rule TerminalToken ****************
  *
- * / * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
+ * / * SuppressWarnings[potentialOverride] * / TerminalToken returns AbstractElement:
  * 	TerminalTokenElement cardinality=("?" | "*" | "+")?;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parser/antlr/internal/InternalBug292245TestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parser/antlr/internal/InternalBug292245TestLanguageLexer.java
@@ -12,14 +12,14 @@ import java.util.ArrayList;
 
 @SuppressWarnings("all")
 public class InternalBug292245TestLanguageLexer extends Lexer {
-    public static final int RULE_CHAR=5;
     public static final int RULE_APOSTROPHE_CHAR=4;
+    public static final int T__10=10;
+    public static final int RULE_CHAR=5;
     public static final int RULE_WS=6;
     public static final int EOF=-1;
     public static final int T__9=9;
     public static final int T__8=8;
     public static final int T__7=7;
-    public static final int T__10=10;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parser/antlr/internal/InternalBug317840TestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parser/antlr/internal/InternalBug317840TestLanguageLexer.java
@@ -661,7 +661,7 @@ public class InternalBug317840TestLanguageLexer extends Lexer {
     static final String DFA12_acceptS =
         "\2\uffff\1\2\1\uffff\1\3\1\4\3\uffff\1\10\1\11\1\uffff\1\3\1\2\1\4\1\5\1\6\1\7\1\10\5\uffff\1\1";
     static final String DFA12_specialS =
-        "\1\0\5\uffff\1\1\1\2\21\uffff}>";
+        "\1\1\5\uffff\1\2\1\0\21\uffff}>";
     static final String[] DFA12_transitionS = {
             "\11\12\2\11\2\12\1\11\22\12\1\11\1\12\1\6\4\12\1\7\6\12\1\2\1\10\12\5\7\12\32\4\3\12\1\3\1\4\1\12\4\4\1\1\25\4\uff85\12",
             "\1\13",
@@ -727,6 +727,16 @@ public class InternalBug317840TestLanguageLexer extends Lexer {
         	int _s = s;
             switch ( s ) {
                     case 0 : 
+                        int LA12_7 = input.LA(1);
+
+                        s = -1;
+                        if ( ((LA12_7>='\u0000' && LA12_7<='\uFFFF')) ) {s = 15;}
+
+                        else s = 10;
+
+                        if ( s>=0 ) return s;
+                        break;
+                    case 1 : 
                         int LA12_0 = input.LA(1);
 
                         s = -1;
@@ -752,21 +762,11 @@ public class InternalBug317840TestLanguageLexer extends Lexer {
 
                         if ( s>=0 ) return s;
                         break;
-                    case 1 : 
+                    case 2 : 
                         int LA12_6 = input.LA(1);
 
                         s = -1;
                         if ( ((LA12_6>='\u0000' && LA12_6<='\uFFFF')) ) {s = 15;}
-
-                        else s = 10;
-
-                        if ( s>=0 ) return s;
-                        break;
-                    case 2 : 
-                        int LA12_7 = input.LA(1);
-
-                        s = -1;
-                        if ( ((LA12_7>='\u0000' && LA12_7<='\uFFFF')) ) {s = 15;}
 
                         else s = 10;
 

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parser/antlr/internal/InternalEcoreTerminalsTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parser/antlr/internal/InternalEcoreTerminalsTestLanguageLexer.java
@@ -12,14 +12,14 @@ import java.util.ArrayList;
 
 @SuppressWarnings("all")
 public class InternalEcoreTerminalsTestLanguageLexer extends Lexer {
-    public static final int RULE_EINT=4;
     public static final int RULE_EDATE=6;
+    public static final int RULE_EDOUBLE=5;
+    public static final int T__10=10;
+    public static final int RULE_EINT=4;
     public static final int RULE_WS=7;
     public static final int EOF=-1;
     public static final int T__9=9;
     public static final int T__8=8;
-    public static final int T__10=10;
-    public static final int RULE_EDOUBLE=5;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parser/antlr/internal/InternalHiddenTerminalsTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parser/antlr/internal/InternalHiddenTerminalsTestLanguageLexer.java
@@ -12,6 +12,12 @@ import java.util.ArrayList;
 
 @SuppressWarnings("all")
 public class InternalHiddenTerminalsTestLanguageLexer extends Lexer {
+    public static final int RULE_ANY_OTHER=7;
+    public static final int RULE_SL_COMMENT=6;
+    public static final int EOF=-1;
+    public static final int T__9=9;
+    public static final int T__8=8;
+    public static final int RULE_ML_COMMENT=5;
     public static final int T__19=19;
     public static final int T__16=16;
     public static final int T__15=15;
@@ -21,14 +27,8 @@ public class InternalHiddenTerminalsTestLanguageLexer extends Lexer {
     public static final int T__11=11;
     public static final int T__14=14;
     public static final int T__13=13;
-    public static final int RULE_ANY_OTHER=7;
     public static final int T__10=10;
     public static final int RULE_WS=4;
-    public static final int RULE_SL_COMMENT=6;
-    public static final int EOF=-1;
-    public static final int T__9=9;
-    public static final int T__8=8;
-    public static final int RULE_ML_COMMENT=5;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parser/antlr/internal/InternalHiddenTerminalsTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/parser/antlr/internal/InternalHiddenTerminalsTestLanguageParser.java
@@ -23,6 +23,12 @@ public class InternalHiddenTerminalsTestLanguageParser extends AbstractInternalA
     public static final String[] tokenNames = new String[] {
         "<invalid>", "<EOR>", "<DOWN>", "<UP>", "RULE_WS", "RULE_ML_COMMENT", "RULE_SL_COMMENT", "RULE_ANY_OTHER", "'without'", "'hiddens'", "';'", "'with'", "'overriding'", "'('", "')'", "'call'", "'inheriting'", "'datatype'", "'rule'", "'hiding'"
     };
+    public static final int RULE_ANY_OTHER=7;
+    public static final int EOF=-1;
+    public static final int RULE_SL_COMMENT=6;
+    public static final int T__9=9;
+    public static final int T__8=8;
+    public static final int RULE_ML_COMMENT=5;
     public static final int T__19=19;
     public static final int T__16=16;
     public static final int T__15=15;
@@ -32,14 +38,8 @@ public class InternalHiddenTerminalsTestLanguageParser extends AbstractInternalA
     public static final int T__11=11;
     public static final int T__14=14;
     public static final int T__13=13;
-    public static final int RULE_ANY_OTHER=7;
     public static final int T__10=10;
     public static final int RULE_WS=4;
-    public static final int RULE_SL_COMMENT=6;
-    public static final int EOF=-1;
-    public static final int T__9=9;
-    public static final int T__8=8;
-    public static final int RULE_ML_COMMENT=5;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/services/XtextTerminalsTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/services/XtextTerminalsTestLanguageGrammarAccess.java
@@ -587,7 +587,7 @@ public class XtextTerminalsTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Keyword cCardinalityAsteriskKeyword_1_0_1 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(1);
 		private final Keyword cCardinalityPlusSignKeyword_1_0_2 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(2);
 		
-		//AbstractTokenWithCardinality returns AbstractElement:
+		/// * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
 		//	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1109,7 +1109,7 @@ public class XtextTerminalsTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Keyword cCardinalityAsteriskKeyword_1_0_1 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(1);
 		private final Keyword cCardinalityPlusSignKeyword_1_0_2 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(2);
 		
-		//TerminalToken returns AbstractElement:
+		/// * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
 		//	TerminalTokenElement cardinality=("?" | "*" | "+")?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1688,7 +1688,7 @@ public class XtextTerminalsTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getAbstractTokenAccess().getRule();
 	}
 
-	//AbstractTokenWithCardinality returns AbstractElement:
+	/// * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
 	//	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
 	public AbstractTokenWithCardinalityElements getAbstractTokenWithCardinalityAccess() {
 		return pAbstractTokenWithCardinality;
@@ -1838,7 +1838,7 @@ public class XtextTerminalsTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getTerminalGroupAccess().getRule();
 	}
 
-	//TerminalToken returns AbstractElement:
+	/// * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
 	//	TerminalTokenElement cardinality=("?" | "*" | "+")?;
 	public TerminalTokenElements getTerminalTokenAccess() {
 		return pTerminalToken;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/services/XtextTerminalsTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/terminalrules/services/XtextTerminalsTestLanguageGrammarAccess.java
@@ -587,7 +587,7 @@ public class XtextTerminalsTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Keyword cCardinalityAsteriskKeyword_1_0_1 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(1);
 		private final Keyword cCardinalityPlusSignKeyword_1_0_2 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(2);
 		
-		/// * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
+		/// * SuppressWarnings[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
 		//	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1109,7 +1109,7 @@ public class XtextTerminalsTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Keyword cCardinalityAsteriskKeyword_1_0_1 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(1);
 		private final Keyword cCardinalityPlusSignKeyword_1_0_2 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(2);
 		
-		/// * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
+		/// * SuppressWarnings[potentialOverride] * / TerminalToken returns AbstractElement:
 		//	TerminalTokenElement cardinality=("?" | "*" | "+")?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1688,7 +1688,7 @@ public class XtextTerminalsTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getAbstractTokenAccess().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
+	/// * SuppressWarnings[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
 	//	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
 	public AbstractTokenWithCardinalityElements getAbstractTokenWithCardinalityAccess() {
 		return pAbstractTokenWithCardinality;
@@ -1838,7 +1838,7 @@ public class XtextTerminalsTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getTerminalGroupAccess().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
+	/// * SuppressWarnings[potentialOverride] * / TerminalToken returns AbstractElement:
 	//	TerminalTokenElement cardinality=("?" | "*" | "+")?;
 	public TerminalTokenElements getTerminalTokenAccess() {
 		return pTerminalToken;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/ExUnorderedGroupsTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/ExUnorderedGroupsTestLanguageParsetreeConstructor.java
@@ -3054,7 +3054,7 @@ protected class NestedModel_NestedKeyword_2 extends KeywordToken  {
 
 /************ begin Rule UnorderedSerialization ****************
  *
- * / * Suppress[potentialOverride] * / UnorderedSerialization:
+ * / * SuppressWarnings[potentialOverride] * / UnorderedSerialization:
  * 	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
  * 	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
  *

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/ExUnorderedGroupsTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/ExUnorderedGroupsTestLanguageParsetreeConstructor.java
@@ -3054,7 +3054,7 @@ protected class NestedModel_NestedKeyword_2 extends KeywordToken  {
 
 /************ begin Rule UnorderedSerialization ****************
  *
- * UnorderedSerialization:
+ * / * Suppress[potentialOverride] * / UnorderedSerialization:
  * 	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
  * 	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
  *

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/SimpleUnorderedGroupsTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/SimpleUnorderedGroupsTestLanguageParsetreeConstructor.java
@@ -3054,7 +3054,7 @@ protected class NestedModel_NestedKeyword_2 extends KeywordToken  {
 
 /************ begin Rule UnorderedSerialization ****************
  *
- * / * Suppress[potentialOverride] * / UnorderedSerialization:
+ * / * SuppressWarnings[potentialOverride] * / UnorderedSerialization:
  * 	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
  * 	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
  *

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/SimpleUnorderedGroupsTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/SimpleUnorderedGroupsTestLanguageParsetreeConstructor.java
@@ -3054,7 +3054,7 @@ protected class NestedModel_NestedKeyword_2 extends KeywordToken  {
 
 /************ begin Rule UnorderedSerialization ****************
  *
- * UnorderedSerialization:
+ * / * Suppress[potentialOverride] * / UnorderedSerialization:
  * 	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
  * 	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
  *

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/UnorderedGroupsTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/UnorderedGroupsTestLanguageParsetreeConstructor.java
@@ -3007,7 +3007,7 @@ protected class NestedModel_NestedKeyword_2 extends KeywordToken  {
 
 /************ begin Rule UnorderedSerialization ****************
  *
- * / * Suppress[potentialOverride] * / UnorderedSerialization:
+ * / * SuppressWarnings[potentialOverride] * / UnorderedSerialization:
  * 	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
  * 	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
  *

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/UnorderedGroupsTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parseTreeConstruction/UnorderedGroupsTestLanguageParsetreeConstructor.java
@@ -3007,7 +3007,7 @@ protected class NestedModel_NestedKeyword_2 extends KeywordToken  {
 
 /************ begin Rule UnorderedSerialization ****************
  *
- * UnorderedSerialization:
+ * / * Suppress[potentialOverride] * / UnorderedSerialization:
  * 	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
  * 	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
  *

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parser/antlr/internal/InternalSimpleUnorderedGroupsTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parser/antlr/internal/InternalSimpleUnorderedGroupsTestLanguageLexer.java
@@ -27,8 +27,8 @@ public class InternalSimpleUnorderedGroupsTestLanguageLexer extends Lexer {
     public static final int EOF=-1;
     public static final int RULE_SL_COMMENT=8;
     public static final int RULE_ML_COMMENT=7;
-    public static final int T__19=19;
     public static final int T__30=30;
+    public static final int T__19=19;
     public static final int T__31=31;
     public static final int T__32=32;
     public static final int RULE_STRING=6;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parser/antlr/internal/InternalUnorderedGroupsTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/parser/antlr/internal/InternalUnorderedGroupsTestLanguageLexer.java
@@ -27,8 +27,8 @@ public class InternalUnorderedGroupsTestLanguageLexer extends Lexer {
     public static final int EOF=-1;
     public static final int RULE_SL_COMMENT=8;
     public static final int RULE_ML_COMMENT=7;
-    public static final int T__19=19;
     public static final int T__30=30;
+    public static final int T__19=19;
     public static final int T__31=31;
     public static final int T__32=32;
     public static final int RULE_STRING=6;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/ExUnorderedGroupsTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/ExUnorderedGroupsTestLanguageGrammarAccess.java
@@ -121,7 +121,7 @@ public class ExUnorderedGroupsTestLanguageGrammarAccess extends AbstractGrammarE
 		return getUnorderedDatatypeAccess().getRule();
 	}
 
-	//UnorderedSerialization:
+	/// * Suppress[potentialOverride] * / UnorderedSerialization:
 	//	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
 	//	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
 	public UnorderedGroupsTestLanguageGrammarAccess.UnorderedSerializationElements getUnorderedSerializationAccess() {

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/ExUnorderedGroupsTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/ExUnorderedGroupsTestLanguageGrammarAccess.java
@@ -121,7 +121,7 @@ public class ExUnorderedGroupsTestLanguageGrammarAccess extends AbstractGrammarE
 		return getUnorderedDatatypeAccess().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / UnorderedSerialization:
+	/// * SuppressWarnings[potentialOverride] * / UnorderedSerialization:
 	//	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
 	//	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
 	public UnorderedGroupsTestLanguageGrammarAccess.UnorderedSerializationElements getUnorderedSerializationAccess() {

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/SimpleUnorderedGroupsTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/SimpleUnorderedGroupsTestLanguageGrammarAccess.java
@@ -121,7 +121,7 @@ public class SimpleUnorderedGroupsTestLanguageGrammarAccess extends AbstractGram
 		return getUnorderedDatatypeAccess().getRule();
 	}
 
-	//UnorderedSerialization:
+	/// * Suppress[potentialOverride] * / UnorderedSerialization:
 	//	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
 	//	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
 	public UnorderedGroupsTestLanguageGrammarAccess.UnorderedSerializationElements getUnorderedSerializationAccess() {

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/SimpleUnorderedGroupsTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/SimpleUnorderedGroupsTestLanguageGrammarAccess.java
@@ -121,7 +121,7 @@ public class SimpleUnorderedGroupsTestLanguageGrammarAccess extends AbstractGram
 		return getUnorderedDatatypeAccess().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / UnorderedSerialization:
+	/// * SuppressWarnings[potentialOverride] * / UnorderedSerialization:
 	//	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
 	//	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
 	public UnorderedGroupsTestLanguageGrammarAccess.UnorderedSerializationElements getUnorderedSerializationAccess() {

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/UnorderedGroupsTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/UnorderedGroupsTestLanguageGrammarAccess.java
@@ -1034,7 +1034,7 @@ public class UnorderedGroupsTestLanguageGrammarAccess extends AbstractGrammarEle
 		private final Assignment cSecondAssignment_1_2_1_1 = (Assignment)cUnorderedGroup_1_2_1.eContents().get(1);
 		private final Keyword cSecondBKeyword_1_2_1_1_0 = (Keyword)cSecondAssignment_1_2_1_1.eContents().get(0);
 		
-		/// * Suppress[potentialOverride] * / UnorderedSerialization:
+		/// * SuppressWarnings[potentialOverride] * / UnorderedSerialization:
 		//	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
 		//	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
 		@Override public ParserRule getRule() { return rule; }
@@ -1213,7 +1213,7 @@ public class UnorderedGroupsTestLanguageGrammarAccess extends AbstractGrammarEle
 		return getUnorderedDatatypeAccess().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / UnorderedSerialization:
+	/// * SuppressWarnings[potentialOverride] * / UnorderedSerialization:
 	//	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
 	//	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
 	public UnorderedSerializationElements getUnorderedSerializationAccess() {

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/UnorderedGroupsTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parser/unorderedGroups/services/UnorderedGroupsTestLanguageGrammarAccess.java
@@ -1034,7 +1034,7 @@ public class UnorderedGroupsTestLanguageGrammarAccess extends AbstractGrammarEle
 		private final Assignment cSecondAssignment_1_2_1_1 = (Assignment)cUnorderedGroup_1_2_1.eContents().get(1);
 		private final Keyword cSecondBKeyword_1_2_1_1_0 = (Keyword)cSecondAssignment_1_2_1_1.eContents().get(0);
 		
-		//UnorderedSerialization:
+		/// * Suppress[potentialOverride] * / UnorderedSerialization:
 		//	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
 		//	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
 		@Override public ParserRule getRule() { return rule; }
@@ -1213,7 +1213,7 @@ public class UnorderedGroupsTestLanguageGrammarAccess extends AbstractGrammarEle
 		return getUnorderedDatatypeAccess().getRule();
 	}
 
-	//UnorderedSerialization:
+	/// * Suppress[potentialOverride] * / UnorderedSerialization:
 	//	{UnorderedSerialization} ("1" first?="a"? & second?="b"? & third?="c"? & forth?="d"? | "2" (firstAsList+="a" &
 	//	secondAsList+="b")* | "3" (firstAsList+="a"+ & second?="b")*);
 	public UnorderedSerializationElements getUnorderedSerializationAccess() {

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/formatter/parser/antlr/internal/InternalElementMatcherTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/formatter/parser/antlr/internal/InternalElementMatcherTestLanguageLexer.java
@@ -27,8 +27,8 @@ public class InternalElementMatcherTestLanguageLexer extends Lexer {
     public static final int EOF=-1;
     public static final int RULE_SL_COMMENT=8;
     public static final int RULE_ML_COMMENT=7;
-    public static final int T__19=19;
     public static final int T__30=30;
+    public static final int T__19=19;
     public static final int T__31=31;
     public static final int T__32=32;
     public static final int RULE_STRING=6;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/formatter/parser/antlr/internal/InternalFormatterTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/formatter/parser/antlr/internal/InternalFormatterTestLanguageLexer.java
@@ -12,11 +12,7 @@ import java.util.ArrayList;
 
 @SuppressWarnings("all")
 public class InternalFormatterTestLanguageLexer extends Lexer {
-    public static final int T__42=42;
-    public static final int T__43=43;
-    public static final int T__40=40;
     public static final int RULE_ID=4;
-    public static final int T__41=41;
     public static final int T__29=29;
     public static final int T__28=28;
     public static final int T__27=27;
@@ -28,30 +24,34 @@ public class InternalFormatterTestLanguageLexer extends Lexer {
     public static final int RULE_ANY_OTHER=10;
     public static final int T__21=21;
     public static final int T__20=20;
-    public static final int RULE_SL_COMMENT=8;
     public static final int EOF=-1;
-    public static final int RULE_ML_COMMENT=7;
-    public static final int T__30=30;
     public static final int T__19=19;
-    public static final int T__31=31;
-    public static final int RULE_STRING=6;
-    public static final int T__32=32;
-    public static final int T__33=33;
     public static final int T__16=16;
-    public static final int T__34=34;
     public static final int T__15=15;
-    public static final int T__35=35;
     public static final int T__18=18;
-    public static final int T__36=36;
     public static final int T__17=17;
-    public static final int T__37=37;
     public static final int T__12=12;
-    public static final int T__38=38;
     public static final int T__11=11;
-    public static final int T__39=39;
     public static final int T__14=14;
     public static final int T__13=13;
     public static final int RULE_INT=5;
+    public static final int T__42=42;
+    public static final int T__43=43;
+    public static final int T__40=40;
+    public static final int T__41=41;
+    public static final int RULE_SL_COMMENT=8;
+    public static final int RULE_ML_COMMENT=7;
+    public static final int T__30=30;
+    public static final int T__31=31;
+    public static final int T__32=32;
+    public static final int RULE_STRING=6;
+    public static final int T__33=33;
+    public static final int T__34=34;
+    public static final int T__35=35;
+    public static final int T__36=36;
+    public static final int T__37=37;
+    public static final int T__38=38;
+    public static final int T__39=39;
     public static final int RULE_WS=9;
 
     // delegates

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/formatter/parser/antlr/internal/InternalFormatterTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/formatter/parser/antlr/internal/InternalFormatterTestLanguageParser.java
@@ -33,8 +33,8 @@ public class InternalFormatterTestLanguageParser extends AbstractInternalAntlrPa
     public static final int T__24=24;
     public static final int T__23=23;
     public static final int T__22=22;
-    public static final int RULE_ANY_OTHER=10;
     public static final int T__21=21;
+    public static final int RULE_ANY_OTHER=10;
     public static final int T__20=20;
     public static final int EOF=-1;
     public static final int T__19=19;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/ComplexReconstrTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/ComplexReconstrTestLanguageParsetreeConstructor.java
@@ -692,7 +692,7 @@ protected class Atom_NameAssignment extends AssignmentToken  {
 
 /************ begin Rule Parens ****************
  *
- * / * Suppress[potentialOverride] * / Parens returns Expression:
+ * / * SuppressWarnings[potentialOverride] * / Parens returns Expression:
  * 	"(" Op ")" em="!"?;
  *
  **/
@@ -853,7 +853,7 @@ protected class Parens_EmAssignment_3 extends AssignmentToken  {
  * * / // disabled, because of https://bugs.eclipse.org/bugs/show_bug.cgi?id=346685
  * //TrickyA returns TypeA1: 'TA' TrickyA1 (name += ID)* ({TypeB.x=current} 'x' | {TypeC.x=current} 'y')? name+=STRING;
  * //TrickyA1 returns TypeD: name+=ID;
- * / * Suppress[noInstantiation] * / TrickyB:
+ * / * SuppressWarnings[noInstantiation] * / TrickyB:
  * 	"TB" (name=ID type+=INT)? type+=INT*;
  *
  **/
@@ -1392,7 +1392,7 @@ protected class TrickyC_ZKeyword_4_1 extends KeywordToken  {
 
 /************ begin Rule TrickyD ****************
  *
- * / * Suppress[noInstantiation] * / TrickyD:
+ * / * SuppressWarnings[noInstantiation] * / TrickyD:
  * 	"TD" (name+=INT foo=STRING type+=ID)? (name+=INT type+=ID)? type+=ID*;
  *
  **/
@@ -1711,7 +1711,7 @@ protected class TrickyD_TypeAssignment_3 extends AssignmentToken  {
 /************ begin Rule TrickyE ****************
  *
  * // 34 "abc" XX 123 "de" YY x 34 DD 45 CC
- * / * Suppress[noInstantiation] * / TrickyE:
+ * / * SuppressWarnings[noInstantiation] * / TrickyE:
  * 	"TE" (name+=INT foo+=STRING type+=ID)* "x" (name+=INT type+=ID)*;
  *
  **/
@@ -2369,7 +2369,7 @@ protected class TrickyG_TreeAssignment_1 extends AssignmentToken  {
 
 /************ begin Rule TrickyG1 ****************
  *
- * / * Suppress[noInstantiation] * / TrickyG1:
+ * / * SuppressWarnings[noInstantiation] * / TrickyG1:
  * 	"[" (vals+=TrickyG2 ("," vals+=TrickyG2)*)? "]";
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/ComplexReconstrTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/ComplexReconstrTestLanguageParsetreeConstructor.java
@@ -692,7 +692,7 @@ protected class Atom_NameAssignment extends AssignmentToken  {
 
 /************ begin Rule Parens ****************
  *
- * Parens returns Expression:
+ * / * Suppress[potentialOverride] * / Parens returns Expression:
  * 	"(" Op ")" em="!"?;
  *
  **/
@@ -853,7 +853,7 @@ protected class Parens_EmAssignment_3 extends AssignmentToken  {
  * * / // disabled, because of https://bugs.eclipse.org/bugs/show_bug.cgi?id=346685
  * //TrickyA returns TypeA1: 'TA' TrickyA1 (name += ID)* ({TypeB.x=current} 'x' | {TypeC.x=current} 'y')? name+=STRING;
  * //TrickyA1 returns TypeD: name+=ID;
- * TrickyB:
+ * / * Suppress[noInstantiation] * / TrickyB:
  * 	"TB" (name=ID type+=INT)? type+=INT*;
  *
  **/
@@ -1392,7 +1392,7 @@ protected class TrickyC_ZKeyword_4_1 extends KeywordToken  {
 
 /************ begin Rule TrickyD ****************
  *
- * TrickyD:
+ * / * Suppress[noInstantiation] * / TrickyD:
  * 	"TD" (name+=INT foo=STRING type+=ID)? (name+=INT type+=ID)? type+=ID*;
  *
  **/
@@ -1711,7 +1711,7 @@ protected class TrickyD_TypeAssignment_3 extends AssignmentToken  {
 /************ begin Rule TrickyE ****************
  *
  * // 34 "abc" XX 123 "de" YY x 34 DD 45 CC
- * TrickyE:
+ * / * Suppress[noInstantiation] * / TrickyE:
  * 	"TE" (name+=INT foo+=STRING type+=ID)* "x" (name+=INT type+=ID)*;
  *
  **/
@@ -2369,7 +2369,7 @@ protected class TrickyG_TreeAssignment_1 extends AssignmentToken  {
 
 /************ begin Rule TrickyG1 ****************
  *
- * TrickyG1:
+ * / * Suppress[noInstantiation] * / TrickyG1:
  * 	"[" (vals+=TrickyG2 ("," vals+=TrickyG2)*)? "]";
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/HiddenTokensMergerTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/HiddenTokensMergerTestLanguageParsetreeConstructor.java
@@ -746,7 +746,7 @@ protected class EnumBug_NameAssignment_3 extends AssignmentToken  {
 
 /************ begin Rule Commentable ****************
  *
- * / * Suppress[noInstantiation] * / Commentable:
+ * / * SuppressWarnings[noInstantiation] * / Commentable:
  * 	"#3" item+=CommentableItem*;
  *
  **/
@@ -950,7 +950,7 @@ protected class CommentableItem_IdAssignment_1 extends AssignmentToken  {
 
 /************ begin Rule ValueList ****************
  *
- * / * Suppress[noInstantiation] * / ValueList:
+ * / * SuppressWarnings[noInstantiation] * / ValueList:
  * 	"#4" ids+=FQN*;
  *
  **/
@@ -1047,7 +1047,7 @@ protected class ValueList_IdsAssignment_1 extends AssignmentToken  {
 
 /************ begin Rule RefList ****************
  *
- * / * Suppress[noInstantiation] * / RefList:
+ * / * SuppressWarnings[noInstantiation] * / RefList:
  * 	"#5" objs+=RefObj* "refs" refs+=[RefObj|FQN]*;
  *
  **/
@@ -1429,7 +1429,7 @@ protected class SingleRef_RefAssignment_3 extends AssignmentToken  {
 /************ begin Rule AppendToFileEnd ****************
  *
  * // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=297938
- * / * Suppress[noInstantiation] * / AppendToFileEnd:
+ * / * SuppressWarnings[noInstantiation] * / AppendToFileEnd:
  * 	"#7" items+=AppendToFileEndItem*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/HiddenTokensMergerTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/HiddenTokensMergerTestLanguageParsetreeConstructor.java
@@ -746,7 +746,7 @@ protected class EnumBug_NameAssignment_3 extends AssignmentToken  {
 
 /************ begin Rule Commentable ****************
  *
- * Commentable:
+ * / * Suppress[noInstantiation] * / Commentable:
  * 	"#3" item+=CommentableItem*;
  *
  **/
@@ -950,7 +950,7 @@ protected class CommentableItem_IdAssignment_1 extends AssignmentToken  {
 
 /************ begin Rule ValueList ****************
  *
- * ValueList:
+ * / * Suppress[noInstantiation] * / ValueList:
  * 	"#4" ids+=FQN*;
  *
  **/
@@ -1047,7 +1047,7 @@ protected class ValueList_IdsAssignment_1 extends AssignmentToken  {
 
 /************ begin Rule RefList ****************
  *
- * RefList:
+ * / * Suppress[noInstantiation] * / RefList:
  * 	"#5" objs+=RefObj* "refs" refs+=[RefObj|FQN]*;
  *
  **/
@@ -1429,7 +1429,7 @@ protected class SingleRef_RefAssignment_3 extends AssignmentToken  {
 /************ begin Rule AppendToFileEnd ****************
  *
  * // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=297938
- * AppendToFileEnd:
+ * / * Suppress[noInstantiation] * / AppendToFileEnd:
  * 	"#7" items+=AppendToFileEndItem*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/SerializationErrorTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/SerializationErrorTestLanguageParsetreeConstructor.java
@@ -819,7 +819,7 @@ protected class TwoOptions_TwoAssignment_1_1_1 extends AssignmentToken  {
 
 /************ begin Rule Indent ****************
  *
- * Indent:
+ * / * Suppress[noInstantiation] * / Indent:
  * 	"{" req=TwoRequired? opt=TwoOptions? indent+=Indent* "}";
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/SerializationErrorTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/SerializationErrorTestLanguageParsetreeConstructor.java
@@ -819,7 +819,7 @@ protected class TwoOptions_TwoAssignment_1_1_1 extends AssignmentToken  {
 
 /************ begin Rule Indent ****************
  *
- * / * Suppress[noInstantiation] * / Indent:
+ * / * SuppressWarnings[noInstantiation] * / Indent:
  * 	"{" req=TwoRequired? opt=TwoOptions? indent+=Indent* "}";
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/SimpleReconstrTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/SimpleReconstrTestLanguageParsetreeConstructor.java
@@ -1364,7 +1364,7 @@ protected class Atom_NameAssignment extends AssignmentToken  {
 
 /************ begin Rule Parens ****************
  *
- * Parens returns Expression:
+ * / * Suppress[potentialOverride] * / Parens returns Expression:
  * 	"(" Op ")" em="!"?;
  *
  **/
@@ -4308,7 +4308,7 @@ protected class LoopBug285452_NameAssignment_2 extends AssignmentToken  {
 
 /************ begin Rule DuplicateBug284491 ****************
  *
- * DuplicateBug284491:
+ * / * Suppress[potentialOverride] * / DuplicateBug284491:
  * 	"#13" (static?="static" | final?="final" | transient?="transient")*;
  *
  **/
@@ -4607,7 +4607,7 @@ protected class EmptyObjectBug284850_ItemsAssignment_1 extends AssignmentToken  
 
 /************ begin Rule EmptyObjectItems ****************
  *
- * EmptyObjectItems:
+ * / * Suppress[noInstantiation] * / EmptyObjectItems:
  * 	list+=EmptyObjectItem*;
  *
  **/
@@ -6936,7 +6936,7 @@ protected class Bug305171_NameAssignment_2 extends AssignmentToken  {
 
 /************ begin Rule Bug310435Enum ****************
  *
- * Bug310435Enum:
+ * / * Suppress[noInstantiation] * / Bug310435Enum:
  * 	"#20" ("kw1" lits+=EnumBug310435Lit1 | "kw2" lits+=EnumBug310435Lit2)*;
  *
  **/
@@ -7182,7 +7182,7 @@ protected class Bug310435Enum_LitsAssignment_1_1_1 extends AssignmentToken  {
 
 /************ begin Rule Bug310435Val ****************
  *
- * Bug310435Val:
+ * / * Suppress[noInstantiation] * / Bug310435Val:
  * 	"#21" ("kw1" lits+=ID | "kw2" lits+=STRING)*;
  *
  **/
@@ -7428,7 +7428,7 @@ protected class Bug310435Val_LitsAssignment_1_1_1 extends AssignmentToken  {
 
 /************ begin Rule CrossRefNameTest ****************
  *
- * CrossRefNameTest:
+ * / * Suppress[noInstantiation] * / CrossRefNameTest:
  * 	"#22" named+=CrossRefNamed* "kw1" ("kw2" ref+=[CrossRefNamed|ID1] | "kw3" ref+=[CrossRefNamed|ID2])*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/SimpleReconstrTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parseTreeConstruction/SimpleReconstrTestLanguageParsetreeConstructor.java
@@ -1364,7 +1364,7 @@ protected class Atom_NameAssignment extends AssignmentToken  {
 
 /************ begin Rule Parens ****************
  *
- * / * Suppress[potentialOverride] * / Parens returns Expression:
+ * / * SuppressWarnings[potentialOverride] * / Parens returns Expression:
  * 	"(" Op ")" em="!"?;
  *
  **/
@@ -4308,7 +4308,7 @@ protected class LoopBug285452_NameAssignment_2 extends AssignmentToken  {
 
 /************ begin Rule DuplicateBug284491 ****************
  *
- * / * Suppress[potentialOverride] * / DuplicateBug284491:
+ * / * SuppressWarnings[potentialOverride] * / DuplicateBug284491:
  * 	"#13" (static?="static" | final?="final" | transient?="transient")*;
  *
  **/
@@ -4607,7 +4607,7 @@ protected class EmptyObjectBug284850_ItemsAssignment_1 extends AssignmentToken  
 
 /************ begin Rule EmptyObjectItems ****************
  *
- * / * Suppress[noInstantiation] * / EmptyObjectItems:
+ * / * SuppressWarnings[noInstantiation] * / EmptyObjectItems:
  * 	list+=EmptyObjectItem*;
  *
  **/
@@ -6936,7 +6936,7 @@ protected class Bug305171_NameAssignment_2 extends AssignmentToken  {
 
 /************ begin Rule Bug310435Enum ****************
  *
- * / * Suppress[noInstantiation] * / Bug310435Enum:
+ * / * SuppressWarnings[noInstantiation] * / Bug310435Enum:
  * 	"#20" ("kw1" lits+=EnumBug310435Lit1 | "kw2" lits+=EnumBug310435Lit2)*;
  *
  **/
@@ -7182,7 +7182,7 @@ protected class Bug310435Enum_LitsAssignment_1_1_1 extends AssignmentToken  {
 
 /************ begin Rule Bug310435Val ****************
  *
- * / * Suppress[noInstantiation] * / Bug310435Val:
+ * / * SuppressWarnings[noInstantiation] * / Bug310435Val:
  * 	"#21" ("kw1" lits+=ID | "kw2" lits+=STRING)*;
  *
  **/
@@ -7428,7 +7428,7 @@ protected class Bug310435Val_LitsAssignment_1_1_1 extends AssignmentToken  {
 
 /************ begin Rule CrossRefNameTest ****************
  *
- * / * Suppress[noInstantiation] * / CrossRefNameTest:
+ * / * SuppressWarnings[noInstantiation] * / CrossRefNameTest:
  * 	"#22" named+=CrossRefNamed* "kw1" ("kw2" ref+=[CrossRefNamed|ID1] | "kw3" ref+=[CrossRefNamed|ID2])*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parser/antlr/internal/InternalComplexReconstrTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parser/antlr/internal/InternalComplexReconstrTestLanguageLexer.java
@@ -12,8 +12,12 @@ import java.util.ArrayList;
 
 @SuppressWarnings("all")
 public class InternalComplexReconstrTestLanguageLexer extends Lexer {
-    public static final int T__19=19;
     public static final int RULE_ID=4;
+    public static final int RULE_ANY_OTHER=10;
+    public static final int RULE_SL_COMMENT=8;
+    public static final int EOF=-1;
+    public static final int RULE_ML_COMMENT=7;
+    public static final int T__19=19;
     public static final int RULE_STRING=6;
     public static final int T__16=16;
     public static final int T__15=15;
@@ -23,12 +27,8 @@ public class InternalComplexReconstrTestLanguageLexer extends Lexer {
     public static final int T__11=11;
     public static final int T__14=14;
     public static final int T__13=13;
-    public static final int RULE_ANY_OTHER=10;
     public static final int RULE_INT=5;
     public static final int RULE_WS=9;
-    public static final int RULE_SL_COMMENT=8;
-    public static final int EOF=-1;
-    public static final int RULE_ML_COMMENT=7;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parser/antlr/internal/InternalComplexReconstrTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parser/antlr/internal/InternalComplexReconstrTestLanguageParser.java
@@ -23,8 +23,12 @@ public class InternalComplexReconstrTestLanguageParser extends AbstractInternalA
     public static final String[] tokenNames = new String[] {
         "<invalid>", "<EOR>", "<DOWN>", "<UP>", "RULE_ID", "RULE_INT", "RULE_STRING", "RULE_ML_COMMENT", "RULE_SL_COMMENT", "RULE_WS", "RULE_ANY_OTHER", "'+'", "'-'", "'('", "')'", "'!'", "'TG'", "'['", "','", "']'"
     };
-    public static final int T__19=19;
     public static final int RULE_ID=4;
+    public static final int RULE_ANY_OTHER=10;
+    public static final int EOF=-1;
+    public static final int RULE_SL_COMMENT=8;
+    public static final int RULE_ML_COMMENT=7;
+    public static final int T__19=19;
     public static final int RULE_STRING=6;
     public static final int T__16=16;
     public static final int T__15=15;
@@ -34,12 +38,8 @@ public class InternalComplexReconstrTestLanguageParser extends AbstractInternalA
     public static final int T__11=11;
     public static final int T__14=14;
     public static final int T__13=13;
-    public static final int RULE_ANY_OTHER=10;
     public static final int RULE_INT=5;
     public static final int RULE_WS=9;
-    public static final int RULE_SL_COMMENT=8;
-    public static final int EOF=-1;
-    public static final int RULE_ML_COMMENT=7;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parser/antlr/internal/InternalHiddenTokensMergerTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parser/antlr/internal/InternalHiddenTokensMergerTestLanguageLexer.java
@@ -27,8 +27,8 @@ public class InternalHiddenTokensMergerTestLanguageLexer extends Lexer {
     public static final int EOF=-1;
     public static final int RULE_SL_COMMENT=8;
     public static final int RULE_ML_COMMENT=7;
-    public static final int T__19=19;
     public static final int T__30=30;
+    public static final int T__19=19;
     public static final int T__31=31;
     public static final int T__32=32;
     public static final int RULE_STRING=6;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parser/antlr/internal/InternalSimpleReconstrTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parser/antlr/internal/InternalSimpleReconstrTestLanguageLexer.java
@@ -14,8 +14,8 @@ import java.util.ArrayList;
 public class InternalSimpleReconstrTestLanguageLexer extends Lexer {
     public static final int T__68=68;
     public static final int T__69=69;
-    public static final int T__66=66;
     public static final int RULE_ID=4;
+    public static final int T__66=66;
     public static final int T__67=67;
     public static final int T__29=29;
     public static final int T__64=64;
@@ -42,8 +42,8 @@ public class InternalSimpleReconstrTestLanguageLexer extends Lexer {
     public static final int T__58=58;
     public static final int T__16=16;
     public static final int T__51=51;
-    public static final int T__52=52;
     public static final int T__15=15;
+    public static final int T__52=52;
     public static final int T__53=53;
     public static final int T__18=18;
     public static final int T__54=54;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parser/antlr/internal/InternalSimpleReconstrTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/parser/antlr/internal/InternalSimpleReconstrTestLanguageParser.java
@@ -54,8 +54,8 @@ public class InternalSimpleReconstrTestLanguageParser extends AbstractInternalAn
     public static final int T__58=58;
     public static final int T__16=16;
     public static final int T__51=51;
-    public static final int T__52=52;
     public static final int T__15=15;
+    public static final int T__52=52;
     public static final int T__53=53;
     public static final int T__18=18;
     public static final int T__54=54;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/ComplexReconstrTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/ComplexReconstrTestLanguageGrammarAccess.java
@@ -143,7 +143,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		private final Assignment cEmAssignment_3 = (Assignment)cGroup.eContents().get(3);
 		private final Keyword cEmExclamationMarkKeyword_3_0 = (Keyword)cEmAssignment_3.eContents().get(0);
 		
-		/// * Suppress[potentialOverride] * / Parens returns Expression:
+		/// * SuppressWarnings[potentialOverride] * / Parens returns Expression:
 		//	"(" Op ")" em="!"?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -184,7 +184,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		// * / // disabled, because of https://bugs.eclipse.org/bugs/show_bug.cgi?id=346685
 		////TrickyA returns TypeA1: 'TA' TrickyA1 (name += ID)* ({TypeB.x=current} 'x' | {TypeC.x=current} 'y')? name+=STRING;
 		////TrickyA1 returns TypeD: name+=ID;
-		/// * Suppress[noInstantiation] * / TrickyB:
+		/// * SuppressWarnings[noInstantiation] * / TrickyB:
 		//	"TB" (name=ID type+=INT)? type+=INT*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -295,7 +295,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		private final Assignment cTypeAssignment_3 = (Assignment)cGroup.eContents().get(3);
 		private final RuleCall cTypeIDTerminalRuleCall_3_0 = (RuleCall)cTypeAssignment_3.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / TrickyD:
+		/// * SuppressWarnings[noInstantiation] * / TrickyD:
 		//	"TD" (name+=INT foo=STRING type+=ID)? (name+=INT type+=ID)? type+=ID*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -367,7 +367,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		private final RuleCall cTypeIDTerminalRuleCall_3_1_0 = (RuleCall)cTypeAssignment_3_1.eContents().get(0);
 		
 		//// 34 "abc" XX 123 "de" YY x 34 DD 45 CC
-		/// * Suppress[noInstantiation] * / TrickyE:
+		/// * SuppressWarnings[noInstantiation] * / TrickyE:
 		//	"TE" (name+=INT foo+=STRING type+=ID)* "x" (name+=INT type+=ID)*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -511,7 +511,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		private final RuleCall cValsTrickyG2ParserRuleCall_1_1_1_0 = (RuleCall)cValsAssignment_1_1_1.eContents().get(0);
 		private final Keyword cRightSquareBracketKeyword_2 = (Keyword)cGroup.eContents().get(2);
 		
-		/// * Suppress[noInstantiation] * / TrickyG1:
+		/// * SuppressWarnings[noInstantiation] * / TrickyG1:
 		//	"[" (vals+=TrickyG2 ("," vals+=TrickyG2)*)? "]";
 		@Override public ParserRule getRule() { return rule; }
 
@@ -696,7 +696,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		return getAtomAccess().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / Parens returns Expression:
+	/// * SuppressWarnings[potentialOverride] * / Parens returns Expression:
 	//	"(" Op ")" em="!"?;
 	public ParensElements getParensAccess() {
 		return pParens;
@@ -712,7 +712,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 	// * / // disabled, because of https://bugs.eclipse.org/bugs/show_bug.cgi?id=346685
 	////TrickyA returns TypeA1: 'TA' TrickyA1 (name += ID)* ({TypeB.x=current} 'x' | {TypeC.x=current} 'y')? name+=STRING;
 	////TrickyA1 returns TypeD: name+=ID;
-	/// * Suppress[noInstantiation] * / TrickyB:
+	/// * SuppressWarnings[noInstantiation] * / TrickyB:
 	//	"TB" (name=ID type+=INT)? type+=INT*;
 	public TrickyBElements getTrickyBAccess() {
 		return pTrickyB;
@@ -732,7 +732,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		return getTrickyCAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / TrickyD:
+	/// * SuppressWarnings[noInstantiation] * / TrickyD:
 	//	"TD" (name+=INT foo=STRING type+=ID)? (name+=INT type+=ID)? type+=ID*;
 	public TrickyDElements getTrickyDAccess() {
 		return pTrickyD;
@@ -743,7 +743,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 	}
 
 	//// 34 "abc" XX 123 "de" YY x 34 DD 45 CC
-	/// * Suppress[noInstantiation] * / TrickyE:
+	/// * SuppressWarnings[noInstantiation] * / TrickyE:
 	//	"TE" (name+=INT foo+=STRING type+=ID)* "x" (name+=INT type+=ID)*;
 	public TrickyEElements getTrickyEAccess() {
 		return pTrickyE;
@@ -774,7 +774,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		return getTrickyGAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / TrickyG1:
+	/// * SuppressWarnings[noInstantiation] * / TrickyG1:
 	//	"[" (vals+=TrickyG2 ("," vals+=TrickyG2)*)? "]";
 	public TrickyG1Elements getTrickyG1Access() {
 		return pTrickyG1;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/ComplexReconstrTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/ComplexReconstrTestLanguageGrammarAccess.java
@@ -143,7 +143,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		private final Assignment cEmAssignment_3 = (Assignment)cGroup.eContents().get(3);
 		private final Keyword cEmExclamationMarkKeyword_3_0 = (Keyword)cEmAssignment_3.eContents().get(0);
 		
-		//Parens returns Expression:
+		/// * Suppress[potentialOverride] * / Parens returns Expression:
 		//	"(" Op ")" em="!"?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -184,7 +184,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		// * / // disabled, because of https://bugs.eclipse.org/bugs/show_bug.cgi?id=346685
 		////TrickyA returns TypeA1: 'TA' TrickyA1 (name += ID)* ({TypeB.x=current} 'x' | {TypeC.x=current} 'y')? name+=STRING;
 		////TrickyA1 returns TypeD: name+=ID;
-		//TrickyB:
+		/// * Suppress[noInstantiation] * / TrickyB:
 		//	"TB" (name=ID type+=INT)? type+=INT*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -295,7 +295,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		private final Assignment cTypeAssignment_3 = (Assignment)cGroup.eContents().get(3);
 		private final RuleCall cTypeIDTerminalRuleCall_3_0 = (RuleCall)cTypeAssignment_3.eContents().get(0);
 		
-		//TrickyD:
+		/// * Suppress[noInstantiation] * / TrickyD:
 		//	"TD" (name+=INT foo=STRING type+=ID)? (name+=INT type+=ID)? type+=ID*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -367,7 +367,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		private final RuleCall cTypeIDTerminalRuleCall_3_1_0 = (RuleCall)cTypeAssignment_3_1.eContents().get(0);
 		
 		//// 34 "abc" XX 123 "de" YY x 34 DD 45 CC
-		//TrickyE:
+		/// * Suppress[noInstantiation] * / TrickyE:
 		//	"TE" (name+=INT foo+=STRING type+=ID)* "x" (name+=INT type+=ID)*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -511,7 +511,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		private final RuleCall cValsTrickyG2ParserRuleCall_1_1_1_0 = (RuleCall)cValsAssignment_1_1_1.eContents().get(0);
 		private final Keyword cRightSquareBracketKeyword_2 = (Keyword)cGroup.eContents().get(2);
 		
-		//TrickyG1:
+		/// * Suppress[noInstantiation] * / TrickyG1:
 		//	"[" (vals+=TrickyG2 ("," vals+=TrickyG2)*)? "]";
 		@Override public ParserRule getRule() { return rule; }
 
@@ -696,7 +696,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		return getAtomAccess().getRule();
 	}
 
-	//Parens returns Expression:
+	/// * Suppress[potentialOverride] * / Parens returns Expression:
 	//	"(" Op ")" em="!"?;
 	public ParensElements getParensAccess() {
 		return pParens;
@@ -712,7 +712,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 	// * / // disabled, because of https://bugs.eclipse.org/bugs/show_bug.cgi?id=346685
 	////TrickyA returns TypeA1: 'TA' TrickyA1 (name += ID)* ({TypeB.x=current} 'x' | {TypeC.x=current} 'y')? name+=STRING;
 	////TrickyA1 returns TypeD: name+=ID;
-	//TrickyB:
+	/// * Suppress[noInstantiation] * / TrickyB:
 	//	"TB" (name=ID type+=INT)? type+=INT*;
 	public TrickyBElements getTrickyBAccess() {
 		return pTrickyB;
@@ -732,7 +732,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		return getTrickyCAccess().getRule();
 	}
 
-	//TrickyD:
+	/// * Suppress[noInstantiation] * / TrickyD:
 	//	"TD" (name+=INT foo=STRING type+=ID)? (name+=INT type+=ID)? type+=ID*;
 	public TrickyDElements getTrickyDAccess() {
 		return pTrickyD;
@@ -743,7 +743,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 	}
 
 	//// 34 "abc" XX 123 "de" YY x 34 DD 45 CC
-	//TrickyE:
+	/// * Suppress[noInstantiation] * / TrickyE:
 	//	"TE" (name+=INT foo+=STRING type+=ID)* "x" (name+=INT type+=ID)*;
 	public TrickyEElements getTrickyEAccess() {
 		return pTrickyE;
@@ -774,7 +774,7 @@ public class ComplexReconstrTestLanguageGrammarAccess extends AbstractGrammarEle
 		return getTrickyGAccess().getRule();
 	}
 
-	//TrickyG1:
+	/// * Suppress[noInstantiation] * / TrickyG1:
 	//	"[" (vals+=TrickyG2 ("," vals+=TrickyG2)*)? "]";
 	public TrickyG1Elements getTrickyG1Access() {
 		return pTrickyG1;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/HiddenTokensMergerTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/HiddenTokensMergerTestLanguageGrammarAccess.java
@@ -181,7 +181,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		private final Assignment cItemAssignment_1 = (Assignment)cGroup.eContents().get(1);
 		private final RuleCall cItemCommentableItemParserRuleCall_1_0 = (RuleCall)cItemAssignment_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / Commentable:
+		/// * SuppressWarnings[noInstantiation] * / Commentable:
 		//	"#3" item+=CommentableItem*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -229,7 +229,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		private final Assignment cIdsAssignment_1 = (Assignment)cGroup.eContents().get(1);
 		private final RuleCall cIdsFQNParserRuleCall_1_0 = (RuleCall)cIdsAssignment_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / ValueList:
+		/// * SuppressWarnings[noInstantiation] * / ValueList:
 		//	"#4" ids+=FQN*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -257,7 +257,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		private final CrossReference cRefsRefObjCrossReference_3_0 = (CrossReference)cRefsAssignment_3.eContents().get(0);
 		private final RuleCall cRefsRefObjFQNParserRuleCall_3_0_1 = (RuleCall)cRefsRefObjCrossReference_3_0.eContents().get(1);
 		
-		/// * Suppress[noInstantiation] * / RefList:
+		/// * SuppressWarnings[noInstantiation] * / RefList:
 		//	"#5" objs+=RefObj* "refs" refs+=[RefObj|FQN]*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -350,7 +350,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		private final RuleCall cItemsAppendToFileEndItemParserRuleCall_1_0 = (RuleCall)cItemsAssignment_1.eContents().get(0);
 		
 		//// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=297938
-		/// * Suppress[noInstantiation] * / AppendToFileEnd:
+		/// * SuppressWarnings[noInstantiation] * / AppendToFileEnd:
 		//	"#7" items+=AppendToFileEndItem*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -645,7 +645,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		return getEnumBugEnumAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / Commentable:
+	/// * SuppressWarnings[noInstantiation] * / Commentable:
 	//	"#3" item+=CommentableItem*;
 	public CommentableElements getCommentableAccess() {
 		return pCommentable;
@@ -665,7 +665,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		return getCommentableItemAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / ValueList:
+	/// * SuppressWarnings[noInstantiation] * / ValueList:
 	//	"#4" ids+=FQN*;
 	public ValueListElements getValueListAccess() {
 		return pValueList;
@@ -675,7 +675,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		return getValueListAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / RefList:
+	/// * SuppressWarnings[noInstantiation] * / RefList:
 	//	"#5" objs+=RefObj* "refs" refs+=[RefObj|FQN]*;
 	public RefListElements getRefListAccess() {
 		return pRefList;
@@ -706,7 +706,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 	}
 
 	//// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=297938
-	/// * Suppress[noInstantiation] * / AppendToFileEnd:
+	/// * SuppressWarnings[noInstantiation] * / AppendToFileEnd:
 	//	"#7" items+=AppendToFileEndItem*;
 	public AppendToFileEndElements getAppendToFileEndAccess() {
 		return pAppendToFileEnd;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/HiddenTokensMergerTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/HiddenTokensMergerTestLanguageGrammarAccess.java
@@ -181,7 +181,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		private final Assignment cItemAssignment_1 = (Assignment)cGroup.eContents().get(1);
 		private final RuleCall cItemCommentableItemParserRuleCall_1_0 = (RuleCall)cItemAssignment_1.eContents().get(0);
 		
-		//Commentable:
+		/// * Suppress[noInstantiation] * / Commentable:
 		//	"#3" item+=CommentableItem*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -229,7 +229,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		private final Assignment cIdsAssignment_1 = (Assignment)cGroup.eContents().get(1);
 		private final RuleCall cIdsFQNParserRuleCall_1_0 = (RuleCall)cIdsAssignment_1.eContents().get(0);
 		
-		//ValueList:
+		/// * Suppress[noInstantiation] * / ValueList:
 		//	"#4" ids+=FQN*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -257,7 +257,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		private final CrossReference cRefsRefObjCrossReference_3_0 = (CrossReference)cRefsAssignment_3.eContents().get(0);
 		private final RuleCall cRefsRefObjFQNParserRuleCall_3_0_1 = (RuleCall)cRefsRefObjCrossReference_3_0.eContents().get(1);
 		
-		//RefList:
+		/// * Suppress[noInstantiation] * / RefList:
 		//	"#5" objs+=RefObj* "refs" refs+=[RefObj|FQN]*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -350,7 +350,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		private final RuleCall cItemsAppendToFileEndItemParserRuleCall_1_0 = (RuleCall)cItemsAssignment_1.eContents().get(0);
 		
 		//// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=297938
-		//AppendToFileEnd:
+		/// * Suppress[noInstantiation] * / AppendToFileEnd:
 		//	"#7" items+=AppendToFileEndItem*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -645,7 +645,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		return getEnumBugEnumAccess().getRule();
 	}
 
-	//Commentable:
+	/// * Suppress[noInstantiation] * / Commentable:
 	//	"#3" item+=CommentableItem*;
 	public CommentableElements getCommentableAccess() {
 		return pCommentable;
@@ -665,7 +665,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		return getCommentableItemAccess().getRule();
 	}
 
-	//ValueList:
+	/// * Suppress[noInstantiation] * / ValueList:
 	//	"#4" ids+=FQN*;
 	public ValueListElements getValueListAccess() {
 		return pValueList;
@@ -675,7 +675,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 		return getValueListAccess().getRule();
 	}
 
-	//RefList:
+	/// * Suppress[noInstantiation] * / RefList:
 	//	"#5" objs+=RefObj* "refs" refs+=[RefObj|FQN]*;
 	public RefListElements getRefListAccess() {
 		return pRefList;
@@ -706,7 +706,7 @@ public class HiddenTokensMergerTestLanguageGrammarAccess extends AbstractGrammar
 	}
 
 	//// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=297938
-	//AppendToFileEnd:
+	/// * Suppress[noInstantiation] * / AppendToFileEnd:
 	//	"#7" items+=AppendToFileEndItem*;
 	public AppendToFileEndElements getAppendToFileEndAccess() {
 		return pAppendToFileEnd;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/SerializationErrorTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/SerializationErrorTestLanguageGrammarAccess.java
@@ -190,7 +190,7 @@ public class SerializationErrorTestLanguageGrammarAccess extends AbstractGrammar
 		private final RuleCall cIndentIndentParserRuleCall_3_0 = (RuleCall)cIndentAssignment_3.eContents().get(0);
 		private final Keyword cRightCurlyBracketKeyword_4 = (Keyword)cGroup.eContents().get(4);
 		
-		/// * Suppress[noInstantiation] * / Indent:
+		/// * SuppressWarnings[noInstantiation] * / Indent:
 		//	"{" req=TwoRequired? opt=TwoOptions? indent+=Indent* "}";
 		@Override public ParserRule getRule() { return rule; }
 
@@ -324,7 +324,7 @@ public class SerializationErrorTestLanguageGrammarAccess extends AbstractGrammar
 		return getTwoOptionsAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / Indent:
+	/// * SuppressWarnings[noInstantiation] * / Indent:
 	//	"{" req=TwoRequired? opt=TwoOptions? indent+=Indent* "}";
 	public IndentElements getIndentAccess() {
 		return pIndent;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/SerializationErrorTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/SerializationErrorTestLanguageGrammarAccess.java
@@ -190,7 +190,7 @@ public class SerializationErrorTestLanguageGrammarAccess extends AbstractGrammar
 		private final RuleCall cIndentIndentParserRuleCall_3_0 = (RuleCall)cIndentAssignment_3.eContents().get(0);
 		private final Keyword cRightCurlyBracketKeyword_4 = (Keyword)cGroup.eContents().get(4);
 		
-		//Indent:
+		/// * Suppress[noInstantiation] * / Indent:
 		//	"{" req=TwoRequired? opt=TwoOptions? indent+=Indent* "}";
 		@Override public ParserRule getRule() { return rule; }
 
@@ -324,7 +324,7 @@ public class SerializationErrorTestLanguageGrammarAccess extends AbstractGrammar
 		return getTwoOptionsAccess().getRule();
 	}
 
-	//Indent:
+	/// * Suppress[noInstantiation] * / Indent:
 	//	"{" req=TwoRequired? opt=TwoOptions? indent+=Indent* "}";
 	public IndentElements getIndentAccess() {
 		return pIndent;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/SimpleReconstrTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/SimpleReconstrTestLanguageGrammarAccess.java
@@ -195,7 +195,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Assignment cEmAssignment_3 = (Assignment)cGroup.eContents().get(3);
 		private final Keyword cEmExclamationMarkKeyword_3_0 = (Keyword)cEmAssignment_3.eContents().get(0);
 		
-		//Parens returns Expression:
+		/// * Suppress[potentialOverride] * / Parens returns Expression:
 		//	"(" Op ")" em="!"?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -918,7 +918,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Assignment cTransientAssignment_1_2 = (Assignment)cAlternatives_1.eContents().get(2);
 		private final Keyword cTransientTransientKeyword_1_2_0 = (Keyword)cTransientAssignment_1_2.eContents().get(0);
 		
-		//DuplicateBug284491:
+		/// * Suppress[potentialOverride] * / DuplicateBug284491:
 		//	"#13" (static?="static" | final?="final" | transient?="transient")*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -979,7 +979,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Assignment cListAssignment = (Assignment)rule.eContents().get(1);
 		private final RuleCall cListEmptyObjectItemParserRuleCall_0 = (RuleCall)cListAssignment.eContents().get(0);
 		
-		//EmptyObjectItems:
+		/// * Suppress[noInstantiation] * / EmptyObjectItems:
 		//	list+=EmptyObjectItem*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1504,7 +1504,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Assignment cLitsAssignment_1_1_1 = (Assignment)cGroup_1_1.eContents().get(1);
 		private final RuleCall cLitsEnumBug310435Lit2EnumRuleCall_1_1_1_0 = (RuleCall)cLitsAssignment_1_1_1.eContents().get(0);
 		
-		//Bug310435Enum:
+		/// * Suppress[noInstantiation] * / Bug310435Enum:
 		//	"#20" ("kw1" lits+=EnumBug310435Lit1 | "kw2" lits+=EnumBug310435Lit2)*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1556,7 +1556,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Assignment cLitsAssignment_1_1_1 = (Assignment)cGroup_1_1.eContents().get(1);
 		private final RuleCall cLitsSTRINGTerminalRuleCall_1_1_1_0 = (RuleCall)cLitsAssignment_1_1_1.eContents().get(0);
 		
-		//Bug310435Val:
+		/// * Suppress[noInstantiation] * / Bug310435Val:
 		//	"#21" ("kw1" lits+=ID | "kw2" lits+=STRING)*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1613,7 +1613,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final CrossReference cRefCrossRefNamedCrossReference_3_1_1_0 = (CrossReference)cRefAssignment_3_1_1.eContents().get(0);
 		private final RuleCall cRefCrossRefNamedID2TerminalRuleCall_3_1_1_0_1 = (RuleCall)cRefCrossRefNamedCrossReference_3_1_1_0.eContents().get(1);
 		
-		//CrossRefNameTest:
+		/// * Suppress[noInstantiation] * / CrossRefNameTest:
 		//	"#22" named+=CrossRefNamed* "kw1" ("kw2" ref+=[CrossRefNamed|ID1] | "kw3" ref+=[CrossRefNamed|ID2])*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1884,7 +1884,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getAtomAccess().getRule();
 	}
 
-	//Parens returns Expression:
+	/// * Suppress[potentialOverride] * / Parens returns Expression:
 	//	"(" Op ")" em="!"?;
 	public ParensElements getParensAccess() {
 		return pParens;
@@ -2034,7 +2034,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getLoopBug285452Access().getRule();
 	}
 
-	//DuplicateBug284491:
+	/// * Suppress[potentialOverride] * / DuplicateBug284491:
 	//	"#13" (static?="static" | final?="final" | transient?="transient")*;
 	public DuplicateBug284491Elements getDuplicateBug284491Access() {
 		return pDuplicateBug284491;
@@ -2054,7 +2054,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getEmptyObjectBug284850Access().getRule();
 	}
 
-	//EmptyObjectItems:
+	/// * Suppress[noInstantiation] * / EmptyObjectItems:
 	//	list+=EmptyObjectItem*;
 	public EmptyObjectItemsElements getEmptyObjectItemsAccess() {
 		return pEmptyObjectItems;
@@ -2224,7 +2224,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getBug305171Access().getRule();
 	}
 
-	//Bug310435Enum:
+	/// * Suppress[noInstantiation] * / Bug310435Enum:
 	//	"#20" ("kw1" lits+=EnumBug310435Lit1 | "kw2" lits+=EnumBug310435Lit2)*;
 	public Bug310435EnumElements getBug310435EnumAccess() {
 		return pBug310435Enum;
@@ -2234,7 +2234,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getBug310435EnumAccess().getRule();
 	}
 
-	//Bug310435Val:
+	/// * Suppress[noInstantiation] * / Bug310435Val:
 	//	"#21" ("kw1" lits+=ID | "kw2" lits+=STRING)*;
 	public Bug310435ValElements getBug310435ValAccess() {
 		return pBug310435Val;
@@ -2264,7 +2264,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getEnumBug310435Lit2Access().getRule();
 	}
 
-	//CrossRefNameTest:
+	/// * Suppress[noInstantiation] * / CrossRefNameTest:
 	//	"#22" named+=CrossRefNamed* "kw1" ("kw2" ref+=[CrossRefNamed|ID1] | "kw3" ref+=[CrossRefNamed|ID2])*;
 	public CrossRefNameTestElements getCrossRefNameTestAccess() {
 		return pCrossRefNameTest;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/SimpleReconstrTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/reconstr/services/SimpleReconstrTestLanguageGrammarAccess.java
@@ -195,7 +195,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Assignment cEmAssignment_3 = (Assignment)cGroup.eContents().get(3);
 		private final Keyword cEmExclamationMarkKeyword_3_0 = (Keyword)cEmAssignment_3.eContents().get(0);
 		
-		/// * Suppress[potentialOverride] * / Parens returns Expression:
+		/// * SuppressWarnings[potentialOverride] * / Parens returns Expression:
 		//	"(" Op ")" em="!"?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -918,7 +918,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Assignment cTransientAssignment_1_2 = (Assignment)cAlternatives_1.eContents().get(2);
 		private final Keyword cTransientTransientKeyword_1_2_0 = (Keyword)cTransientAssignment_1_2.eContents().get(0);
 		
-		/// * Suppress[potentialOverride] * / DuplicateBug284491:
+		/// * SuppressWarnings[potentialOverride] * / DuplicateBug284491:
 		//	"#13" (static?="static" | final?="final" | transient?="transient")*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -979,7 +979,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Assignment cListAssignment = (Assignment)rule.eContents().get(1);
 		private final RuleCall cListEmptyObjectItemParserRuleCall_0 = (RuleCall)cListAssignment.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / EmptyObjectItems:
+		/// * SuppressWarnings[noInstantiation] * / EmptyObjectItems:
 		//	list+=EmptyObjectItem*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1504,7 +1504,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Assignment cLitsAssignment_1_1_1 = (Assignment)cGroup_1_1.eContents().get(1);
 		private final RuleCall cLitsEnumBug310435Lit2EnumRuleCall_1_1_1_0 = (RuleCall)cLitsAssignment_1_1_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / Bug310435Enum:
+		/// * SuppressWarnings[noInstantiation] * / Bug310435Enum:
 		//	"#20" ("kw1" lits+=EnumBug310435Lit1 | "kw2" lits+=EnumBug310435Lit2)*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1556,7 +1556,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final Assignment cLitsAssignment_1_1_1 = (Assignment)cGroup_1_1.eContents().get(1);
 		private final RuleCall cLitsSTRINGTerminalRuleCall_1_1_1_0 = (RuleCall)cLitsAssignment_1_1_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / Bug310435Val:
+		/// * SuppressWarnings[noInstantiation] * / Bug310435Val:
 		//	"#21" ("kw1" lits+=ID | "kw2" lits+=STRING)*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1613,7 +1613,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		private final CrossReference cRefCrossRefNamedCrossReference_3_1_1_0 = (CrossReference)cRefAssignment_3_1_1.eContents().get(0);
 		private final RuleCall cRefCrossRefNamedID2TerminalRuleCall_3_1_1_0_1 = (RuleCall)cRefCrossRefNamedCrossReference_3_1_1_0.eContents().get(1);
 		
-		/// * Suppress[noInstantiation] * / CrossRefNameTest:
+		/// * SuppressWarnings[noInstantiation] * / CrossRefNameTest:
 		//	"#22" named+=CrossRefNamed* "kw1" ("kw2" ref+=[CrossRefNamed|ID1] | "kw3" ref+=[CrossRefNamed|ID2])*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1884,7 +1884,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getAtomAccess().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / Parens returns Expression:
+	/// * SuppressWarnings[potentialOverride] * / Parens returns Expression:
 	//	"(" Op ")" em="!"?;
 	public ParensElements getParensAccess() {
 		return pParens;
@@ -2034,7 +2034,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getLoopBug285452Access().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / DuplicateBug284491:
+	/// * SuppressWarnings[potentialOverride] * / DuplicateBug284491:
 	//	"#13" (static?="static" | final?="final" | transient?="transient")*;
 	public DuplicateBug284491Elements getDuplicateBug284491Access() {
 		return pDuplicateBug284491;
@@ -2054,7 +2054,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getEmptyObjectBug284850Access().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / EmptyObjectItems:
+	/// * SuppressWarnings[noInstantiation] * / EmptyObjectItems:
 	//	list+=EmptyObjectItem*;
 	public EmptyObjectItemsElements getEmptyObjectItemsAccess() {
 		return pEmptyObjectItems;
@@ -2224,7 +2224,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getBug305171Access().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / Bug310435Enum:
+	/// * SuppressWarnings[noInstantiation] * / Bug310435Enum:
 	//	"#20" ("kw1" lits+=EnumBug310435Lit1 | "kw2" lits+=EnumBug310435Lit2)*;
 	public Bug310435EnumElements getBug310435EnumAccess() {
 		return pBug310435Enum;
@@ -2234,7 +2234,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getBug310435EnumAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / Bug310435Val:
+	/// * SuppressWarnings[noInstantiation] * / Bug310435Val:
 	//	"#21" ("kw1" lits+=ID | "kw2" lits+=STRING)*;
 	public Bug310435ValElements getBug310435ValAccess() {
 		return pBug310435Val;
@@ -2264,7 +2264,7 @@ public class SimpleReconstrTestLanguageGrammarAccess extends AbstractGrammarElem
 		return getEnumBug310435Lit2Access().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / CrossRefNameTest:
+	/// * SuppressWarnings[noInstantiation] * / CrossRefNameTest:
 	//	"#22" named+=CrossRefNamed* "kw1" ("kw2" ref+=[CrossRefNamed|ID1] | "kw3" ref+=[CrossRefNamed|ID2])*;
 	public CrossRefNameTestElements getCrossRefNameTestAccess() {
 		return pCrossRefNameTest;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/unassignedtext/parser/antlr/internal/InternalUnassignedTextTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/unassignedtext/parser/antlr/internal/InternalUnassignedTextTestLanguageLexer.java
@@ -14,8 +14,8 @@ import java.util.ArrayList;
 public class InternalUnassignedTextTestLanguageLexer extends Lexer {
     public static final int RULE_ID=9;
     public static final int RULE_ANY_OTHER=14;
-    public static final int EOF=-1;
     public static final int RULE_SL_COMMENT=12;
+    public static final int EOF=-1;
     public static final int RULE_PLURAL=6;
     public static final int RULE_ML_COMMENT=11;
     public static final int T__19=19;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/unassignedtext/parser/antlr/internal/InternalUnassignedTextTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/parsetree/unassignedtext/parser/antlr/internal/InternalUnassignedTextTestLanguageParser.java
@@ -23,23 +23,23 @@ public class InternalUnassignedTextTestLanguageParser extends AbstractInternalAn
     public static final String[] tokenNames = new String[] {
         "<invalid>", "<EOR>", "<DOWN>", "<UP>", "RULE_CASEINSENSITIVEKEYWORD", "RULE_INT", "RULE_PLURAL", "RULE_MULTI", "RULE_STRING", "RULE_ID", "RULE_MULTI2", "RULE_ML_COMMENT", "RULE_SL_COMMENT", "RULE_WS", "RULE_ANY_OTHER", "'contents:'", "'multi'", "'datatype'", "'str'", "'terminals'"
     };
-    public static final int T__19=19;
     public static final int RULE_ID=9;
+    public static final int RULE_ANY_OTHER=14;
+    public static final int EOF=-1;
+    public static final int RULE_SL_COMMENT=12;
+    public static final int RULE_PLURAL=6;
+    public static final int RULE_ML_COMMENT=11;
+    public static final int T__19=19;
     public static final int RULE_STRING=8;
     public static final int T__16=16;
     public static final int T__15=15;
     public static final int T__18=18;
     public static final int T__17=17;
     public static final int RULE_CASEINSENSITIVEKEYWORD=4;
-    public static final int RULE_ANY_OTHER=14;
     public static final int RULE_MULTI2=10;
     public static final int RULE_INT=5;
     public static final int RULE_WS=13;
-    public static final int RULE_SL_COMMENT=12;
-    public static final int EOF=-1;
-    public static final int RULE_ML_COMMENT=11;
     public static final int RULE_MULTI=7;
-    public static final int RULE_PLURAL=6;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/resource/parser/antlr/internal/InternalBug385636Lexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/resource/parser/antlr/internal/InternalBug385636Lexer.java
@@ -14,8 +14,8 @@ import java.util.ArrayList;
 public class InternalBug385636Lexer extends Lexer {
     public static final int RULE_ID=4;
     public static final int T__22=22;
-    public static final int RULE_ANY_OTHER=10;
     public static final int T__21=21;
+    public static final int RULE_ANY_OTHER=10;
     public static final int T__20=20;
     public static final int EOF=-1;
     public static final int RULE_SL_COMMENT=8;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/parseTreeConstruction/HiddenTokenSequencerTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/parseTreeConstruction/HiddenTokenSequencerTestLanguageParsetreeConstructor.java
@@ -98,7 +98,7 @@ protected class Model_DomainModelAssignment extends AssignmentToken  {
 
 /************ begin Rule DomainModel ****************
  *
- * / * Suppress[noInstantiation] * / DomainModel:
+ * / * SuppressWarnings[noInstantiation] * / DomainModel:
  * 	"entities" entities+=Entity* "end";
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/parseTreeConstruction/HiddenTokenSequencerTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/parseTreeConstruction/HiddenTokenSequencerTestLanguageParsetreeConstructor.java
@@ -98,7 +98,7 @@ protected class Model_DomainModelAssignment extends AssignmentToken  {
 
 /************ begin Rule DomainModel ****************
  *
- * DomainModel:
+ * / * Suppress[noInstantiation] * / DomainModel:
  * 	"entities" entities+=Entity* "end";
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/parser/antlr/internal/InternalSequencerTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/parser/antlr/internal/InternalSequencerTestLanguageLexer.java
@@ -27,12 +27,12 @@ public class InternalSequencerTestLanguageLexer extends Lexer {
     public static final int EOF=-1;
     public static final int T__55=55;
     public static final int T__19=19;
-    public static final int T__16=16;
     public static final int T__51=51;
+    public static final int T__16=16;
     public static final int T__15=15;
     public static final int T__52=52;
-    public static final int T__53=53;
     public static final int T__18=18;
+    public static final int T__53=53;
     public static final int T__54=54;
     public static final int T__17=17;
     public static final int T__14=14;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/parser/antlr/internal/InternalSequencerTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/parser/antlr/internal/InternalSequencerTestLanguageParser.java
@@ -43,8 +43,8 @@ public class InternalSequencerTestLanguageParser extends AbstractInternalAntlrPa
     public static final int T__51=51;
     public static final int T__15=15;
     public static final int T__52=52;
-    public static final int T__53=53;
     public static final int T__18=18;
+    public static final int T__53=53;
     public static final int T__54=54;
     public static final int T__17=17;
     public static final int T__14=14;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/services/HiddenTokenSequencerTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/services/HiddenTokenSequencerTestLanguageGrammarAccess.java
@@ -42,7 +42,7 @@ public class HiddenTokenSequencerTestLanguageGrammarAccess extends AbstractGramm
 		private final RuleCall cEntitiesEntityParserRuleCall_1_0 = (RuleCall)cEntitiesAssignment_1.eContents().get(0);
 		private final Keyword cEndKeyword_2 = (Keyword)cGroup.eContents().get(2);
 		
-		//DomainModel:
+		/// * Suppress[noInstantiation] * / DomainModel:
 		//	"entities" entities+=Entity* "end";
 		@Override public ParserRule getRule() { return rule; }
 
@@ -146,7 +146,7 @@ public class HiddenTokenSequencerTestLanguageGrammarAccess extends AbstractGramm
 		return getModelAccess().getRule();
 	}
 
-	//DomainModel:
+	/// * Suppress[noInstantiation] * / DomainModel:
 	//	"entities" entities+=Entity* "end";
 	public DomainModelElements getDomainModelAccess() {
 		return pDomainModel;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/services/HiddenTokenSequencerTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/serializer/services/HiddenTokenSequencerTestLanguageGrammarAccess.java
@@ -42,7 +42,7 @@ public class HiddenTokenSequencerTestLanguageGrammarAccess extends AbstractGramm
 		private final RuleCall cEntitiesEntityParserRuleCall_1_0 = (RuleCall)cEntitiesAssignment_1.eContents().get(0);
 		private final Keyword cEndKeyword_2 = (Keyword)cGroup.eContents().get(2);
 		
-		/// * Suppress[noInstantiation] * / DomainModel:
+		/// * SuppressWarnings[noInstantiation] * / DomainModel:
 		//	"entities" entities+=Entity* "end";
 		@Override public ParserRule getRule() { return rule; }
 
@@ -146,7 +146,7 @@ public class HiddenTokenSequencerTestLanguageGrammarAccess extends AbstractGramm
 		return getModelAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / DomainModel:
+	/// * SuppressWarnings[noInstantiation] * / DomainModel:
 	//	"entities" entities+=Entity* "end";
 	public DomainModelElements getDomainModelAccess() {
 		return pDomainModel;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/services/XtextGrammarTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/services/XtextGrammarTestLanguageGrammarAccess.java
@@ -588,7 +588,7 @@ public class XtextGrammarTestLanguageGrammarAccess extends AbstractGrammarElemen
 		private final Keyword cCardinalityAsteriskKeyword_1_0_1 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(1);
 		private final Keyword cCardinalityPlusSignKeyword_1_0_2 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(2);
 		
-		//AbstractTokenWithCardinality returns AbstractElement:
+		/// * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
 		//	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1178,7 +1178,7 @@ public class XtextGrammarTestLanguageGrammarAccess extends AbstractGrammarElemen
 		private final Keyword cCardinalityAsteriskKeyword_1_0_1 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(1);
 		private final Keyword cCardinalityPlusSignKeyword_1_0_2 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(2);
 		
-		//TerminalToken returns AbstractElement:
+		/// * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
 		//	TerminalTokenElement cardinality=("?" | "*" | "+")?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1755,7 +1755,7 @@ public class XtextGrammarTestLanguageGrammarAccess extends AbstractGrammarElemen
 		return getAbstractTokenAccess().getRule();
 	}
 
-	//AbstractTokenWithCardinality returns AbstractElement:
+	/// * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
 	//	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
 	public AbstractTokenWithCardinalityElements getAbstractTokenWithCardinalityAccess() {
 		return pAbstractTokenWithCardinality;
@@ -1925,7 +1925,7 @@ public class XtextGrammarTestLanguageGrammarAccess extends AbstractGrammarElemen
 		return getTerminalGroupAccess().getRule();
 	}
 
-	//TerminalToken returns AbstractElement:
+	/// * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
 	//	TerminalTokenElement cardinality=("?" | "*" | "+")?;
 	public TerminalTokenElements getTerminalTokenAccess() {
 		return pTerminalToken;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/services/XtextGrammarTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/services/XtextGrammarTestLanguageGrammarAccess.java
@@ -588,7 +588,7 @@ public class XtextGrammarTestLanguageGrammarAccess extends AbstractGrammarElemen
 		private final Keyword cCardinalityAsteriskKeyword_1_0_1 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(1);
 		private final Keyword cCardinalityPlusSignKeyword_1_0_2 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(2);
 		
-		/// * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
+		/// * SuppressWarnings[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
 		//	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1178,7 +1178,7 @@ public class XtextGrammarTestLanguageGrammarAccess extends AbstractGrammarElemen
 		private final Keyword cCardinalityAsteriskKeyword_1_0_1 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(1);
 		private final Keyword cCardinalityPlusSignKeyword_1_0_2 = (Keyword)cCardinalityAlternatives_1_0.eContents().get(2);
 		
-		/// * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
+		/// * SuppressWarnings[potentialOverride] * / TerminalToken returns AbstractElement:
 		//	TerminalTokenElement cardinality=("?" | "*" | "+")?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1755,7 +1755,7 @@ public class XtextGrammarTestLanguageGrammarAccess extends AbstractGrammarElemen
 		return getAbstractTokenAccess().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
+	/// * SuppressWarnings[potentialOverride] * / AbstractTokenWithCardinality returns AbstractElement:
 	//	(Assignment | AbstractTerminal) cardinality=("?" | "*" | "+")?;
 	public AbstractTokenWithCardinalityElements getAbstractTokenWithCardinalityAccess() {
 		return pAbstractTokenWithCardinality;
@@ -1925,7 +1925,7 @@ public class XtextGrammarTestLanguageGrammarAccess extends AbstractGrammarElemen
 		return getTerminalGroupAccess().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / TerminalToken returns AbstractElement:
+	/// * SuppressWarnings[potentialOverride] * / TerminalToken returns AbstractElement:
 	//	TerminalTokenElement cardinality=("?" | "*" | "+")?;
 	public TerminalTokenElements getTerminalTokenAccess() {
 		return pTerminalToken;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/indent/parser/antlr/internal/InternalIndentationAwareTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/indent/parser/antlr/internal/InternalIndentationAwareTestLanguageLexer.java
@@ -12,8 +12,8 @@ import java.util.ArrayList;
 
 @SuppressWarnings("all")
 public class InternalIndentationAwareTestLanguageLexer extends Lexer {
-    public static final int RULE_OTHER=7;
     public static final int RULE_END=6;
+    public static final int RULE_OTHER=7;
     public static final int RULE_BEGIN=5;
     public static final int RULE_NL=4;
     public static final int EOF=-1;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/indent/parser/antlr/internal/InternalIndentationAwareTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/indent/parser/antlr/internal/InternalIndentationAwareTestLanguageParser.java
@@ -23,8 +23,8 @@ public class InternalIndentationAwareTestLanguageParser extends AbstractInternal
     public static final String[] tokenNames = new String[] {
         "<invalid>", "<EOR>", "<DOWN>", "<UP>", "RULE_NL", "RULE_BEGIN", "RULE_END", "RULE_OTHER"
     };
-    public static final int RULE_OTHER=7;
     public static final int RULE_END=6;
+    public static final int RULE_OTHER=7;
     public static final int RULE_BEGIN=5;
     public static final int RULE_NL=4;
     public static final int EOF=-1;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/parseTreeConstruction/FowlerDslTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/parseTreeConstruction/FowlerDslTestLanguageParsetreeConstructor.java
@@ -43,7 +43,7 @@ protected class ThisRootNode extends RootToken {
 
 /************ begin Rule Statemachine ****************
  *
- * Statemachine:
+ * / * Suppress[noInstantiation] * / Statemachine:
  * 	"events" events+=Event* "end" "commands" commands+=Command* "end" states+=State*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/parseTreeConstruction/FowlerDslTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/parseTreeConstruction/FowlerDslTestLanguageParsetreeConstructor.java
@@ -43,7 +43,7 @@ protected class ThisRootNode extends RootToken {
 
 /************ begin Rule Statemachine ****************
  *
- * / * Suppress[noInstantiation] * / Statemachine:
+ * / * SuppressWarnings[noInstantiation] * / Statemachine:
  * 	"events" events+=Event* "end" "commands" commands+=Command* "end" states+=State*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/parser/antlr/internal/InternalFowlerDslTestLanguageLexer.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/parser/antlr/internal/InternalFowlerDslTestLanguageLexer.java
@@ -12,8 +12,12 @@ import java.util.ArrayList;
 
 @SuppressWarnings("all")
 public class InternalFowlerDslTestLanguageLexer extends Lexer {
-    public static final int T__19=19;
     public static final int RULE_ID=4;
+    public static final int RULE_ANY_OTHER=10;
+    public static final int RULE_SL_COMMENT=8;
+    public static final int EOF=-1;
+    public static final int RULE_ML_COMMENT=7;
+    public static final int T__19=19;
     public static final int RULE_STRING=6;
     public static final int T__16=16;
     public static final int T__15=15;
@@ -23,12 +27,8 @@ public class InternalFowlerDslTestLanguageLexer extends Lexer {
     public static final int T__11=11;
     public static final int T__14=14;
     public static final int T__13=13;
-    public static final int RULE_ANY_OTHER=10;
     public static final int RULE_INT=5;
     public static final int RULE_WS=9;
-    public static final int RULE_SL_COMMENT=8;
-    public static final int EOF=-1;
-    public static final int RULE_ML_COMMENT=7;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/parser/antlr/internal/InternalFowlerDslTestLanguageParser.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/parser/antlr/internal/InternalFowlerDslTestLanguageParser.java
@@ -23,8 +23,12 @@ public class InternalFowlerDslTestLanguageParser extends AbstractInternalAntlrPa
     public static final String[] tokenNames = new String[] {
         "<invalid>", "<EOR>", "<DOWN>", "<UP>", "RULE_ID", "RULE_INT", "RULE_STRING", "RULE_ML_COMMENT", "RULE_SL_COMMENT", "RULE_WS", "RULE_ANY_OTHER", "'events'", "'end'", "'commands'", "'resetting'", "'state'", "'actions'", "'{'", "'}'", "'=>'"
     };
-    public static final int T__19=19;
     public static final int RULE_ID=4;
+    public static final int RULE_ANY_OTHER=10;
+    public static final int EOF=-1;
+    public static final int RULE_SL_COMMENT=8;
+    public static final int RULE_ML_COMMENT=7;
+    public static final int T__19=19;
     public static final int RULE_STRING=6;
     public static final int T__16=16;
     public static final int T__15=15;
@@ -34,12 +38,8 @@ public class InternalFowlerDslTestLanguageParser extends AbstractInternalAntlrPa
     public static final int T__11=11;
     public static final int T__14=14;
     public static final int T__13=13;
-    public static final int RULE_ANY_OTHER=10;
     public static final int RULE_INT=5;
     public static final int RULE_WS=9;
-    public static final int RULE_SL_COMMENT=8;
-    public static final int EOF=-1;
-    public static final int RULE_ML_COMMENT=7;
 
     // delegates
     // delegators

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/services/FowlerDslTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/services/FowlerDslTestLanguageGrammarAccess.java
@@ -32,7 +32,7 @@ public class FowlerDslTestLanguageGrammarAccess extends AbstractGrammarElementFi
 		private final Assignment cStatesAssignment_6 = (Assignment)cGroup.eContents().get(6);
 		private final RuleCall cStatesStateParserRuleCall_6_0 = (RuleCall)cStatesAssignment_6.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / Statemachine:
+		/// * SuppressWarnings[noInstantiation] * / Statemachine:
 		//	"events" events+=Event* "end" "commands" commands+=Command* "end" states+=State*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -288,7 +288,7 @@ public class FowlerDslTestLanguageGrammarAccess extends AbstractGrammarElementFi
 	}
 
 	
-	/// * Suppress[noInstantiation] * / Statemachine:
+	/// * SuppressWarnings[noInstantiation] * / Statemachine:
 	//	"events" events+=Event* "end" "commands" commands+=Command* "end" states+=State*;
 	public StatemachineElements getStatemachineAccess() {
 		return pStatemachine;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/services/FowlerDslTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/testlanguages/services/FowlerDslTestLanguageGrammarAccess.java
@@ -32,7 +32,7 @@ public class FowlerDslTestLanguageGrammarAccess extends AbstractGrammarElementFi
 		private final Assignment cStatesAssignment_6 = (Assignment)cGroup.eContents().get(6);
 		private final RuleCall cStatesStateParserRuleCall_6_0 = (RuleCall)cStatesAssignment_6.eContents().get(0);
 		
-		//Statemachine:
+		/// * Suppress[noInstantiation] * / Statemachine:
 		//	"events" events+=Event* "end" "commands" commands+=Command* "end" states+=State*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -288,7 +288,7 @@ public class FowlerDslTestLanguageGrammarAccess extends AbstractGrammarElementFi
 	}
 
 	
-	//Statemachine:
+	/// * Suppress[noInstantiation] * / Statemachine:
 	//	"events" events+=Event* "end" "commands" commands+=Command* "end" states+=State*;
 	public StatemachineElements getStatemachineAccess() {
 		return pStatemachine;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/validation/parseTreeConstruction/ConcreteSyntaxValidationTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/validation/parseTreeConstruction/ConcreteSyntaxValidationTestLanguageParsetreeConstructor.java
@@ -4913,7 +4913,7 @@ protected class Combination2_Val4Assignment_2_1_1 extends AssignmentToken  {
 
 /************ begin Rule Combination3 ****************
  *
- * Combination3:
+ * / * Suppress[potentialOverride] * / Combination3:
  * 	"#15" (val1=ID | val2=INT | val3=STRING)*;
  *
  **/
@@ -5490,7 +5490,7 @@ protected class List1_Val1Assignment_2_1 extends AssignmentToken  {
 
 /************ begin Rule List2 ****************
  *
- * List2:
+ * / * Suppress[noInstantiation] * / List2:
  * 	"#18" (val1+=ID ("," val1+=ID)*)?;
  *
  **/
@@ -7310,7 +7310,7 @@ protected class AltList2_Val3Assignment_1_1_3 extends AssignmentToken  {
 
 /************ begin Rule TransientObject ****************
  *
- * TransientObject:
+ * / * Suppress[noInstantiation] * / TransientObject:
  * 	"#24" (val1=ID nested=TransientObjectSub)?;
  *
  **/
@@ -7582,7 +7582,7 @@ protected class TransientObjectSub_Val3Assignment_1 extends AssignmentToken  {
 
 /************ begin Rule TransientSerializeables1 ****************
  *
- * TransientSerializeables1:
+ * / * Suppress[noInstantiation] * / TransientSerializeables1:
  * 	"#25" (val1=ID enum1=TransientSerializeables1Enum)? (val2=ID int1=INT)?;
  *
  **/
@@ -7828,7 +7828,7 @@ protected class TransientSerializeables1_Int1Assignment_2_1 extends AssignmentTo
 
 /************ begin Rule StaticSimplification ****************
  *
- * StaticSimplification:
+ * / * Suppress[potentialOverride] * / StaticSimplification:
  * 	"#26" ("kw1" | {EmptyAlternativeSub} | val1=ID) ("kw2" | val2=ID) ("kw3" ("kw4" val3=ID+)?);
  *
  **/
@@ -9120,7 +9120,7 @@ protected class TwoVersionNo2_Extra4Assignment_6_1_1 extends AssignmentToken  {
 
 /************ begin Rule Heuristic1 ****************
  *
- * Heuristic1:
+ * / * Suppress[noInstantiation] * / Heuristic1:
  * 	"#28" ("kw1" a+=ID b+=ID)* ("kw2" a+=ID c+=ID)* ("kw3" b+=ID c+=ID)*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/validation/parseTreeConstruction/ConcreteSyntaxValidationTestLanguageParsetreeConstructor.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/validation/parseTreeConstruction/ConcreteSyntaxValidationTestLanguageParsetreeConstructor.java
@@ -4913,7 +4913,7 @@ protected class Combination2_Val4Assignment_2_1_1 extends AssignmentToken  {
 
 /************ begin Rule Combination3 ****************
  *
- * / * Suppress[potentialOverride] * / Combination3:
+ * / * SuppressWarnings[potentialOverride] * / Combination3:
  * 	"#15" (val1=ID | val2=INT | val3=STRING)*;
  *
  **/
@@ -5490,7 +5490,7 @@ protected class List1_Val1Assignment_2_1 extends AssignmentToken  {
 
 /************ begin Rule List2 ****************
  *
- * / * Suppress[noInstantiation] * / List2:
+ * / * SuppressWarnings[noInstantiation] * / List2:
  * 	"#18" (val1+=ID ("," val1+=ID)*)?;
  *
  **/
@@ -7310,7 +7310,7 @@ protected class AltList2_Val3Assignment_1_1_3 extends AssignmentToken  {
 
 /************ begin Rule TransientObject ****************
  *
- * / * Suppress[noInstantiation] * / TransientObject:
+ * / * SuppressWarnings[noInstantiation] * / TransientObject:
  * 	"#24" (val1=ID nested=TransientObjectSub)?;
  *
  **/
@@ -7582,7 +7582,7 @@ protected class TransientObjectSub_Val3Assignment_1 extends AssignmentToken  {
 
 /************ begin Rule TransientSerializeables1 ****************
  *
- * / * Suppress[noInstantiation] * / TransientSerializeables1:
+ * / * SuppressWarnings[noInstantiation] * / TransientSerializeables1:
  * 	"#25" (val1=ID enum1=TransientSerializeables1Enum)? (val2=ID int1=INT)?;
  *
  **/
@@ -7828,7 +7828,7 @@ protected class TransientSerializeables1_Int1Assignment_2_1 extends AssignmentTo
 
 /************ begin Rule StaticSimplification ****************
  *
- * / * Suppress[potentialOverride] * / StaticSimplification:
+ * / * SuppressWarnings[potentialOverride] * / StaticSimplification:
  * 	"#26" ("kw1" | {EmptyAlternativeSub} | val1=ID) ("kw2" | val2=ID) ("kw3" ("kw4" val3=ID+)?);
  *
  **/
@@ -9120,7 +9120,7 @@ protected class TwoVersionNo2_Extra4Assignment_6_1_1 extends AssignmentToken  {
 
 /************ begin Rule Heuristic1 ****************
  *
- * / * Suppress[noInstantiation] * / Heuristic1:
+ * / * SuppressWarnings[noInstantiation] * / Heuristic1:
  * 	"#28" ("kw1" a+=ID b+=ID)* ("kw2" a+=ID c+=ID)* ("kw3" b+=ID c+=ID)*;
  *
  **/

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/validation/services/ConcreteSyntaxValidationTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/validation/services/ConcreteSyntaxValidationTestLanguageGrammarAccess.java
@@ -1047,7 +1047,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cVal3Assignment_1_2 = (Assignment)cAlternatives_1.eContents().get(2);
 		private final RuleCall cVal3STRINGTerminalRuleCall_1_2_0 = (RuleCall)cVal3Assignment_1_2.eContents().get(0);
 		
-		/// * Suppress[potentialOverride] * / Combination3:
+		/// * SuppressWarnings[potentialOverride] * / Combination3:
 		//	"#15" (val1=ID | val2=INT | val3=STRING)*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1179,7 +1179,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cVal1Assignment_1_1_1 = (Assignment)cGroup_1_1.eContents().get(1);
 		private final RuleCall cVal1IDTerminalRuleCall_1_1_1_0 = (RuleCall)cVal1Assignment_1_1_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / List2:
+		/// * SuppressWarnings[noInstantiation] * / List2:
 		//	"#18" (val1+=ID ("," val1+=ID)*)?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1573,7 +1573,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cNestedAssignment_1_1 = (Assignment)cGroup_1.eContents().get(1);
 		private final RuleCall cNestedTransientObjectSubParserRuleCall_1_1_0 = (RuleCall)cNestedAssignment_1_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / TransientObject:
+		/// * SuppressWarnings[noInstantiation] * / TransientObject:
 		//	"#24" (val1=ID nested=TransientObjectSub)?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1642,7 +1642,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cInt1Assignment_2_1 = (Assignment)cGroup_2.eContents().get(1);
 		private final RuleCall cInt1INTTerminalRuleCall_2_1_0 = (RuleCall)cInt1Assignment_2_1.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / TransientSerializeables1:
+		/// * SuppressWarnings[noInstantiation] * / TransientSerializeables1:
 		//	"#25" (val1=ID enum1=TransientSerializeables1Enum)? (val2=ID int1=INT)?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1703,7 +1703,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cVal3Assignment_3_1_1 = (Assignment)cGroup_3_1.eContents().get(1);
 		private final RuleCall cVal3IDTerminalRuleCall_3_1_1_0 = (RuleCall)cVal3Assignment_3_1_1.eContents().get(0);
 		
-		/// * Suppress[potentialOverride] * / StaticSimplification:
+		/// * SuppressWarnings[potentialOverride] * / StaticSimplification:
 		//	"#26" ("kw1" | {EmptyAlternativeSub} | val1=ID) ("kw2" | val2=ID) ("kw3" ("kw4" val3=ID+)?);
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1978,7 +1978,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cCAssignment_3_2 = (Assignment)cGroup_3.eContents().get(2);
 		private final RuleCall cCIDTerminalRuleCall_3_2_0 = (RuleCall)cCAssignment_3_2.eContents().get(0);
 		
-		/// * Suppress[noInstantiation] * / Heuristic1:
+		/// * SuppressWarnings[noInstantiation] * / Heuristic1:
 		//	"#28" ("kw1" a+=ID b+=ID)* ("kw2" a+=ID c+=ID)* ("kw3" b+=ID c+=ID)*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -2356,7 +2356,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getCombination2Access().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / Combination3:
+	/// * SuppressWarnings[potentialOverride] * / Combination3:
 	//	"#15" (val1=ID | val2=INT | val3=STRING)*;
 	public Combination3Elements getCombination3Access() {
 		return pCombination3;
@@ -2386,7 +2386,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getList1Access().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / List2:
+	/// * SuppressWarnings[noInstantiation] * / List2:
 	//	"#18" (val1+=ID ("," val1+=ID)*)?;
 	public List2Elements getList2Access() {
 		return pList2;
@@ -2446,7 +2446,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getAltList2Access().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / TransientObject:
+	/// * SuppressWarnings[noInstantiation] * / TransientObject:
 	//	"#24" (val1=ID nested=TransientObjectSub)?;
 	public TransientObjectElements getTransientObjectAccess() {
 		return pTransientObject;
@@ -2466,7 +2466,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getTransientObjectSubAccess().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / TransientSerializeables1:
+	/// * SuppressWarnings[noInstantiation] * / TransientSerializeables1:
 	//	"#25" (val1=ID enum1=TransientSerializeables1Enum)? (val2=ID int1=INT)?;
 	public TransientSerializeables1Elements getTransientSerializeables1Access() {
 		return pTransientSerializeables1;
@@ -2486,7 +2486,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getTransientSerializeables1EnumAccess().getRule();
 	}
 
-	/// * Suppress[potentialOverride] * / StaticSimplification:
+	/// * SuppressWarnings[potentialOverride] * / StaticSimplification:
 	//	"#26" ("kw1" | {EmptyAlternativeSub} | val1=ID) ("kw2" | val2=ID) ("kw3" ("kw4" val3=ID+)?);
 	public StaticSimplificationElements getStaticSimplificationAccess() {
 		return pStaticSimplification;
@@ -2526,7 +2526,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getTwoVersionNo2Access().getRule();
 	}
 
-	/// * Suppress[noInstantiation] * / Heuristic1:
+	/// * SuppressWarnings[noInstantiation] * / Heuristic1:
 	//	"#28" ("kw1" a+=ID b+=ID)* ("kw2" a+=ID c+=ID)* ("kw3" b+=ID c+=ID)*;
 	public Heuristic1Elements getHeuristic1Access() {
 		return pHeuristic1;

--- a/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/validation/services/ConcreteSyntaxValidationTestLanguageGrammarAccess.java
+++ b/tests/org.eclipse.xtext.tests/src-gen/org/eclipse/xtext/validation/services/ConcreteSyntaxValidationTestLanguageGrammarAccess.java
@@ -1047,7 +1047,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cVal3Assignment_1_2 = (Assignment)cAlternatives_1.eContents().get(2);
 		private final RuleCall cVal3STRINGTerminalRuleCall_1_2_0 = (RuleCall)cVal3Assignment_1_2.eContents().get(0);
 		
-		//Combination3:
+		/// * Suppress[potentialOverride] * / Combination3:
 		//	"#15" (val1=ID | val2=INT | val3=STRING)*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1179,7 +1179,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cVal1Assignment_1_1_1 = (Assignment)cGroup_1_1.eContents().get(1);
 		private final RuleCall cVal1IDTerminalRuleCall_1_1_1_0 = (RuleCall)cVal1Assignment_1_1_1.eContents().get(0);
 		
-		//List2:
+		/// * Suppress[noInstantiation] * / List2:
 		//	"#18" (val1+=ID ("," val1+=ID)*)?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1573,7 +1573,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cNestedAssignment_1_1 = (Assignment)cGroup_1.eContents().get(1);
 		private final RuleCall cNestedTransientObjectSubParserRuleCall_1_1_0 = (RuleCall)cNestedAssignment_1_1.eContents().get(0);
 		
-		//TransientObject:
+		/// * Suppress[noInstantiation] * / TransientObject:
 		//	"#24" (val1=ID nested=TransientObjectSub)?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1642,7 +1642,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cInt1Assignment_2_1 = (Assignment)cGroup_2.eContents().get(1);
 		private final RuleCall cInt1INTTerminalRuleCall_2_1_0 = (RuleCall)cInt1Assignment_2_1.eContents().get(0);
 		
-		//TransientSerializeables1:
+		/// * Suppress[noInstantiation] * / TransientSerializeables1:
 		//	"#25" (val1=ID enum1=TransientSerializeables1Enum)? (val2=ID int1=INT)?;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1703,7 +1703,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cVal3Assignment_3_1_1 = (Assignment)cGroup_3_1.eContents().get(1);
 		private final RuleCall cVal3IDTerminalRuleCall_3_1_1_0 = (RuleCall)cVal3Assignment_3_1_1.eContents().get(0);
 		
-		//StaticSimplification:
+		/// * Suppress[potentialOverride] * / StaticSimplification:
 		//	"#26" ("kw1" | {EmptyAlternativeSub} | val1=ID) ("kw2" | val2=ID) ("kw3" ("kw4" val3=ID+)?);
 		@Override public ParserRule getRule() { return rule; }
 
@@ -1978,7 +1978,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		private final Assignment cCAssignment_3_2 = (Assignment)cGroup_3.eContents().get(2);
 		private final RuleCall cCIDTerminalRuleCall_3_2_0 = (RuleCall)cCAssignment_3_2.eContents().get(0);
 		
-		//Heuristic1:
+		/// * Suppress[noInstantiation] * / Heuristic1:
 		//	"#28" ("kw1" a+=ID b+=ID)* ("kw2" a+=ID c+=ID)* ("kw3" b+=ID c+=ID)*;
 		@Override public ParserRule getRule() { return rule; }
 
@@ -2356,7 +2356,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getCombination2Access().getRule();
 	}
 
-	//Combination3:
+	/// * Suppress[potentialOverride] * / Combination3:
 	//	"#15" (val1=ID | val2=INT | val3=STRING)*;
 	public Combination3Elements getCombination3Access() {
 		return pCombination3;
@@ -2386,7 +2386,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getList1Access().getRule();
 	}
 
-	//List2:
+	/// * Suppress[noInstantiation] * / List2:
 	//	"#18" (val1+=ID ("," val1+=ID)*)?;
 	public List2Elements getList2Access() {
 		return pList2;
@@ -2446,7 +2446,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getAltList2Access().getRule();
 	}
 
-	//TransientObject:
+	/// * Suppress[noInstantiation] * / TransientObject:
 	//	"#24" (val1=ID nested=TransientObjectSub)?;
 	public TransientObjectElements getTransientObjectAccess() {
 		return pTransientObject;
@@ -2466,7 +2466,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getTransientObjectSubAccess().getRule();
 	}
 
-	//TransientSerializeables1:
+	/// * Suppress[noInstantiation] * / TransientSerializeables1:
 	//	"#25" (val1=ID enum1=TransientSerializeables1Enum)? (val2=ID int1=INT)?;
 	public TransientSerializeables1Elements getTransientSerializeables1Access() {
 		return pTransientSerializeables1;
@@ -2486,7 +2486,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getTransientSerializeables1EnumAccess().getRule();
 	}
 
-	//StaticSimplification:
+	/// * Suppress[potentialOverride] * / StaticSimplification:
 	//	"#26" ("kw1" | {EmptyAlternativeSub} | val1=ID) ("kw2" | val2=ID) ("kw3" ("kw4" val3=ID+)?);
 	public StaticSimplificationElements getStaticSimplificationAccess() {
 		return pStaticSimplification;
@@ -2526,7 +2526,7 @@ public class ConcreteSyntaxValidationTestLanguageGrammarAccess extends AbstractG
 		return getTwoVersionNo2Access().getRule();
 	}
 
-	//Heuristic1:
+	/// * Suppress[noInstantiation] * / Heuristic1:
 	//	"#28" ("kw1" a+=ID b+=ID)* ("kw2" a+=ID c+=ID)* ("kw3" b+=ID c+=ID)*;
 	public Heuristic1Elements getHeuristic1Access() {
 		return pHeuristic1;

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/XtextGrammarTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/XtextGrammarTestLanguage.xtext
@@ -58,7 +58,7 @@ AbstractToken returns AbstractElement:
 	Action
 ;
 
-/* Suppress[potentialOverride] */
+/* SuppressWarnings[potentialOverride] */
 AbstractTokenWithCardinality returns AbstractElement:
 	(Assignment | 
 	 AbstractTerminal) (cardinality=('?'|'*'|'+'))?
@@ -130,7 +130,7 @@ TerminalGroup returns AbstractElement:
 	TerminalToken ({Group.tokens+=current} (tokens+=TerminalToken)+)?
 ;
 
-/* Suppress[potentialOverride] */
+/* SuppressWarnings[potentialOverride] */
 TerminalToken returns AbstractElement:
 	TerminalTokenElement (cardinality=('?'|'*'|'+'))?
 ;

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/XtextGrammarTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/XtextGrammarTestLanguage.xtext
@@ -58,6 +58,7 @@ AbstractToken returns AbstractElement:
 	Action
 ;
 
+/* Suppress[potentialOverride] */
 AbstractTokenWithCardinality returns AbstractElement:
 	(Assignment | 
 	 AbstractTerminal) (cardinality=('?'|'*'|'+'))?
@@ -129,6 +130,7 @@ TerminalGroup returns AbstractElement:
 	TerminalToken ({Group.tokens+=current} (tokens+=TerminalToken)+)?
 ;
 
+/* Suppress[potentialOverride] */
 TerminalToken returns AbstractElement:
 	TerminalTokenElement (cardinality=('?'|'*'|'+'))?
 ;

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/enumrules/EnumRulesTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/enumrules/EnumRulesTestLanguage.xtext
@@ -8,6 +8,7 @@
  *******************************************************************************/
 grammar org.eclipse.xtext.enumrules.EnumRulesTestLanguage with org.eclipse.xtext.common.Terminals
 
+/* Suppress[external] */
 import "classpath:/org/eclipse/xtext/enumrules/enums.ecore"
 generate enumRulesTestLanguage "http://www.eclipse.org/2009/tmf/xtext/EnumRulesTest"
  

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/enumrules/EnumRulesTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/enumrules/EnumRulesTestLanguage.xtext
@@ -8,7 +8,7 @@
  *******************************************************************************/
 grammar org.eclipse.xtext.enumrules.EnumRulesTestLanguage with org.eclipse.xtext.common.Terminals
 
-/* Suppress[external] */
+/* SuppressWarnings[external] */
 import "classpath:/org/eclipse/xtext/enumrules/enums.ecore"
 generate enumRulesTestLanguage "http://www.eclipse.org/2009/tmf/xtext/EnumRulesTest"
  

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/CompositeGeneratorFragmentTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/CompositeGeneratorFragmentTest.java
@@ -11,9 +11,11 @@ import java.io.FileNotFoundException;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.apache.log4j.Level;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.xpand2.XpandExecutionContext;
 import org.eclipse.xtext.Grammar;
+import org.eclipse.xtext.junit4.logging.LoggingTester;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,7 +28,7 @@ public class CompositeGeneratorFragmentTest extends Assert {
 
 	@Test
 	public void testFinalBindingsPersist() throws Exception {
-		CompositeGeneratorFragment fragment = new CompositeGeneratorFragment();
+		final CompositeGeneratorFragment fragment = new CompositeGeneratorFragment();
 		fragment.addFragment(new DefaultGeneratorFragment() {
 			@Override
 			public Set<Binding> getGuiceBindingsRt(Grammar grammar) {
@@ -43,9 +45,16 @@ public class CompositeGeneratorFragmentTest extends Assert {
 				return bindFactory.getBindings();
 			}
 		});
-		Set<Binding> bindings = fragment.getGuiceBindingsRt(null);
-		assertEquals(1, bindings.size());
-		assertEquals("BAR", bindings.iterator().next().getValue().getTypeName());
+		LoggingTester.captureLogging(Level.WARN, CompositeGeneratorFragment.class, new Runnable() {
+
+			@Override
+			public void run() {
+				Set<Binding> bindings = fragment.getGuiceBindingsRt(null);
+				assertEquals(1, bindings.size());
+				assertEquals("BAR", bindings.iterator().next().getValue().getTypeName());
+			}
+			
+		}).assertLogEntry("Cannot override final binding 'final FOO -> BAR (contributed by org.eclipse.xtext.generator.CompositeGeneratorFragmentTest$1)'. Ignoring binding from fragment 'org.eclipse.xtext.generator.CompositeGeneratorFragmentTest$2'");
 	}
 
 	@Test
@@ -95,7 +104,6 @@ public class CompositeGeneratorFragmentTest extends Assert {
 			fragment.getGuiceBindingsRt(null);
 			fail("exception expected");
 		} catch (IllegalStateException e) {
-			System.out.println(e);
 			// expected
 		}
 	}

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/ecore/EcoreFragmentTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/ecore/EcoreFragmentTestLanguage.xtext
@@ -1,6 +1,6 @@
 grammar org.eclipse.xtext.generator.ecore.EcoreFragmentTestLanguage with org.eclipse.xtext.common.Terminals
 
-/* Suppress[external] */
+/* SuppressWarnings[external] */
 import "classpath:/org/eclipse/xtext/generator/ecore/First.ecore" as first
 generate second "http://www.eclipse.org/2009/tmf/xtext/EcoreFragmentTestLanguage" as second
 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/ecore/EcoreFragmentTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/ecore/EcoreFragmentTestLanguage.xtext
@@ -1,5 +1,6 @@
 grammar org.eclipse.xtext.generator.ecore.EcoreFragmentTestLanguage with org.eclipse.xtext.common.Terminals
 
+/* Suppress[external] */
 import "classpath:/org/eclipse/xtext/generator/ecore/First.ecore" as first
 generate second "http://www.eclipse.org/2009/tmf/xtext/EcoreFragmentTestLanguage" as second
 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/grammarAccess/ElementFinderTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/grammarAccess/ElementFinderTestLanguage.xtext
@@ -14,9 +14,11 @@ AType:
 AnotherType:
 	'bar' {AnotherType};
 	
+/* Suppress[noInstantiation] */
 FinderKeywords: 
 	'myKeyword' name=ID? 'myKeyword' 'lala'; 
 	
+/* Suppress[potentialOverride] */
 FinderKeywordPairs:
 	'begin' 'whatever' name=ID ('begin' nested=ID 'end')* 'end' 'begin' second=ID 'end';
 	

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/grammarAccess/ElementFinderTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/grammarAccess/ElementFinderTestLanguage.xtext
@@ -14,11 +14,11 @@ AType:
 AnotherType:
 	'bar' {AnotherType};
 	
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 FinderKeywords: 
 	'myKeyword' name=ID? 'myKeyword' 'lala'; 
 	
-/* Suppress[potentialOverride] */
+/* SuppressWarnings[potentialOverride] */
 FinderKeywordPairs:
 	'begin' 'whatever' name=ID ('begin' nested=ID 'end')* 'end' 'begin' second=ID 'end';
 	

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/grammarAccess/GrammarAccessTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/grammarAccess/GrammarAccessTestLanguage.xtext
@@ -1,6 +1,8 @@
 grammar org.eclipse.xtext.generator.grammarAccess.GrammarAccessTestLanguage with org.eclipse.xtext.common.Terminals
 
+/* Suppress[external] */
 import "classpath:/org/eclipse/xtext/generator/grammarAccess/ametamodel.ecore#//asubpackage" as root
+/* Suppress[external] */
 import "classpath:/org/eclipse/xtext/generator/grammarAccess/ametamodel.ecore#//asubpackage/emptyPackage/subsubpackage" as sub
 
 Root returns root::AModel:

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/grammarAccess/GrammarAccessTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/grammarAccess/GrammarAccessTestLanguage.xtext
@@ -1,8 +1,8 @@
 grammar org.eclipse.xtext.generator.grammarAccess.GrammarAccessTestLanguage with org.eclipse.xtext.common.Terminals
 
-/* Suppress[external] */
+/* SuppressWarnings[external] */
 import "classpath:/org/eclipse/xtext/generator/grammarAccess/ametamodel.ecore#//asubpackage" as root
-/* Suppress[external] */
+/* SuppressWarnings[external] */
 import "classpath:/org/eclipse/xtext/generator/grammarAccess/ametamodel.ecore#//asubpackage/emptyPackage/subsubpackage" as sub
 
 Root returns root::AModel:

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/grammarinheritance/AbstractTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/grammarinheritance/AbstractTestLanguage.xtext
@@ -14,7 +14,7 @@ import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 InheritedParserRule returns mm::AType:
 	'element' name=ID;
 	
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 AbstractCallOverridenParserRule returns mm::AModel:
 	'overridemodel' (elements+=OverridableParserRule)*;
 	
@@ -24,7 +24,7 @@ OverridableParserRule returns mm::AType :
 OverridableParserRule2 returns mm::AType :
     'other element' name=STRING;
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 AbstractCallExtendedParserRule returns mm::AModel:
 	'extendedmodel' (elements+=ExtendableParserRule)*;
 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/grammarinheritance/AbstractTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/grammarinheritance/AbstractTestLanguage.xtext
@@ -14,6 +14,7 @@ import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 InheritedParserRule returns mm::AType:
 	'element' name=ID;
 	
+/* Suppress[noInstantiation] */
 AbstractCallOverridenParserRule returns mm::AModel:
 	'overridemodel' (elements+=OverridableParserRule)*;
 	
@@ -23,6 +24,7 @@ OverridableParserRule returns mm::AType :
 OverridableParserRule2 returns mm::AType :
     'other element' name=STRING;
 
+/* Suppress[noInstantiation] */
 AbstractCallExtendedParserRule returns mm::AModel:
 	'extendedmodel' (elements+=ExtendableParserRule)*;
 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/index/IndexTestLanguageInjectorProvider.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/index/IndexTestLanguageInjectorProvider.xtend
@@ -14,7 +14,7 @@ import org.eclipse.xtext.junit4.IInjectorProvider
 import org.eclipse.xtext.junit4.IRegistryConfigurator
 
 /**
- * @author Sven efftinge - Initial contribution and API
+ * @author Sven Efftinge - Initial contribution and API
  */
 class IndexTestLanguageInjectorProvider implements IInjectorProvider, IRegistryConfigurator {
 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/linking/Bug287988TestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/linking/Bug287988TestLanguage.xtext
@@ -9,6 +9,7 @@ grammar org.eclipse.xtext.linking.Bug287988TestLanguage with org.eclipse.xtext.c
 
 generate bug287988Test "http://eclipse.org/xtext/Bug287988TestLanguage"
 
+/* Suppress[noInstantiation] */
 Model:
     ('actions' attributes+=BaseAttribute*)
   | ('simple' attributes+=SimpleAttribute*)

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/linking/Bug287988TestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/linking/Bug287988TestLanguage.xtext
@@ -9,7 +9,7 @@ grammar org.eclipse.xtext.linking.Bug287988TestLanguage with org.eclipse.xtext.c
 
 generate bug287988Test "http://eclipse.org/xtext/Bug287988TestLanguage"
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 Model:
     ('actions' attributes+=BaseAttribute*)
   | ('simple' attributes+=SimpleAttribute*)

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/linking/lazy/LazyLinkingTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/linking/lazy/LazyLinkingTestLanguage.xtext
@@ -12,6 +12,10 @@ generate lazyLinking "http://eclipse.org/xtext/lazyLinkingTestLanguage"
 Model : 
 	types+=Type*;
 	
+/* 
+ * Suppress[BidirectionalReference]
+ * Suppress[potentialOverride]
+ */
 Type :
 	'type' name=ID ('extends' ^extends=[Type] '.' parentId=[Property])? ('for' parentId=[Property] 'in' ^extends=[Type])? '{'
 		(properties+=Property)* 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/linking/lazy/LazyLinkingTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/linking/lazy/LazyLinkingTestLanguage.xtext
@@ -13,8 +13,8 @@ Model :
 	types+=Type*;
 	
 /* 
- * Suppress[BidirectionalReference]
- * Suppress[potentialOverride]
+ * SuppressWarnings[BidirectionalReference]
+ * SuppressWarnings[potentialOverride]
  */
 Type :
 	'type' name=ID ('extends' ^extends=[Type] '.' parentId=[Property])? ('for' parentId=[Property] 'in' ^extends=[Type])? '{'

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/metamodelreferencing/tests/EcoreReferenceTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/metamodelreferencing/tests/EcoreReferenceTestLanguage.xtext
@@ -8,7 +8,8 @@
  *******************************************************************************/
 grammar org.eclipse.xtext.metamodelreferencing.tests.EcoreReferenceTestLanguage with org.eclipse.xtext.common.Terminals
 
-import "http://www.eclipse.org/2011/tmf/xtext/ecorePerNsURI" // the warning is intentional
+/* Suppress[external] */
+import "http://www.eclipse.org/2011/tmf/xtext/ecorePerNsURI"
 import "http://www.eclipse.org/2011/tmf/xtext/ecorePerPlatformPlugin"
 import "http://www.eclipse.org/2011/tmf/xtext/ecorePerPlatformResource"
 import "http://www.eclipse.org/emf/2002/Ecore"

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/metamodelreferencing/tests/EcoreReferenceTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/metamodelreferencing/tests/EcoreReferenceTestLanguage.xtext
@@ -8,7 +8,7 @@
  *******************************************************************************/
 grammar org.eclipse.xtext.metamodelreferencing.tests.EcoreReferenceTestLanguage with org.eclipse.xtext.common.Terminals
 
-/* Suppress[external] */
+/* SuppressWarnings[external] */
 import "http://www.eclipse.org/2011/tmf/xtext/ecorePerNsURI"
 import "http://www.eclipse.org/2011/tmf/xtext/ecorePerPlatformPlugin"
 import "http://www.eclipse.org/2011/tmf/xtext/ecorePerPlatformResource"

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/mwe/AbstractReaderTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/mwe/AbstractReaderTest.java
@@ -13,6 +13,7 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.log4j.Level;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.mwe.core.WorkflowContext;
 import org.eclipse.emf.mwe.core.WorkflowContextDefaultImpl;
@@ -25,6 +26,7 @@ import org.eclipse.xtext.index.IndexTestLanguageStandaloneSetup;
 import org.eclipse.xtext.index.indexTestLanguage.Entity;
 import org.eclipse.xtext.index.indexTestLanguage.IndexTestLanguagePackage;
 import org.eclipse.xtext.junit4.AbstractXtextTests;
+import org.eclipse.xtext.junit4.logging.LoggingTester;
 import org.junit.Test;
 
 /**
@@ -33,7 +35,7 @@ import org.junit.Test;
 public abstract class AbstractReaderTest extends AbstractXtextTests {
 
 	@Test public void testLoadMatchNone() throws Exception {
-		Reader reader = getReader();
+		final Reader reader = getReader();
 		reader.addPath(pathTo("emptyFolder"));
 		reader.addPath(pathTo("nonemptyFolder"));
 		reader.addRegister(new IndexTestLanguageStandaloneSetup());
@@ -48,8 +50,15 @@ public abstract class AbstractReaderTest extends AbstractXtextTests {
 				return false;
 			}
 		});
-		WorkflowContext ctx = ctx();
-		reader.invoke(ctx, monitor(), issues());
+		final WorkflowContext ctx = ctx();
+		LoggingTester.captureLogging(Level.WARN, SlotEntry.class, new Runnable() {
+
+			@Override
+			public void run() {
+				reader.invoke(ctx, monitor(), issues());
+			}
+			
+		}).assertLogEntry("Could not find any exported element of type 'Type' -> Slot 'model' is empty.");
 		Collection<?> slotContent = (Collection<?>) ctx.get("model");
 		assertNotNull(slotContent);
 		assertTrue(slotContent.isEmpty());

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/antlr/Bug296889ExTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/antlr/Bug296889ExTestLanguage.xtext
@@ -9,7 +9,7 @@ grammar org.eclipse.xtext.parser.antlr.Bug296889ExTestLanguage with org.eclipse.
 
 generate bug296889ExTest "http://eclipse.org/xtext/Bug296889ExTestLanguage"
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 Model: "Model" expressions += Expression* | "DataType" values += DataTypeExpression* ;
 
 Expression: Postop | Preop ; 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/antlr/Bug296889ExTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/antlr/Bug296889ExTestLanguage.xtext
@@ -9,6 +9,7 @@ grammar org.eclipse.xtext.parser.antlr.Bug296889ExTestLanguage with org.eclipse.
 
 generate bug296889ExTest "http://eclipse.org/xtext/Bug296889ExTestLanguage"
 
+/* Suppress[noInstantiation] */
 Model: "Model" expressions += Expression* | "DataType" values += DataTypeExpression* ;
 
 Expression: Postop | Preop ; 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/antlr/Bug296889TestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/antlr/Bug296889TestLanguage.xtext
@@ -9,6 +9,7 @@ grammar org.eclipse.xtext.parser.antlr.Bug296889TestLanguage with org.eclipse.xt
 
 generate bug296889Test "http://eclipse.org/xtext/Bug296889TestLanguage"
 
+/* Suppress[noInstantiation] */
 Model: "Model" expressions += Expression* | "DataType" values += DataTypeExpression* ;
 
 Expression: Postop | Preop ; 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/antlr/Bug296889TestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/antlr/Bug296889TestLanguage.xtext
@@ -9,7 +9,7 @@ grammar org.eclipse.xtext.parser.antlr.Bug296889TestLanguage with org.eclipse.xt
 
 generate bug296889Test "http://eclipse.org/xtext/Bug296889TestLanguage"
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 Model: "Model" expressions += Expression* | "DataType" values += DataTypeExpression* ;
 
 Expression: Postop | Preop ; 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/terminalrules/XtextTerminalsTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/terminalrules/XtextTerminalsTestLanguage.xtext
@@ -57,7 +57,7 @@ AbstractToken returns AbstractElement:
 	Action
 ;
 
-/* Suppress[potentialOverride] */
+/* SuppressWarnings[potentialOverride] */
 AbstractTokenWithCardinality returns AbstractElement:
 	(Assignment | 
 	 AbstractTerminal) (cardinality=('?'|'*'|'+'))?
@@ -121,7 +121,7 @@ TerminalGroup returns AbstractElement:
 	TerminalToken ({Group.tokens+=current} (tokens+=TerminalToken)+)?
 ;
 
-/* Suppress[potentialOverride] */
+/* SuppressWarnings[potentialOverride] */
 TerminalToken returns AbstractElement:
 	TerminalTokenElement (cardinality=('?'|'*'|'+'))?
 ;

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/terminalrules/XtextTerminalsTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/terminalrules/XtextTerminalsTestLanguage.xtext
@@ -57,6 +57,7 @@ AbstractToken returns AbstractElement:
 	Action
 ;
 
+/* Suppress[potentialOverride] */
 AbstractTokenWithCardinality returns AbstractElement:
 	(Assignment | 
 	 AbstractTerminal) (cardinality=('?'|'*'|'+'))?
@@ -120,6 +121,7 @@ TerminalGroup returns AbstractElement:
 	TerminalToken ({Group.tokens+=current} (tokens+=TerminalToken)+)?
 ;
 
+/* Suppress[potentialOverride] */
 TerminalToken returns AbstractElement:
 	TerminalTokenElement (cardinality=('?'|'*'|'+'))?
 ;

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/unorderedGroups/UnorderedGroupsTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/unorderedGroups/UnorderedGroupsTestLanguage.xtext
@@ -54,6 +54,7 @@ UnorderedDatatype:
   | '14' (('a' & 'b') & ('c' & 'd'))+
 ;
 
+/* Suppress[potentialOverride] */
 UnorderedSerialization: {UnorderedSerialization} (
     '1' first?='a'?  & second?='b'? & third?='c'? & forth?='d'?
   | '2' (firstAsList+='a' & secondAsList+='b')*

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/unorderedGroups/UnorderedGroupsTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/unorderedGroups/UnorderedGroupsTestLanguage.xtext
@@ -54,7 +54,7 @@ UnorderedDatatype:
   | '14' (('a' & 'b') & ('c' & 'd'))+
 ;
 
-/* Suppress[potentialOverride] */
+/* SuppressWarnings[potentialOverride] */
 UnorderedSerialization: {UnorderedSerialization} (
     '1' first?='a'?  & second?='b'? & third?='c'? & forth?='d'?
   | '2' (firstAsList+='a' & secondAsList+='b')*

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterExpected.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterExpected.xtext
@@ -15,9 +15,11 @@ import "http://www.eclipse.org/2008/Xtext" as xtext
 Root:
 	"test" (TestLinewrap | TestIndentation);
 
+/* Suppress[noInstantiation] */
 TestLinewrap:
 	"linewrap" items+=STRING*;
 
+/* Suppress[noInstantiation] */
 TestIndentation:
 	"indentation" "{"
 	(sub+=TestIndentation |

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterExpected.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterExpected.xtext
@@ -15,11 +15,11 @@ import "http://www.eclipse.org/2008/Xtext" as xtext
 Root:
 	"test" (TestLinewrap | TestIndentation);
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 TestLinewrap:
 	"linewrap" items+=STRING*;
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 TestIndentation:
 	"indentation" "{"
 	(sub+=TestIndentation |

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterMessy.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterMessy.xtext
@@ -17,11 +17,11 @@ import "http://www.eclipse.org/2008/Xtext" as xtext
 Root:
 	"test" (TestLinewrap | TestIndentation);
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 TestLinewrap:
 	"linewrap" items+=STRING*;
 	
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 TestIndentation:
 	"indentation" "{" 
 		(sub+=TestIndentation | 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterMessy.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/formatter/XtextFormatterMessy.xtext
@@ -16,10 +16,12 @@ import "http://www.eclipse.org/2008/Xtext" as xtext
 
 Root:
 	"test" (TestLinewrap | TestIndentation);
-		
+
+/* Suppress[noInstantiation] */
 TestLinewrap:
 	"linewrap" items+=STRING*;
 	
+/* Suppress[noInstantiation] */
 TestIndentation:
 	"indentation" "{" 
 		(sub+=TestIndentation | 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/ComplexReconstrTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/ComplexReconstrTestLanguage.xtext
@@ -21,6 +21,7 @@ Term returns Expression:
 Atom: 
 	name=ID;
 
+/* Suppress[potentialOverride] */
 Parens returns Expression: 
 	'(' Op ')' em='!'?;
 
@@ -33,19 +34,23 @@ StrangeStuff :
 //TrickyA returns TypeA1: 'TA' TrickyA1 (name += ID)* ({TypeB.x=current} 'x' | {TypeC.x=current} 'y')? name+=STRING;
 //TrickyA1 returns TypeD: name+=ID;
 
+/* Suppress[noInstantiation] */
 TrickyB : 'TB' (name = ID type += INT)? (type += INT)*;
 
 TrickyC : 'TC' name = ID ({C1.x=current} 'x')? ({C2.y=current} 'y')? ({C3.z=current} 'z')?;
 
+/* Suppress[noInstantiation] */
 TrickyD: 'TD' (name += INT foo = STRING type += ID)? (name += INT type += ID)? (type += ID)*;  
 
 // 34 "abc" XX 123 "de" YY x 34 DD 45 CC
+/* Suppress[noInstantiation] */
 TrickyE: 'TE' (name+=INT foo+=STRING type+=ID)* 'x' (name+=INT type+=ID)*;
 
 // 
 TrickyF: 'TF' (name+=ID type+=INT)* (name+=ID | type+=INT);
 
-TrickyG: 'TG' tree=TrickyG1; 
+TrickyG: 'TG' tree=TrickyG1;
+/* Suppress[noInstantiation] */ 
 TrickyG1: '[' (vals+=TrickyG2 (',' vals+=TrickyG2)*)? ']';
 TrickyG2: TrickyG1 | val=INT;
 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/ComplexReconstrTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/ComplexReconstrTestLanguage.xtext
@@ -21,7 +21,7 @@ Term returns Expression:
 Atom: 
 	name=ID;
 
-/* Suppress[potentialOverride] */
+/* SuppressWarnings[potentialOverride] */
 Parens returns Expression: 
 	'(' Op ')' em='!'?;
 
@@ -34,23 +34,23 @@ StrangeStuff :
 //TrickyA returns TypeA1: 'TA' TrickyA1 (name += ID)* ({TypeB.x=current} 'x' | {TypeC.x=current} 'y')? name+=STRING;
 //TrickyA1 returns TypeD: name+=ID;
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 TrickyB : 'TB' (name = ID type += INT)? (type += INT)*;
 
 TrickyC : 'TC' name = ID ({C1.x=current} 'x')? ({C2.y=current} 'y')? ({C3.z=current} 'z')?;
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 TrickyD: 'TD' (name += INT foo = STRING type += ID)? (name += INT type += ID)? (type += ID)*;  
 
 // 34 "abc" XX 123 "de" YY x 34 DD 45 CC
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 TrickyE: 'TE' (name+=INT foo+=STRING type+=ID)* 'x' (name+=INT type+=ID)*;
 
 // 
 TrickyF: 'TF' (name+=ID type+=INT)* (name+=ID | type+=INT);
 
 TrickyG: 'TG' tree=TrickyG1;
-/* Suppress[noInstantiation] */ 
+/* SuppressWarnings[noInstantiation] */ 
 TrickyG1: '[' (vals+=TrickyG2 (',' vals+=TrickyG2)*)? ']';
 TrickyG2: TrickyG1 | val=INT;
 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/HiddenTokensMergerTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/HiddenTokensMergerTestLanguage.xtext
@@ -23,18 +23,18 @@ EnumBug:
 	
 enum EnumBugEnum: array="array" | object="object" | resultSet="resultSet" | iterator="iterator";	
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 Commentable:
 	'#3' item+=CommentableItem*;
 	
 CommentableItem:
 	'item' id=ID;
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 ValueList:
 	'#4' ids+=FQN*;
 	
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 RefList:
 	'#5' objs+=RefObj* 'refs' refs+=[RefObj|FQN]*;
 	
@@ -45,7 +45,7 @@ SingleRef:
 	'#6' obj=RefObj 'ref' ref=[RefObj|FQN];
 	
 // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=297938
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 AppendToFileEnd:
 	'#7' items+=AppendToFileEndItem*;
 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/HiddenTokensMergerTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/HiddenTokensMergerTestLanguage.xtext
@@ -23,15 +23,18 @@ EnumBug:
 	
 enum EnumBugEnum: array="array" | object="object" | resultSet="resultSet" | iterator="iterator";	
 
+/* Suppress[noInstantiation] */
 Commentable:
 	'#3' item+=CommentableItem*;
 	
 CommentableItem:
 	'item' id=ID;
 
+/* Suppress[noInstantiation] */
 ValueList:
 	'#4' ids+=FQN*;
 	
+/* Suppress[noInstantiation] */
 RefList:
 	'#5' objs+=RefObj* 'refs' refs+=[RefObj|FQN]*;
 	
@@ -42,6 +45,7 @@ SingleRef:
 	'#6' obj=RefObj 'ref' ref=[RefObj|FQN];
 	
 // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=297938
+/* Suppress[noInstantiation] */
 AppendToFileEnd:
 	'#7' items+=AppendToFileEndItem*;
 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/SerializationErrorTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/SerializationErrorTestLanguage.xtext
@@ -25,5 +25,6 @@ TwoRequired:
 TwoOptions:
 	"twooptions" ("one" one=ID | "two" two=ID);
 
+/* Suppress[noInstantiation] */
 Indent:
 	"{" req=TwoRequired? opt=TwoOptions? indent+=Indent* "}";

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/SerializationErrorTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/SerializationErrorTestLanguage.xtext
@@ -25,6 +25,6 @@ TwoRequired:
 TwoOptions:
 	"twooptions" ("one" one=ID | "two" two=ID);
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 Indent:
 	"{" req=TwoRequired? opt=TwoOptions? indent+=Indent* "}";

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/SimpleReconstrTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/SimpleReconstrTestLanguage.xtext
@@ -24,7 +24,7 @@ Term returns Expression:
 Atom: 
 	name=ID;
 
-/* Suppress[potentialOverride] */
+/* SuppressWarnings[potentialOverride] */
 Parens returns Expression: 
 	'(' Op ')' em='!'?;
 	
@@ -70,14 +70,14 @@ Loop4:
 LoopBug285452:
 	'#12' (interface?="interface"|"class") name=ID;
 
-/* Suppress[potentialOverride] */
+/* SuppressWarnings[potentialOverride] */
 DuplicateBug284491:
 	'#13' (static?='static' | final?='final' | transient?='transient')*;
 	
 EmptyObjectBug284850:
 	'#14' items=EmptyObjectItems;
 	
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 EmptyObjectItems:
 	list+=EmptyObjectItem*;
 	
@@ -115,11 +115,11 @@ TypeBug2B: {TypeBug2B} "kb" name=ID;
 Bug305171:
 	"#19" (('kx' x+=ID (',' x+=ID)*)? (('ky' y+=ID (',' y+=ID)*)? ('kz' z+=ID (',' z+=ID)*)?)) name=ID;
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 Bug310435Enum:
 	"#20" ('kw1' lits+=EnumBug310435Lit1 | 'kw2' lits+=EnumBug310435Lit2)*;
 	
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 Bug310435Val:
 	"#21" ('kw1' lits+=ID | 'kw2' lits+=STRING)*;
 	
@@ -129,7 +129,7 @@ enum EnumBug310435Lit1 returns EnumBug310435Enum:
 enum EnumBug310435Lit2 returns EnumBug310435Enum:
 	lit2='lit2';
 	
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 CrossRefNameTest:
 	"#22" named+=CrossRefNamed* "kw1" ("kw2" ref+=[CrossRefNamed|ID1] | "kw3" ref+=[CrossRefNamed|ID2])*;
 	

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/SimpleReconstrTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parsetree/reconstr/SimpleReconstrTestLanguage.xtext
@@ -24,6 +24,7 @@ Term returns Expression:
 Atom: 
 	name=ID;
 
+/* Suppress[potentialOverride] */
 Parens returns Expression: 
 	'(' Op ')' em='!'?;
 	
@@ -68,13 +69,15 @@ Loop4:
 	
 LoopBug285452:
 	'#12' (interface?="interface"|"class") name=ID;
-	
+
+/* Suppress[potentialOverride] */
 DuplicateBug284491:
 	'#13' (static?='static' | final?='final' | transient?='transient')*;
 	
 EmptyObjectBug284850:
 	'#14' items=EmptyObjectItems;
 	
+/* Suppress[noInstantiation] */
 EmptyObjectItems:
 	list+=EmptyObjectItem*;
 	
@@ -112,9 +115,11 @@ TypeBug2B: {TypeBug2B} "kb" name=ID;
 Bug305171:
 	"#19" (('kx' x+=ID (',' x+=ID)*)? (('ky' y+=ID (',' y+=ID)*)? ('kz' z+=ID (',' z+=ID)*)?)) name=ID;
 
+/* Suppress[noInstantiation] */
 Bug310435Enum:
 	"#20" ('kw1' lits+=EnumBug310435Lit1 | 'kw2' lits+=EnumBug310435Lit2)*;
 	
+/* Suppress[noInstantiation] */
 Bug310435Val:
 	"#21" ('kw1' lits+=ID | 'kw2' lits+=STRING)*;
 	
@@ -124,6 +129,7 @@ enum EnumBug310435Lit1 returns EnumBug310435Enum:
 enum EnumBug310435Lit2 returns EnumBug310435Enum:
 	lit2='lit2';
 	
+/* Suppress[noInstantiation] */
 CrossRefNameTest:
 	"#22" named+=CrossRefNamed* "kw1" ("kw2" ref+=[CrossRefNamed|ID1] | "kw3" ref+=[CrossRefNamed|ID2])*;
 	

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/ResourceServiceProvideRegistryTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/ResourceServiceProvideRegistryTest.java
@@ -9,7 +9,9 @@ package org.eclipse.xtext.resource;
 
 import static org.junit.Assert.*;
 
+import org.apache.log4j.Level;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.junit4.logging.LoggingTester;
 import org.eclipse.xtext.resource.impl.ResourceServiceProviderRegistryImpl;
 import org.junit.Test;
 
@@ -27,11 +29,17 @@ public class ResourceServiceProvideRegistryTest {
 			}
 		};
 		
-		IResourceServiceProvider.Registry reg = new ResourceServiceProviderRegistryImpl();
+		final IResourceServiceProvider.Registry reg = new ResourceServiceProviderRegistryImpl();
 		reg.getExtensionToFactoryMap().put("foo", provider);
 		
 		assertEquals(1, reg.getExtensionToFactoryMap().size());
-		assertNull(reg.getResourceServiceProvider(URI.createURI("hubba.foo")));
+		LoggingTester.captureLogging(Level.ERROR, ResourceServiceProviderRegistryImpl.class, new Runnable() {
+			@Override
+			public void run() {
+				assertNull(reg.getResourceServiceProvider(URI.createURI("hubba.foo")));
+			}
+		}).assertLogEntry("Errorneous resource service provider registered for 'hubba.foo'. Removing it from the registry.");
+		
 		assertEquals(0, reg.getExtensionToFactoryMap().size());
 	}
 }

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/uriHell/SrcSegmentsInUrisAreNotRemovedTests.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/uriHell/SrcSegmentsInUrisAreNotRemovedTests.java
@@ -87,7 +87,6 @@ public class SrcSegmentsInUrisAreNotRemovedTests {
 		writer.flush();
 		String fileContent = writer.toString();
 
-		System.out.println(fileContent);
 		assertTrue(
 				"We should have a src/ in the serialization as we are refering to a.ecore which is in a src folder.",
 				fileContent.indexOf("src") > -1);

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/HiddenTokenSequencerTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/HiddenTokenSequencerTestLanguage.xtext
@@ -14,6 +14,7 @@ Model:
 	domainModel = DomainModel
 ;
 
+/* Suppress[noInstantiation] */
 DomainModel:
 	'entities'
 		(entities+=Entity)*

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/HiddenTokenSequencerTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/HiddenTokenSequencerTestLanguage.xtext
@@ -14,7 +14,7 @@ Model:
 	domainModel = DomainModel
 ;
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 DomainModel:
 	'entities'
 		(entities+=Entity)*

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/testlanguages/FowlerDslTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/testlanguages/FowlerDslTestLanguage.xtext
@@ -10,7 +10,7 @@ grammar org.eclipse.xtext.testlanguages.FowlerDslTestLanguage with org.eclipse.x
 
 generate fowlerdsl "http://example.xtext.org/FowlerDslTestLanguage"
 
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 Statemachine :
   'events'
      (events+=Event)*

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/testlanguages/FowlerDslTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/testlanguages/FowlerDslTestLanguage.xtext
@@ -10,6 +10,7 @@ grammar org.eclipse.xtext.testlanguages.FowlerDslTestLanguage with org.eclipse.x
 
 generate fowlerdsl "http://example.xtext.org/FowlerDslTestLanguage"
 
+/* Suppress[noInstantiation] */
 Statemachine :
   'events'
      (events+=Event)*

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/ConcreteSyntaxValidationTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/ConcreteSyntaxValidationTestLanguage.xtext
@@ -65,7 +65,7 @@ Combination1:
 Combination2:
 	"#14" val1=ID (("kw1" val2=ID) | (val3+=ID val4+=ID)*);
 	
-/* Suppress[potentialOverride] */
+/* SuppressWarnings[potentialOverride] */
 Combination3:
 	"#15" (val1=ID | val2=INT | val3=STRING)*;
 	
@@ -75,7 +75,7 @@ Combination4:
 List1:
 	"#17" val1+=ID ("," val1+=ID)*;
 	
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 List2:
 	"#18" (val1+=ID ("," val1+=ID)*)?;
 	
@@ -94,21 +94,21 @@ AltList1:
 AltList2:
 	"#23" (val1+=ID val2=ID | "kw" val1+=ID ("," val1+=ID)* val3=ID);  
 	
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 TransientObject:
 	"#24" (val1=ID nested=TransientObjectSub)?;
 	
 TransientObjectSub:
 	val2=ID val3=ID;
 	
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 TransientSerializeables1:
 	"#25" (val1=ID enum1=TransientSerializeables1Enum)? (val2=ID int1=INT)?;
 	
 enum TransientSerializeables1Enum:
 	lit1 | lit2;
 	
-/* Suppress[potentialOverride] */
+/* SuppressWarnings[potentialOverride] */
 StaticSimplification:
 	"#26" ("kw1"|{EmptyAlternativeSub}|val1=ID) ("kw2"|val2=ID) ("kw3" ("kw4" (val3=ID)+)?);
 	
@@ -122,7 +122,7 @@ TwoVersionNo2 returns TwoVersion:
 	shared1=ID? shared2=ID "long" (shared3+=ID shared3+=ID*)?
 	"extra" extra1=ID? ((extra2=ID extra3=ID) | "two" extra4=ID)?; 
 	
-/* Suppress[noInstantiation] */
+/* SuppressWarnings[noInstantiation] */
 Heuristic1:
 	"#28" ("kw1" a+=ID b+=ID)* ("kw2" a+=ID c+=ID)* ("kw3" b+=ID c+=ID)*;
 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/ConcreteSyntaxValidationTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/validation/ConcreteSyntaxValidationTestLanguage.xtext
@@ -65,6 +65,7 @@ Combination1:
 Combination2:
 	"#14" val1=ID (("kw1" val2=ID) | (val3+=ID val4+=ID)*);
 	
+/* Suppress[potentialOverride] */
 Combination3:
 	"#15" (val1=ID | val2=INT | val3=STRING)*;
 	
@@ -74,6 +75,7 @@ Combination4:
 List1:
 	"#17" val1+=ID ("," val1+=ID)*;
 	
+/* Suppress[noInstantiation] */
 List2:
 	"#18" (val1+=ID ("," val1+=ID)*)?;
 	
@@ -91,19 +93,22 @@ AltList1:
 	
 AltList2:
 	"#23" (val1+=ID val2=ID | "kw" val1+=ID ("," val1+=ID)* val3=ID);  
-	   
+	
+/* Suppress[noInstantiation] */
 TransientObject:
 	"#24" (val1=ID nested=TransientObjectSub)?;
 	
 TransientObjectSub:
 	val2=ID val3=ID;
 	
+/* Suppress[noInstantiation] */
 TransientSerializeables1:
 	"#25" (val1=ID enum1=TransientSerializeables1Enum)? (val2=ID int1=INT)?;
 	
 enum TransientSerializeables1Enum:
 	lit1 | lit2;
 	
+/* Suppress[potentialOverride] */
 StaticSimplification:
 	"#26" ("kw1"|{EmptyAlternativeSub}|val1=ID) ("kw2"|val2=ID) ("kw3" ("kw4" (val3=ID)+)?);
 	
@@ -117,6 +122,7 @@ TwoVersionNo2 returns TwoVersion:
 	shared1=ID? shared2=ID "long" (shared3+=ID shared3+=ID*)?
 	"extra" extra1=ID? ((extra2=ID extra3=ID) | "two" extra4=ID)?; 
 	
+/* Suppress[noInstantiation] */
 Heuristic1:
 	"#28" ("kw1" a+=ID b+=ID)* ("kw2" a+=ID c+=ID)* ("kw3" b+=ID c+=ID)*;
 

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/Bug287082Test.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/Bug287082Test.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xtext;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.xtext.Grammar;
+import org.eclipse.xtext.ParserRule;
+import org.eclipse.xtext.XtextStandaloneSetup;
+import org.eclipse.xtext.validation.AbstractValidationMessageAcceptingTestCase;
+import org.junit.Test;
+
+/**
+ * @author Sebastian Zarnekow - Initial contribution and API
+ */
+public class Bug287082Test extends AbstractValidationMessageAcceptingTestCase {
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		with(XtextStandaloneSetup.class);
+	}
+	
+	@Test public void testBug285605() throws Exception {
+		String grammarAsString = "grammar org.xtext.example.MyDsl with org.eclipse.xtext.common.Terminals\n" + 
+				"generate myDsl \"http://www.xtext.org/example/MyDsl\"\n" + 
+				"\n" + 
+				"A: {A} (feature=ID+)?;\n";
+		Grammar grammar = (Grammar) getModel(grammarAsString);
+		OverriddenValueInspector inspector = new OverriddenValueInspector(this);
+		inspector.inspect((ParserRule) grammar.getRules().get(0));
+	}
+
+	@Override
+	public void acceptWarning(String message, EObject object, EStructuralFeature feature, int index, String code,
+			String... issueData) {
+		if (code.equals(OverriddenValueInspector.ISSUE_CODE)) {
+			String expectation = "";
+			assertEquals(expectation, message);
+		} else {
+			super.acceptWarning(message, object, feature, index, code, issueData);
+		}
+	}
+
+}

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/Bug287082Test.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/Bug287082Test.java
@@ -40,7 +40,7 @@ public class Bug287082Test extends AbstractValidationMessageAcceptingTestCase {
 	public void acceptWarning(String message, EObject object, EStructuralFeature feature, int index, String code,
 			String... issueData) {
 		if (code.equals(OverriddenValueInspector.ISSUE_CODE)) {
-			String expectation = "";
+			String expectation = "The assigned value of feature 'feature' will possibly override itself because it is used inside of a loop.";
 			assertEquals(expectation, message);
 		} else {
 			super.acceptWarning(message, object, feature, index, code, issueData);

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextGrammarSerializationTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextGrammarSerializationTest.java
@@ -42,6 +42,14 @@ public class XtextGrammarSerializationTest extends AbstractXtextTests {
 				+ "mm \"http://bar\" as fooMM\n\nStartRule returns fooMM::T:\n	name=ID;";
 		doTestSerialization(model, expectedModel);
 	}
+	
+	@Test public void testSerializationWithCardinalityOverride() throws Exception {
+		final String model = "grammar foo with org.eclipse.xtext.common.Terminals\n"
+				+ "generate mm \"http://bar\" as fooMM\n" + "StartRule returns fooMM::T: (name+=ID?)+;";
+		final String expectedModel = "grammar foo with org.eclipse.xtext.common.Terminals\n\ngenerate "
+				+ "mm \"http://bar\" as fooMM\n\nStartRule returns fooMM::T:\n	name+=ID*;";
+		doTestSerialization(model, expectedModel);
+	}
 
 	private void doTestSerialization(String model, String expectedModel) throws Exception {
 		final XtextResource resource = getResourceFromString(model);

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextValidationTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextValidationTest.java
@@ -105,7 +105,7 @@ public class XtextValidationTest extends AbstractValidationMessageAcceptingTestC
 				"generate metamodel 'myURI'\n" +
 				 
 				"Model: child=Child;\n" + 
-				"/* Suppress[noInstantiation] */\n" +
+				"/* SuppressWarnings[noInstantiation] */\n" +
 				"Child: name=ID?;");
 		assertTrue(resource.getErrors().toString(), resource.getErrors().isEmpty());
 		assertTrue(resource.getWarnings().toString(), resource.getWarnings().isEmpty());
@@ -120,7 +120,7 @@ public class XtextValidationTest extends AbstractValidationMessageAcceptingTestC
 				"grammar org.acme.Bar with org.eclipse.xtext.common.Terminals\n" +
 				"generate metamodel 'myURI'\n" +
 						
-				"/* Suppress[potentialOverride] */\n" + 
+				"/* SuppressWarnings[potentialOverride] */\n" + 
 				"Parens: \n" + 
 				"  ('(' Parens ')'|name=ID) em='!'?;");
 		assertTrue(resource.getErrors().toString(), resource.getErrors().isEmpty());

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/DataTypeRuleWithEnumResultTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/DataTypeRuleWithEnumResultTestLanguage.xtext
@@ -9,6 +9,7 @@ grammar org.eclipse.xtext.xtext.ecoreInference.DataTypeRuleWithEnumResultTestLan
 	with org.eclipse.xtext.enumrules.EnumRulesTestLanguage
 
 import 'http://www.eclipse.org/2009/tmf/xtext/EnumRulesTest'
+/* Suppress[external] */
 import 'classpath:/org/eclipse/xtext/enumrules/enums.ecore'
  
 Model:

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/DataTypeRuleWithEnumResultTestLanguage.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/DataTypeRuleWithEnumResultTestLanguage.xtext
@@ -9,7 +9,7 @@ grammar org.eclipse.xtext.xtext.ecoreInference.DataTypeRuleWithEnumResultTestLan
 	with org.eclipse.xtext.enumrules.EnumRulesTestLanguage
 
 import 'http://www.eclipse.org/2009/tmf/xtext/EnumRulesTest'
-/* Suppress[external] */
+/* SuppressWarnings[external] */
 import 'classpath:/org/eclipse/xtext/enumrules/enums.ecore'
  
 Model:

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/Test.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/Test.xtext
@@ -1,5 +1,6 @@
 grammar org.eclipse.xtext.xtext.ecoreInference.Test with org.eclipse.xtext.common.Terminals
 generate root "http://root"
+/* Suppress[external] */
 import "classpath:/org/eclipse/xtext/xtext/ecoreInference/test.ecore" as test
 
 Root :

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/Test.xtext
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/ecoreInference/Test.xtext
@@ -1,6 +1,6 @@
 grammar org.eclipse.xtext.xtext.ecoreInference.Test with org.eclipse.xtext.common.Terminals
 generate root "http://root"
-/* Suppress[external] */
+/* SuppressWarnings[external] */
 import "classpath:/org/eclipse/xtext/xtext/ecoreInference/test.ecore" as test
 
 Root :

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/index/IndexTestLanguageInjectorProvider.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/index/IndexTestLanguageInjectorProvider.java
@@ -14,7 +14,7 @@ import org.eclipse.xtext.junit4.IInjectorProvider;
 import org.eclipse.xtext.junit4.IRegistryConfigurator;
 
 /**
- * @author Sven efftinge - Initial contribution and API
+ * @author Sven Efftinge - Initial contribution and API
  */
 @SuppressWarnings("all")
 public class IndexTestLanguageInjectorProvider implements IInjectorProvider, IRegistryConfigurator {


### PR DESCRIPTION
Recently we saw different incarnations of this problem in customer grammars thus I wanted to get rid of it.

Also implements a simple approach to suppress warnings in grammar itself, e.g. via a preceding comment ```/* SuppressWarnings[issueCodeSuffix] */```



