### PR TITLE
[idea][bug 475120] don't throw NPE for a psi element without an associated virtual file, e.g. PsiDirectory

### DIFF
--- a/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/execution/ConfigurationProducerExtensions.xtend
+++ b/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/execution/ConfigurationProducerExtensions.xtend
@@ -63,10 +63,14 @@ class ConfigurationProducerExtensions {
 
 	def private Iterable<PsiFile> getJavaFiles(@NotNull PsiElement xtextElement) {
 		val xtextFile = xtextElement.getParentOfType(BaseXtextFile, false)
-		if (xtextFile == null) {
+		if (xtextFile === null) {
 			return emptySet
 		}
-		val IIdeaTrace trace = traceProvider.getTraceToTarget(VirtualFileInProject.forPsiElement(xtextFile))
+		val fileInProject = VirtualFileInProject.forPsiElement(xtextFile)
+		if (fileInProject == null) {
+			return emptySet
+		}
+		val IIdeaTrace trace = traceProvider.getTraceToTarget(fileInProject)
 		if (trace !== null) {
 			val javaFiles = newArrayList
 			for (uri : trace.allAssociatedLocations) {

--- a/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/trace/TraceForVirtualFileProvider.xtend
+++ b/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/trace/TraceForVirtualFileProvider.xtend
@@ -16,7 +16,6 @@ import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.PsiUtilCore
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException
@@ -69,10 +68,10 @@ class TraceForVirtualFileProvider extends AbstractTraceForURIProvider<VirtualFil
 	@Inject Provider<VirtualFileBasedTrace> traceProvider
 	
 	override getGeneratedElements(PsiElement element) {
-		if (element === null || PsiUtilCore.getVirtualFile(element) === null) {
+		val fileInProject = VirtualFileInProject.forPsiElement(element)
+		if (fileInProject === null) {
 			return emptyList
 		}
-		val fileInProject = VirtualFileInProject.forPsiElement(element)
 		val traceToTarget = getTraceToTarget(fileInProject)
 		return getTracedElements(traceToTarget, element)
 	}
@@ -110,6 +109,9 @@ class TraceForVirtualFileProvider extends AbstractTraceForURIProvider<VirtualFil
 	
 	override getOriginalElements(PsiElement element) {
 		val fileInProject = VirtualFileInProject.forPsiElement(element)
+		if (fileInProject === null)
+			return emptyList
+
 		val traceToSource = getTraceToSource(fileInProject)
 		return getTracedElements(traceToSource, element)
 	}

--- a/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/trace/VirtualFileInProject.xtend
+++ b/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/trace/VirtualFileInProject.xtend
@@ -21,9 +21,9 @@ class VirtualFileInProject {
 	
 	def static VirtualFileInProject forPsiElement(PsiElement element) {
 		val virtualFile = XtextPsiUtils.findVirtualFile(element)
-		if (virtualFile == null) {
-			throw new NullPointerException('virtualFile')
-		}
+		if (virtualFile == null)
+			return null
+
 		return new VirtualFileInProject(virtualFile, element.project)
 	}
 	

--- a/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/debug/TraceBasedPositionManagerFactory.java
+++ b/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/debug/TraceBasedPositionManagerFactory.java
@@ -96,10 +96,12 @@ public class TraceBasedPositionManagerFactory extends PositionManagerFactory {
         public Set<String> compute() {
           try {
             PsiElement _elementAt = source.getElementAt();
-            VirtualFileInProject _forPsiElement = VirtualFileInProject.forPsiElement(_elementAt);
-            final IIdeaTrace trace = TraceBasedPositionManager.this.traceForVirtualFileProvider.getTraceToTarget(_forPsiElement);
-            boolean _equals = Objects.equal(trace, null);
-            if (_equals) {
+            final VirtualFileInProject sourceResource = VirtualFileInProject.forPsiElement(_elementAt);
+            if ((sourceResource == null)) {
+              throw NoDataException.INSTANCE;
+            }
+            final IIdeaTrace trace = TraceBasedPositionManager.this.traceForVirtualFileProvider.getTraceToTarget(sourceResource);
+            if ((trace == null)) {
               throw NoDataException.INSTANCE;
             }
             Iterable<? extends ILocationInVirtualFile> _allAssociatedLocations = trace.getAllAssociatedLocations();
@@ -279,10 +281,12 @@ public class TraceBasedPositionManagerFactory extends PositionManagerFactory {
             final Document document = _instance.getDocument(_containingFile);
             int _line = position.getLine();
             final TextRange range = DocumentUtil.getLineTextRange(document, _line);
-            VirtualFileInProject _forPsiElement = VirtualFileInProject.forPsiElement(psi);
-            final IIdeaTrace traceToTarget = TraceBasedPositionManager.this.traceForVirtualFileProvider.getTraceToTarget(_forPsiElement);
-            boolean _equals = Objects.equal(traceToTarget, null);
-            if (_equals) {
+            final VirtualFileInProject sourceResource = VirtualFileInProject.forPsiElement(psi);
+            if ((sourceResource == null)) {
+              throw NoDataException.INSTANCE;
+            }
+            final IIdeaTrace traceToTarget = TraceBasedPositionManager.this.traceForVirtualFileProvider.getTraceToTarget(sourceResource);
+            if ((traceToTarget == null)) {
               throw NoDataException.INSTANCE;
             }
             final ArrayList<Location> result = CollectionLiterals.<Location>newArrayList();
@@ -305,16 +309,16 @@ public class TraceBasedPositionManagerFactory extends PositionManagerFactory {
               URI _uRI = _srcRelativeResourceURI.getURI();
               String _lastSegment = _uRI.lastSegment();
               String _string = _lastSegment.toString();
-              boolean _equals_1 = Objects.equal(_sourceName, _string);
-              if (!_equals_1) {
+              boolean _equals = Objects.equal(_sourceName, _string);
+              if (!_equals) {
                 _and = false;
               } else {
                 ITextRegionWithLineInformation _textRegion_1 = location.getTextRegion();
                 int _lineNumber = _textRegion_1.getLineNumber();
                 ITextRegionWithLineInformation _textRegion_2 = location.getTextRegion();
                 int _endLineNumber = _textRegion_2.getEndLineNumber();
-                boolean _equals_2 = (_lineNumber == _endLineNumber);
-                _and = _equals_2;
+                boolean _equals_1 = (_lineNumber == _endLineNumber);
+                _and = _equals_1;
               }
               if (_and) {
                 ITextRegionWithLineInformation _textRegion_3 = location.getTextRegion();

--- a/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/execution/ConfigurationProducerExtensions.java
+++ b/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/execution/ConfigurationProducerExtensions.java
@@ -96,12 +96,15 @@ public class ConfigurationProducerExtensions {
   
   private Iterable<PsiFile> getJavaFiles(@NotNull final PsiElement xtextElement) {
     final BaseXtextFile xtextFile = PsiTreeUtil.<BaseXtextFile>getParentOfType(xtextElement, BaseXtextFile.class, false);
-    boolean _equals = Objects.equal(xtextFile, null);
+    if ((xtextFile == null)) {
+      return CollectionLiterals.<PsiFile>emptySet();
+    }
+    final VirtualFileInProject fileInProject = VirtualFileInProject.forPsiElement(xtextFile);
+    boolean _equals = Objects.equal(fileInProject, null);
     if (_equals) {
       return CollectionLiterals.<PsiFile>emptySet();
     }
-    VirtualFileInProject _forPsiElement = VirtualFileInProject.forPsiElement(xtextFile);
-    final IIdeaTrace trace = this.traceProvider.getTraceToTarget(_forPsiElement);
+    final IIdeaTrace trace = this.traceProvider.getTraceToTarget(fileInProject);
     if ((trace != null)) {
       final ArrayList<PsiFile> javaFiles = CollectionLiterals.<PsiFile>newArrayList();
       Iterable<? extends ILocationInVirtualFile> _allAssociatedLocations = trace.getAllAssociatedLocations();

--- a/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/trace/TraceForVirtualFileProvider.java
+++ b/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/trace/TraceForVirtualFileProvider.java
@@ -24,7 +24,6 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
-import com.intellij.psi.util.PsiUtilCore;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -122,18 +121,10 @@ public class TraceForVirtualFileProvider extends AbstractTraceForURIProvider<Vir
   
   @Override
   public List<? extends PsiElement> getGeneratedElements(final PsiElement element) {
-    boolean _or = false;
-    if ((element == null)) {
-      _or = true;
-    } else {
-      VirtualFile _virtualFile = PsiUtilCore.getVirtualFile(element);
-      boolean _tripleEquals = (_virtualFile == null);
-      _or = _tripleEquals;
-    }
-    if (_or) {
+    final VirtualFileInProject fileInProject = VirtualFileInProject.forPsiElement(element);
+    if ((fileInProject == null)) {
       return CollectionLiterals.<PsiElement>emptyList();
     }
-    final VirtualFileInProject fileInProject = VirtualFileInProject.forPsiElement(element);
     final IIdeaTrace traceToTarget = this.getTraceToTarget(fileInProject);
     return this.getTracedElements(traceToTarget, element);
   }
@@ -211,6 +202,9 @@ public class TraceForVirtualFileProvider extends AbstractTraceForURIProvider<Vir
   @Override
   public List<? extends PsiElement> getOriginalElements(final PsiElement element) {
     final VirtualFileInProject fileInProject = VirtualFileInProject.forPsiElement(element);
+    if ((fileInProject == null)) {
+      return CollectionLiterals.<PsiElement>emptyList();
+    }
     final VirtualFileBasedTrace traceToSource = this.getTraceToSource(fileInProject);
     return this.getTracedElements(traceToSource, element);
   }

--- a/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/trace/VirtualFileInProject.java
+++ b/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/trace/VirtualFileInProject.java
@@ -26,7 +26,7 @@ public class VirtualFileInProject {
     final VirtualFile virtualFile = XtextPsiUtils.findVirtualFile(element);
     boolean _equals = Objects.equal(virtualFile, null);
     if (_equals) {
-      throw new NullPointerException("virtualFile");
+      return null;
     }
     Project _project = element.getProject();
     return new VirtualFileInProject(virtualFile, _project);


### PR DESCRIPTION
Change-Id: I70b24538cd241dfef4417a65b66543ac0e94902a
Signed-off-by: akosyakov <anton.kosyakov@itemis.de>