### PR TITLE
[469805] Handle bogus value converter configuration

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/conversion/IValueConverter.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/conversion/IValueConverter.java
@@ -62,8 +62,10 @@ public interface IValueConverter<Type> {
 	 * that is converted, may implement this interface. The framework will
 	 * set the rule according to the annotation of the method that provides
 	 * the value converter.
+	 * 
+	 * @throw IllegalArgumentException if the rule doesn't match the expectation of the value converter
 	 */
 	interface RuleSpecific {
-		void setRule(AbstractRule rule);
+		void setRule(AbstractRule rule) throws IllegalArgumentException;
 	}
 }

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/conversion/impl/AbstractLexerBasedConverter.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/conversion/impl/AbstractLexerBasedConverter.java
@@ -13,6 +13,7 @@ import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.Token;
 import org.antlr.runtime.TokenSource;
 import org.eclipse.xtext.AbstractRule;
+import org.eclipse.xtext.TerminalRule;
 import org.eclipse.xtext.conversion.IValueConverter;
 import org.eclipse.xtext.conversion.ValueConverterException;
 import org.eclipse.xtext.parser.antlr.ITokenDefProvider;
@@ -121,7 +122,11 @@ public abstract class AbstractLexerBasedConverter<T> extends AbstractValueConver
 	
 	@Override
 	public void setRule(AbstractRule rule) {
-		this.rule = rule;
+		if (rule instanceof TerminalRule) {
+			this.rule = rule;
+		} else {
+			throw new IllegalArgumentException("Only terminal rules are supported by lexer based converters but got: " + String.valueOf(rule));
+		}
 	}
 	
 	public void setLexerProvider(Provider<Lexer> lexerProvider) {


### PR DESCRIPTION
If an AbstractLexerBasedConverter is configured
with a datatype rule, it will be disabled and an
error will be logged.