### PR TITLE
[469679] Guard against missing adapter

### DIFF
--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/reconciler/XtextDocumentReconcileStrategy.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/reconciler/XtextDocumentReconcileStrategy.java
@@ -18,6 +18,7 @@ import org.eclipse.jface.text.reconciler.IReconcilingStrategy;
 import org.eclipse.jface.text.reconciler.IReconcilingStrategyExtension;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.xtext.EcoreUtil2;
+import org.eclipse.xtext.parser.IParseResult;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.ui.editor.DirtyStateEditorSupport;
@@ -180,7 +181,12 @@ public class XtextDocumentReconcileStrategy implements IReconcilingStrategy, IRe
 		} catch(OperationCanceledException e) {
 			throw e;
 		} catch(RuntimeException e) {
-			log.error("Error post-processing resource", e);
+			String message = "Error post-processing resource with content";
+			IParseResult parseResult = resource.getParseResult();
+			if (parseResult != null && parseResult.getRootNode() != null) {
+				message = message + ":\n" + parseResult.getRootNode().getText();
+			}
+			log.error(message, e);
 			resource.getCache().clear(resource);
 		}
 	}

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
@@ -1838,10 +1838,10 @@ public class XbaseCompiler extends FeatureCallCompiler {
 			return false;
 		}
 		if (expr instanceof XCastedExpression) {
-			return false;
+			return isVariableDeclarationRequired(((XCastedExpression) expr).getTarget(), b);
 		}
 		if (expr instanceof XInstanceOfExpression) {
-			return false;
+			return isVariableDeclarationRequired(((XInstanceOfExpression) expr).getExpression(), b);
 		}
 		if (expr instanceof XMemberFeatureCall && isVariableDeclarationRequired((XMemberFeatureCall) expr, b))
 			return true;

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.xtend
@@ -8,6 +8,7 @@
 package org.eclipse.xtext.xbase.resource
 
 import com.google.common.collect.Sets
+import java.io.IOException
 import java.io.ObjectInputStream
 import java.util.Map
 import java.util.Set
@@ -24,14 +25,14 @@ import org.eclipse.xtext.xbase.jvmmodel.JvmModelAssociator
 
 @FinalFieldsConstructor class BatchLinkableResourceStorageLoadable extends ResourceStorageLoadable {
 	
-	override protected loadEntries(StorageAwareResource resource, ZipInputStream zipIn) {
+	override protected loadEntries(StorageAwareResource resource, ZipInputStream zipIn) throws IOException {
 		super.loadEntries(resource, zipIn)
 		if (resource instanceof BatchLinkableResource) {
 			readAssociationsAdapter(resource, zipIn)
 		}
 	}
 	
-	override protected handleLoadEObject(InternalEObject loaded, EObjectInputStream input) {
+	override protected handleLoadEObject(InternalEObject loaded, EObjectInputStream input) throws IOException {
 		super.handleLoadEObject(loaded, input)
 		// load documentation adapters
 		if (input.readBoolean) {
@@ -48,7 +49,7 @@ import org.eclipse.xtext.xbase.jvmmodel.JvmModelAssociator
 		}
 	}
 	
-	protected def void readAssociationsAdapter(BatchLinkableResource resource, ZipInputStream stream) {
+	protected def void readAssociationsAdapter(BatchLinkableResource resource, ZipInputStream stream) throws IOException {
 		val existing = resource.eAdapters.filter(JvmModelAssociator.Adapter).head
 		val adapter = existing
 			?: (new JvmModelAssociator.Adapter()=> [

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/CustomTypeParameterSubstitutor.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/util/CustomTypeParameterSubstitutor.java
@@ -64,12 +64,12 @@ public abstract class CustomTypeParameterSubstitutor extends TypeParameterSubsti
 						LightweightTypeReference result = boundTypeArgument.getTypeReference().accept(this, visiting);
 						if (boundTypeArgument.getVariance() == VarianceInfo.OUT) {
 							WildcardTypeReference wildcard = getOwner().newWildcardTypeReference();
-							wildcard.addUpperBound(result);
+							wildcard.addUpperBound(result.getInvariantBoundSubstitute());
 							result = wildcard;
 						} else if (boundTypeArgument.getVariance() == VarianceInfo.IN) {
 							WildcardTypeReference wildcard = getOwner().newWildcardTypeReference();
 							wildcard.addUpperBound(getObjectReference());
-							wildcard.setLowerBound(result);
+							wildcard.setLowerBound(result.getInvariantBoundSubstitute());
 							result = wildcard;
 						}
 						return result;

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.java
@@ -9,6 +9,7 @@ package org.eclipse.xtext.xbase.resource;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.util.HashSet;
@@ -38,7 +39,7 @@ import org.eclipse.xtext.xbase.resource.BatchLinkableResource;
 @SuppressWarnings("all")
 public class BatchLinkableResourceStorageLoadable extends ResourceStorageLoadable {
   @Override
-  protected void loadEntries(final StorageAwareResource resource, final ZipInputStream zipIn) {
+  protected void loadEntries(final StorageAwareResource resource, final ZipInputStream zipIn) throws IOException {
     super.loadEntries(resource, zipIn);
     if ((resource instanceof BatchLinkableResource)) {
       this.readAssociationsAdapter(((BatchLinkableResource)resource), zipIn);
@@ -46,53 +47,49 @@ public class BatchLinkableResourceStorageLoadable extends ResourceStorageLoadabl
   }
   
   @Override
-  protected Object handleLoadEObject(final InternalEObject loaded, final BinaryResourceImpl.EObjectInputStream input) {
-    try {
-      boolean _xblockexpression = false;
-      {
-        super.handleLoadEObject(loaded, input);
-        boolean _readBoolean = input.readBoolean();
-        if (_readBoolean) {
-          final String doc = input.readString();
-          EList<Adapter> _eAdapters = loaded.eAdapters();
-          DocumentationAdapter _documentationAdapter = new DocumentationAdapter();
-          final Procedure1<DocumentationAdapter> _function = new Procedure1<DocumentationAdapter>() {
-            @Override
-            public void apply(final DocumentationAdapter it) {
-              it.setDocumentation(doc);
-            }
-          };
-          DocumentationAdapter _doubleArrow = ObjectExtensions.<DocumentationAdapter>operator_doubleArrow(_documentationAdapter, _function);
-          _eAdapters.add(_doubleArrow);
-        }
-        boolean _xifexpression = false;
-        boolean _readBoolean_1 = input.readBoolean();
-        if (_readBoolean_1) {
-          EList<Adapter> _eAdapters_1 = loaded.eAdapters();
-          JvmIdentifiableMetaData _jvmIdentifiableMetaData = new JvmIdentifiableMetaData();
-          final Procedure1<JvmIdentifiableMetaData> _function_1 = new Procedure1<JvmIdentifiableMetaData>() {
-            @Override
-            public void apply(final JvmIdentifiableMetaData it) {
-              try {
-                boolean _readBoolean = input.readBoolean();
-                it.setSynthetic(_readBoolean);
-              } catch (Throwable _e) {
-                throw Exceptions.sneakyThrow(_e);
-              }
-            }
-          };
-          JvmIdentifiableMetaData _doubleArrow_1 = ObjectExtensions.<JvmIdentifiableMetaData>operator_doubleArrow(_jvmIdentifiableMetaData, _function_1);
-          _xifexpression = _eAdapters_1.add(_doubleArrow_1);
-        }
-        _xblockexpression = _xifexpression;
+  protected Object handleLoadEObject(final InternalEObject loaded, final BinaryResourceImpl.EObjectInputStream input) throws IOException {
+    boolean _xblockexpression = false;
+    {
+      super.handleLoadEObject(loaded, input);
+      boolean _readBoolean = input.readBoolean();
+      if (_readBoolean) {
+        final String doc = input.readString();
+        EList<Adapter> _eAdapters = loaded.eAdapters();
+        DocumentationAdapter _documentationAdapter = new DocumentationAdapter();
+        final Procedure1<DocumentationAdapter> _function = new Procedure1<DocumentationAdapter>() {
+          @Override
+          public void apply(final DocumentationAdapter it) {
+            it.setDocumentation(doc);
+          }
+        };
+        DocumentationAdapter _doubleArrow = ObjectExtensions.<DocumentationAdapter>operator_doubleArrow(_documentationAdapter, _function);
+        _eAdapters.add(_doubleArrow);
       }
-      return Boolean.valueOf(_xblockexpression);
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
+      boolean _xifexpression = false;
+      boolean _readBoolean_1 = input.readBoolean();
+      if (_readBoolean_1) {
+        EList<Adapter> _eAdapters_1 = loaded.eAdapters();
+        JvmIdentifiableMetaData _jvmIdentifiableMetaData = new JvmIdentifiableMetaData();
+        final Procedure1<JvmIdentifiableMetaData> _function_1 = new Procedure1<JvmIdentifiableMetaData>() {
+          @Override
+          public void apply(final JvmIdentifiableMetaData it) {
+            try {
+              boolean _readBoolean = input.readBoolean();
+              it.setSynthetic(_readBoolean);
+            } catch (Throwable _e) {
+              throw Exceptions.sneakyThrow(_e);
+            }
+          }
+        };
+        JvmIdentifiableMetaData _doubleArrow_1 = ObjectExtensions.<JvmIdentifiableMetaData>operator_doubleArrow(_jvmIdentifiableMetaData, _function_1);
+        _xifexpression = _eAdapters_1.add(_doubleArrow_1);
+      }
+      _xblockexpression = _xifexpression;
     }
+    return Boolean.valueOf(_xblockexpression);
   }
   
-  protected void readAssociationsAdapter(final BatchLinkableResource resource, final ZipInputStream stream) {
+  protected void readAssociationsAdapter(final BatchLinkableResource resource, final ZipInputStream stream) throws IOException {
     try {
       EList<Adapter> _eAdapters = resource.eAdapters();
       Iterable<JvmModelAssociator.Adapter> _filter = Iterables.<JvmModelAssociator.Adapter>filter(_eAdapters, JvmModelAssociator.Adapter.class);

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageWritable.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageWritable.java
@@ -11,6 +11,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import java.io.BufferedOutputStream;
+import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
@@ -36,7 +37,6 @@ import org.eclipse.xtext.xbase.compiler.DocumentationAdapter;
 import org.eclipse.xtext.xbase.jvmmodel.JvmIdentifiableMetaData;
 import org.eclipse.xtext.xbase.jvmmodel.JvmModelAssociator;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.resource.BatchLinkableResource;
@@ -51,30 +51,26 @@ public class BatchLinkableResourceStorageWritable extends ResourceStorageWritabl
   private final static Logger LOG = Logger.getLogger(BatchLinkableResourceStorageWritable.class);
   
   @Override
-  protected void writeEntries(final StorageAwareResource resource, final ZipOutputStream zipOut) {
-    try {
-      super.writeEntries(resource, zipOut);
-      if ((resource instanceof BatchLinkableResource)) {
-        ZipEntry _zipEntry = new ZipEntry("associations");
-        zipOut.putNextEntry(_zipEntry);
-        final BufferedOutputStream buffOut = new BufferedOutputStream(zipOut);
-        try {
-          this.writeAssociationsAdapter(((BatchLinkableResource)resource), buffOut);
-        } finally {
-          buffOut.flush();
-          zipOut.closeEntry();
-        }
+  protected void writeEntries(final StorageAwareResource resource, final ZipOutputStream zipOut) throws IOException {
+    super.writeEntries(resource, zipOut);
+    if ((resource instanceof BatchLinkableResource)) {
+      ZipEntry _zipEntry = new ZipEntry("associations");
+      zipOut.putNextEntry(_zipEntry);
+      final BufferedOutputStream buffOut = new BufferedOutputStream(zipOut);
+      try {
+        this.writeAssociationsAdapter(((BatchLinkableResource)resource), buffOut);
+      } finally {
+        buffOut.flush();
+        zipOut.closeEntry();
       }
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
     }
   }
   
   @Override
-  protected Object beforeSaveEObject(final InternalEObject object, final BinaryResourceImpl.EObjectOutputStream writable_1) {
+  protected Object beforeSaveEObject(final InternalEObject object, final BinaryResourceImpl.EObjectOutputStream writable) throws IOException {
     JvmType _xblockexpression = null;
     {
-      super.beforeSaveEObject(object, writable_1);
+      super.beforeSaveEObject(object, writable);
       JvmType _xifexpression = null;
       if ((object instanceof XComputedTypeReference)) {
         _xifexpression = ((XComputedTypeReference)object).getType();
@@ -85,150 +81,160 @@ public class BatchLinkableResourceStorageWritable extends ResourceStorageWritabl
   }
   
   @Override
-  protected void handleSaveEObject(final InternalEObject object, final BinaryResourceImpl.EObjectOutputStream out) {
-    try {
-      super.handleSaveEObject(object, out);
-      DocumentationAdapter documentationAdapter = null;
-      JvmIdentifiableMetaData metaDataAdapter = null;
-      EList<Adapter> _eAdapters = object.eAdapters();
-      for (final Adapter adapter : _eAdapters) {
-        {
-          if ((adapter instanceof DocumentationAdapter)) {
-            documentationAdapter = ((DocumentationAdapter)adapter);
-          }
-          if ((adapter instanceof JvmIdentifiableMetaData)) {
-            metaDataAdapter = ((JvmIdentifiableMetaData)adapter);
-          }
+  protected void handleSaveEObject(final InternalEObject object, final BinaryResourceImpl.EObjectOutputStream out) throws IOException {
+    super.handleSaveEObject(object, out);
+    DocumentationAdapter documentationAdapter = null;
+    JvmIdentifiableMetaData metaDataAdapter = null;
+    EList<Adapter> _eAdapters = object.eAdapters();
+    for (final Adapter adapter : _eAdapters) {
+      {
+        if ((adapter instanceof DocumentationAdapter)) {
+          documentationAdapter = ((DocumentationAdapter)adapter);
+        }
+        if ((adapter instanceof JvmIdentifiableMetaData)) {
+          metaDataAdapter = ((JvmIdentifiableMetaData)adapter);
         }
       }
-      boolean _notEquals = (!Objects.equal(documentationAdapter, null));
-      if (_notEquals) {
-        out.writeBoolean(true);
-        String _documentation = documentationAdapter.getDocumentation();
-        out.writeString(_documentation);
-      } else {
-        out.writeBoolean(false);
-      }
-      boolean _notEquals_1 = (!Objects.equal(metaDataAdapter, null));
-      if (_notEquals_1) {
-        out.writeBoolean(true);
-        boolean _isSynthetic = metaDataAdapter.isSynthetic();
-        out.writeBoolean(_isSynthetic);
-      } else {
-        out.writeBoolean(false);
-      }
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
+    }
+    boolean _notEquals = (!Objects.equal(documentationAdapter, null));
+    if (_notEquals) {
+      out.writeBoolean(true);
+      String _documentation = documentationAdapter.getDocumentation();
+      out.writeString(_documentation);
+    } else {
+      out.writeBoolean(false);
+    }
+    boolean _notEquals_1 = (!Objects.equal(metaDataAdapter, null));
+    if (_notEquals_1) {
+      out.writeBoolean(true);
+      boolean _isSynthetic = metaDataAdapter.isSynthetic();
+      out.writeBoolean(_isSynthetic);
+    } else {
+      out.writeBoolean(false);
     }
   }
   
-  protected void writeAssociationsAdapter(final BatchLinkableResource resource, final OutputStream zipOut) {
-    try {
-      EList<Adapter> _eAdapters = resource.eAdapters();
-      Iterable<JvmModelAssociator.Adapter> _filter = Iterables.<JvmModelAssociator.Adapter>filter(_eAdapters, JvmModelAssociator.Adapter.class);
-      final JvmModelAssociator.Adapter adapter = IterableExtensions.<JvmModelAssociator.Adapter>head(_filter);
-      final ObjectOutputStream objOut = new ObjectOutputStream(zipOut);
-      try {
-        final HashMap<String, String> logicalMap = CollectionLiterals.<String, String>newHashMap();
-        Set<Map.Entry<EObject, JvmIdentifiableElement>> _entrySet = adapter.logicalContainerMap.entrySet();
-        for (final Map.Entry<EObject, JvmIdentifiableElement> entry : _entrySet) {
-          EObject _key = entry.getKey();
-          Resource _eResource = _key.eResource();
-          boolean _notEquals = (!Objects.equal(_eResource, resource));
-          if (_notEquals) {
-            URI _uRI = resource.getURI();
-            String _plus = ((("entry " + entry) + " not from resource ") + _uRI);
-            String _plus_1 = (_plus + " but from ");
-            EObject _key_1 = entry.getKey();
-            Resource _eResource_1 = _key_1.eResource();
-            URI _uRI_1 = null;
-            if (_eResource_1!=null) {
-              _uRI_1=_eResource_1.getURI();
-            }
-            String _plus_2 = (_plus_1 + _uRI_1);
-            BatchLinkableResourceStorageWritable.LOG.info(_plus_2);
-          } else {
-            EObject _key_2 = entry.getKey();
-            String _fragment = this.getFragment(_key_2);
-            JvmIdentifiableElement _value = entry.getValue();
-            String _fragment_1 = this.getFragment(_value);
-            logicalMap.put(_fragment, _fragment_1);
-          }
+  protected void writeAssociationsAdapter(final BatchLinkableResource resource, final OutputStream zipOut) throws IOException {
+    EList<Adapter> _eAdapters = resource.eAdapters();
+    Iterable<JvmModelAssociator.Adapter> _filter = Iterables.<JvmModelAssociator.Adapter>filter(_eAdapters, JvmModelAssociator.Adapter.class);
+    JvmModelAssociator.Adapter adapter = IterableExtensions.<JvmModelAssociator.Adapter>head(_filter);
+    if ((adapter == null)) {
+      EList<EObject> _contents = resource.getContents();
+      Iterable<EObject> _tail = IterableExtensions.<EObject>tail(_contents);
+      final Function1<EObject, Boolean> _function = new Function1<EObject, Boolean>() {
+        @Override
+        public Boolean apply(final EObject it) {
+          return Boolean.valueOf((it instanceof JvmType));
         }
-        objOut.writeObject(logicalMap);
-        final HashMap<String, HashSet<String>> sourceToTarget = CollectionLiterals.<String, HashSet<String>>newHashMap();
-        Set<Map.Entry<EObject, Set<EObject>>> _entrySet_1 = adapter.sourceToTargetMap.entrySet();
-        for (final Map.Entry<EObject, Set<EObject>> entry_1 : _entrySet_1) {
-          EObject _key_3 = entry_1.getKey();
-          Resource _eResource_2 = _key_3.eResource();
-          boolean _notEquals_1 = (!Objects.equal(_eResource_2, resource));
-          if (_notEquals_1) {
-            URI _uRI_2 = resource.getURI();
-            String _plus_3 = ("entry not from resource " + _uRI_2);
-            String _plus_4 = (_plus_3 + " but from ");
-            EObject _key_4 = entry_1.getKey();
-            Resource _eResource_3 = _key_4.eResource();
-            URI _uRI_3 = null;
-            if (_eResource_3!=null) {
-              _uRI_3=_eResource_3.getURI();
-            }
-            String _plus_5 = (_plus_4 + _uRI_3);
-            BatchLinkableResourceStorageWritable.LOG.info(_plus_5);
-          } else {
-            EObject _key_5 = entry_1.getKey();
-            String _fragment_2 = this.getFragment(_key_5);
-            Set<EObject> _value_1 = entry_1.getValue();
-            final Function1<EObject, String> _function = new Function1<EObject, String>() {
-              @Override
-              public String apply(final EObject it) {
-                return BatchLinkableResourceStorageWritable.this.getFragment(it);
-              }
-            };
-            Iterable<String> _map = IterableExtensions.<EObject, String>map(_value_1, _function);
-            HashSet<String> _newHashSet = Sets.<String>newHashSet(_map);
-            sourceToTarget.put(_fragment_2, _newHashSet);
-          }
-        }
-        objOut.writeObject(sourceToTarget);
-        final HashMap<String, HashSet<String>> targetToSource = CollectionLiterals.<String, HashSet<String>>newHashMap();
-        Set<Map.Entry<EObject, Set<EObject>>> _entrySet_2 = adapter.targetToSourceMap.entrySet();
-        for (final Map.Entry<EObject, Set<EObject>> entry_2 : _entrySet_2) {
-          EObject _key_6 = entry_2.getKey();
-          Resource _eResource_4 = _key_6.eResource();
-          boolean _notEquals_2 = (!Objects.equal(_eResource_4, resource));
-          if (_notEquals_2) {
-            URI _uRI_4 = resource.getURI();
-            String _plus_6 = ("entry not from resource " + _uRI_4);
-            String _plus_7 = (_plus_6 + " but from ");
-            EObject _key_7 = entry_2.getKey();
-            Resource _eResource_5 = _key_7.eResource();
-            URI _uRI_5 = null;
-            if (_eResource_5!=null) {
-              _uRI_5=_eResource_5.getURI();
-            }
-            String _plus_8 = (_plus_7 + _uRI_5);
-            BatchLinkableResourceStorageWritable.LOG.info(_plus_8);
-          } else {
-            EObject _key_8 = entry_2.getKey();
-            String _fragment_3 = this.getFragment(_key_8);
-            Set<EObject> _value_2 = entry_2.getValue();
-            final Function1<EObject, String> _function_1 = new Function1<EObject, String>() {
-              @Override
-              public String apply(final EObject it) {
-                return BatchLinkableResourceStorageWritable.this.getFragment(it);
-              }
-            };
-            Iterable<String> _map_1 = IterableExtensions.<EObject, String>map(_value_2, _function_1);
-            HashSet<String> _newHashSet_1 = Sets.<String>newHashSet(_map_1);
-            targetToSource.put(_fragment_3, _newHashSet_1);
-          }
-        }
-        objOut.writeObject(targetToSource);
-      } finally {
-        objOut.flush();
+      };
+      boolean _exists = IterableExtensions.<EObject>exists(_tail, _function);
+      if (_exists) {
+        URI _uRI = resource.getURI();
+        String _plus = ("Missing JvmModelAssociator.Adapter but resource contains inferred types: " + _uRI);
+        throw new IOException(_plus);
       }
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
+      JvmModelAssociator.Adapter _adapter = new JvmModelAssociator.Adapter();
+      adapter = _adapter;
+    }
+    final ObjectOutputStream objOut = new ObjectOutputStream(zipOut);
+    try {
+      final HashMap<String, String> logicalMap = CollectionLiterals.<String, String>newHashMap();
+      Set<Map.Entry<EObject, JvmIdentifiableElement>> _entrySet = adapter.logicalContainerMap.entrySet();
+      for (final Map.Entry<EObject, JvmIdentifiableElement> entry : _entrySet) {
+        EObject _key = entry.getKey();
+        Resource _eResource = _key.eResource();
+        boolean _notEquals = (!Objects.equal(_eResource, resource));
+        if (_notEquals) {
+          URI _uRI_1 = resource.getURI();
+          String _plus_1 = ((("entry " + entry) + " not from resource ") + _uRI_1);
+          String _plus_2 = (_plus_1 + " but from ");
+          EObject _key_1 = entry.getKey();
+          Resource _eResource_1 = _key_1.eResource();
+          URI _uRI_2 = null;
+          if (_eResource_1!=null) {
+            _uRI_2=_eResource_1.getURI();
+          }
+          String _plus_3 = (_plus_2 + _uRI_2);
+          BatchLinkableResourceStorageWritable.LOG.info(_plus_3);
+        } else {
+          EObject _key_2 = entry.getKey();
+          String _fragment = this.getFragment(_key_2);
+          JvmIdentifiableElement _value = entry.getValue();
+          String _fragment_1 = this.getFragment(_value);
+          logicalMap.put(_fragment, _fragment_1);
+        }
+      }
+      objOut.writeObject(logicalMap);
+      final HashMap<String, HashSet<String>> sourceToTarget = CollectionLiterals.<String, HashSet<String>>newHashMap();
+      Set<Map.Entry<EObject, Set<EObject>>> _entrySet_1 = adapter.sourceToTargetMap.entrySet();
+      for (final Map.Entry<EObject, Set<EObject>> entry_1 : _entrySet_1) {
+        EObject _key_3 = entry_1.getKey();
+        Resource _eResource_2 = _key_3.eResource();
+        boolean _notEquals_1 = (!Objects.equal(_eResource_2, resource));
+        if (_notEquals_1) {
+          URI _uRI_3 = resource.getURI();
+          String _plus_4 = ("entry not from resource " + _uRI_3);
+          String _plus_5 = (_plus_4 + " but from ");
+          EObject _key_4 = entry_1.getKey();
+          Resource _eResource_3 = _key_4.eResource();
+          URI _uRI_4 = null;
+          if (_eResource_3!=null) {
+            _uRI_4=_eResource_3.getURI();
+          }
+          String _plus_6 = (_plus_5 + _uRI_4);
+          BatchLinkableResourceStorageWritable.LOG.info(_plus_6);
+        } else {
+          EObject _key_5 = entry_1.getKey();
+          String _fragment_2 = this.getFragment(_key_5);
+          Set<EObject> _value_1 = entry_1.getValue();
+          final Function1<EObject, String> _function_1 = new Function1<EObject, String>() {
+            @Override
+            public String apply(final EObject it) {
+              return BatchLinkableResourceStorageWritable.this.getFragment(it);
+            }
+          };
+          Iterable<String> _map = IterableExtensions.<EObject, String>map(_value_1, _function_1);
+          HashSet<String> _newHashSet = Sets.<String>newHashSet(_map);
+          sourceToTarget.put(_fragment_2, _newHashSet);
+        }
+      }
+      objOut.writeObject(sourceToTarget);
+      final HashMap<String, HashSet<String>> targetToSource = CollectionLiterals.<String, HashSet<String>>newHashMap();
+      Set<Map.Entry<EObject, Set<EObject>>> _entrySet_2 = adapter.targetToSourceMap.entrySet();
+      for (final Map.Entry<EObject, Set<EObject>> entry_2 : _entrySet_2) {
+        EObject _key_6 = entry_2.getKey();
+        Resource _eResource_4 = _key_6.eResource();
+        boolean _notEquals_2 = (!Objects.equal(_eResource_4, resource));
+        if (_notEquals_2) {
+          URI _uRI_5 = resource.getURI();
+          String _plus_7 = ("entry not from resource " + _uRI_5);
+          String _plus_8 = (_plus_7 + " but from ");
+          EObject _key_7 = entry_2.getKey();
+          Resource _eResource_5 = _key_7.eResource();
+          URI _uRI_6 = null;
+          if (_eResource_5!=null) {
+            _uRI_6=_eResource_5.getURI();
+          }
+          String _plus_9 = (_plus_8 + _uRI_6);
+          BatchLinkableResourceStorageWritable.LOG.info(_plus_9);
+        } else {
+          EObject _key_8 = entry_2.getKey();
+          String _fragment_3 = this.getFragment(_key_8);
+          Set<EObject> _value_2 = entry_2.getValue();
+          final Function1<EObject, String> _function_2 = new Function1<EObject, String>() {
+            @Override
+            public String apply(final EObject it) {
+              return BatchLinkableResourceStorageWritable.this.getFragment(it);
+            }
+          };
+          Iterable<String> _map_1 = IterableExtensions.<EObject, String>map(_value_2, _function_2);
+          HashSet<String> _newHashSet_1 = Sets.<String>newHashSet(_map_1);
+          targetToSource.put(_fragment_3, _newHashSet_1);
+        }
+      }
+      objOut.writeObject(targetToSource);
+    } finally {
+      objOut.flush();
     }
   }
   

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/resource/persistence/StorageAwareResource.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/resource/persistence/StorageAwareResource.xtend
@@ -38,11 +38,18 @@ class StorageAwareResource extends LazyLinkingResource {
 			if (LOG.isDebugEnabled) {
 				LOG.debug("Loading "+URI+" from storage.")
 			}
-			val in = resourceStorageFacade.getOrCreateResourceStorageLoadable(this);
-			loadFromStorage(in)
-		} else {
-			super.load(options)
+			try {
+				val in = resourceStorageFacade.getOrCreateResourceStorageLoadable(this);
+				loadFromStorage(in)
+				return;
+			} catch(IOException e) {
+				// revert the resource into a clean state
+				contents.clear
+				eAdapters.clear
+				unload
+			}
 		}
+		super.load(options)
 	}
 	
 	def void loadFromStorage(ResourceStorageLoadable storageInputStream) {

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug472142Test.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug472142Test.xtend
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.compiler
+
+import org.junit.Test
+
+/**
+ * @author Sebastian Zarnekow - Initial contribution and API
+ */
+class CompilerBug472142Test extends AbstractXtendCompilerTest {
+	
+	@Test def test_01() {
+		'''
+			class C {
+				def boolean m(CharSequence obj) {
+					return obj?.subSequence(1,1) instanceof String && obj!==null && obj.getClass()!==null;
+				}
+			}
+		'''.assertCompilesTo('''
+			@SuppressWarnings("all")
+			public class C {
+			  public boolean m(final CharSequence obj) {
+			    boolean _and = false;
+			    boolean _and_1 = false;
+			    CharSequence _subSequence = null;
+			    if (obj!=null) {
+			      _subSequence=obj.subSequence(1, 1);
+			    }
+			    if (!(_subSequence instanceof String)) {
+			      _and_1 = false;
+			    } else {
+			      _and_1 = (obj != null);
+			    }
+			    if (!_and_1) {
+			      _and = false;
+			    } else {
+			      Class<? extends CharSequence> _class = obj.getClass();
+			      boolean _tripleNotEquals = (_class != null);
+			      _and = _tripleNotEquals;
+			    }
+			    return _and;
+			  }
+			}
+		''')
+	}
+	
+	@Test def test_02() {
+		'''
+			class C {
+				def boolean m(CharSequence obj) {
+					return obj?.subSequence(1,1) instanceof String && obj!==null
+				}
+			}
+		'''.assertCompilesTo('''
+			@SuppressWarnings("all")
+			public class C {
+			  public boolean m(final CharSequence obj) {
+			    boolean _and = false;
+			    CharSequence _subSequence = null;
+			    if (obj!=null) {
+			      _subSequence=obj.subSequence(1, 1);
+			    }
+			    if (!(_subSequence instanceof String)) {
+			      _and = false;
+			    } else {
+			      _and = (obj != null);
+			    }
+			    return _and;
+			  }
+			}
+		''')
+	}
+	
+}

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerTest.java
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerTest.java
@@ -70,6 +70,14 @@ import com.google.inject.Injector;
  */
 public class CompilerTest extends AbstractXtendTestCase {
 	
+	@Test public void testBug472142() throws Exception {
+		String code = 
+				" def boolean m(Object obj) {\n" + 
+				"   return obj?.toString() instanceof String && obj!==null && obj.getClass()!==null;\n" + 
+				" }";
+		invokeAndExpect2(Boolean.FALSE,code,"m", new Object[] { null });
+	}
+	
 	@Test public void testGenericVoidFunction() throws Exception {
 		String code = 
 				" def String getString(String myString) {\n" + 

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/resource/ResourceStorageTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/resource/ResourceStorageTest.xtend
@@ -21,6 +21,11 @@ import org.eclipse.xtext.resource.persistence.StorageAwareResource
 import org.eclipse.xtext.xbase.compiler.DocumentationAdapter
 import org.junit.Test
 import org.eclipse.xtext.common.types.JvmField
+import java.io.IOException
+import org.eclipse.xtext.xbase.resource.BatchLinkableResource
+import org.eclipse.xtext.xbase.jvmmodel.JvmModelAssociator
+import org.eclipse.xtext.xbase.resource.BatchLinkableResourceStorageWritable
+import java.io.OutputStream
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -94,6 +99,17 @@ class ResourceStorageTest extends AbstractXtendTestCase {
 		}
 		
 		assertFalse(originalNodes.hasNext)
+	}
+	
+	@Test(expected=IOException) def void testFailedWrite() throws Exception {
+		val file = file('class C{}')
+		new BatchLinkableResourceStorageWritable(new ByteArrayOutputStream, false) {
+			override protected writeAssociationsAdapter(BatchLinkableResource resource, OutputStream zipOut) throws IOException {
+				val removeMe = resource.eAdapters.findFirst[it instanceof JvmModelAssociator.Adapter]
+				assertTrue(resource.eAdapters.remove(removeMe))
+				super.writeAssociationsAdapter(resource, zipOut)
+			}
+		}.writeResource(file.eResource as StorageAwareResource)	
 	}
 	
 	@Test def void testConstantValueIsPersisted() {

--- a/tests/org.eclipse.xtend.core.tests/suites/org/eclipse/xtend/core/tests/compiler/CompilerSuite.java
+++ b/tests/org.eclipse.xtend.core.tests/suites/org/eclipse/xtend/core/tests/compiler/CompilerSuite.java
@@ -91,6 +91,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	CompilerBug465058Test.class,
 	CompilerBug465649Test.class,
 	CompilerBug471631Test.class,
+	CompilerBug472142Test.class,
 	CompilerBugDependentTypeParametersTest.class,
 	CompilerBugInheritedDispatchTest.class,
 	CompilerBugProtectedVisibilityTest.class,

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug472142Test.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug472142Test.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.compiler;
+
+import org.eclipse.xtend.core.tests.compiler.AbstractXtendCompilerTest;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.junit.Test;
+
+/**
+ * @author Sebastian Zarnekow - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class CompilerBug472142Test extends AbstractXtendCompilerTest {
+  @Test
+  public void test_01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class C {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def boolean m(CharSequence obj) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("return obj?.subSequence(1,1) instanceof String && obj!==null && obj.getClass()!==null;");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public boolean m(final CharSequence obj) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("boolean _and = false;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("boolean _and_1 = false;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("CharSequence _subSequence = null;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("if (obj!=null) {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_subSequence=obj.subSequence(1, 1);");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("if (!(_subSequence instanceof String)) {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_and_1 = false;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("} else {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_and_1 = (obj != null);");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("if (!_and_1) {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_and = false;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("} else {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("Class<? extends CharSequence> _class = obj.getClass();");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("boolean _tripleNotEquals = (_class != null);");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_and = _tripleNotEquals;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return _and;");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void test_02() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class C {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def boolean m(CharSequence obj) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("return obj?.subSequence(1,1) instanceof String && obj!==null");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public boolean m(final CharSequence obj) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("boolean _and = false;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("CharSequence _subSequence = null;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("if (obj!=null) {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_subSequence=obj.subSequence(1, 1);");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("if (!(_subSequence instanceof String)) {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_and = false;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("} else {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_and = (obj != null);");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return _and;");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+}


### PR DESCRIPTION
Don’t write streams with bogus content to the stored resource. [1]
Also revert incomplete state that was read from storage. See bug 471535 [2]

[1] https://bugs.eclipse.org/bugs/show_bug.cgi?id=469679
[2] https://bugs.eclipse.org/bugs/show_bug.cgi?id=471535