### PR TITLE
updated comment in the generated JvmModelInferrer

### DIFF
--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/xbase/XbaseGeneratorFragment.xpt
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/xbase/XbaseGeneratorFragment.xpt
@@ -56,9 +56,7 @@ class «getJvmModelInferrerName().toSimpleName()» extends AbstractModelInferrer {
 	 *            {@link IJvmDeclaredTypeAcceptor#accept(org.eclipse.xtext.common.types.JvmDeclaredType)
 	 *            accept(..)} method takes the constructed empty type for the
 	 *            pre-indexing phase. This one is further initialized in the
-	 *            indexing phase using the closure you pass to the returned
-	 *            {@link org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor.IPostIndexingInitializing#initializeLater(org.eclipse.xtext.xbase.lib.Procedures.Procedure1)
-	 *            initializeLater(..)}.
+	 *            indexing phase using the lambda you pass as the last argument.
 	 * @param isPreIndexingPhase
 	 *            whether the method is called in a pre-indexing phase, i.e.
 	 *            when the global index is not yet fully updated. You must not


### PR DESCRIPTION
The generated JvmModelInferrer was still referring to the deprecated
IJvmDeclaredTypeAcceptor.IPostIndexingInitializing#initializeLater in
the comment section.

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>