### PR TITLE
JdtBasedProcessorProvider isOutputFolderIncluded()

### DIFF
--- a/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.xtend
+++ b/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.xtend
@@ -85,12 +85,16 @@ class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvider {
 	protected def createClassLoaderForJavaProject(IJavaProject projectToUse) {
 		val urls = newLinkedHashSet()
 		try {
-			collectClasspathURLs(projectToUse, urls, false, newHashSet)
+			collectClasspathURLs(projectToUse, urls, isOutputFolderIncluded(), newHashSet)
 		} catch(JavaModelException e) {
 			if (!e.isDoesNotExist)
 				LOG.error(e.message, e)
 		}
 		return new URLClassLoader(urls, getParentClassLoader())
+	}
+
+	protected def isOutputFolderIncluded() {
+		false;
 	}
 
 	protected def void collectClasspathURLs(IJavaProject projectToUse, LinkedHashSet<URL> result,

--- a/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.java
+++ b/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.java
@@ -134,8 +134,9 @@ public class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvid
   protected URLClassLoader createClassLoaderForJavaProject(final IJavaProject projectToUse) {
     final LinkedHashSet<URL> urls = CollectionLiterals.<URL>newLinkedHashSet();
     try {
+      boolean _isOutputFolderIncluded = this.isOutputFolderIncluded();
       HashSet<IJavaProject> _newHashSet = CollectionLiterals.<IJavaProject>newHashSet();
-      this.collectClasspathURLs(projectToUse, urls, false, _newHashSet);
+      this.collectClasspathURLs(projectToUse, urls, _isOutputFolderIncluded, _newHashSet);
     } catch (final Throwable _t) {
       if (_t instanceof JavaModelException) {
         final JavaModelException e = (JavaModelException)_t;
@@ -151,6 +152,10 @@ public class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvid
     }
     ClassLoader _parentClassLoader = this.getParentClassLoader();
     return new URLClassLoader(((URL[])Conversions.unwrapArray(urls, URL.class)), _parentClassLoader);
+  }
+  
+  protected boolean isOutputFolderIncluded() {
+    return false;
   }
   
   protected void collectClasspathURLs(final IJavaProject projectToUse, final LinkedHashSet<URL> result, final boolean includeOutputFolder, final Set<IJavaProject> visited) throws JavaModelException {


### PR DESCRIPTION
Hi guys, how about this? If you were to accept this, then I could simplify http://git.eclipse.org/c/emf/org.eclipse.emf.eson.git/tree/plugins/org.eclipse.emf.eson/src/org/eclipse/emf/eson/generators/JdtBasedClassLoaderProvider.java to just do @Override isOutputFolderIncluded() { return true; } for what I need, instead of copy/pasting the entire createClassLoaderForJavaProject() .. so then I would not have to "catch up" doing https://git.eclipse.org/r/#/c/54483/1/plugins/org.eclipse.emf.eson/src/org/eclipse/emf/eson/generators/JdtBasedClassLoaderProvider.java when you do https://github.com/eclipse/xtext/commit/5d3aa9798fc1b04eac08e645b0022821af433e14 ... ;-)