### PR TITLE
[475368] Another approach to solve the deadlock issue

### DIFF
--- a/plugins/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/builderState/AbstractBuilderState.java
+++ b/plugins/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/builderState/AbstractBuilderState.java
@@ -13,13 +13,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
-import org.eclipse.core.resources.IWorkspaceRoot;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.core.runtime.jobs.IJobManager;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
@@ -70,16 +66,7 @@ public abstract class AbstractBuilderState extends AbstractResourceDescriptionCh
 
 	protected void ensureLoaded() {
 		if (!isLoaded) {
-			// prevent deadlock by wrapping load into a workspace lock
-			// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=475368
-			IJobManager manager = Job.getJobManager();
-			IWorkspaceRoot rule = ResourcesPlugin.getWorkspace().getRoot();
-			try {
-				manager.beginRule(rule, null);
-				load();
-			} finally {
-				manager.endRule(rule);
-			}
+			load();
 		}
 	}
 

--- a/plugins/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/JavaCoreListenerRegistrar.java
+++ b/plugins/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/JavaCoreListenerRegistrar.java
@@ -28,12 +28,7 @@ public class JavaCoreListenerRegistrar implements IEagerContribution {
 	@Override
 	public void initialize() {
 		JavaCore.addElementChangedListener(classpathChangeListener);
-		new Thread(new Runnable() {
-			@Override
-			public void run() {
-				storage2UriMapperJavaImpl.initializeCache();
-			}
-		}).start();
+		storage2UriMapperJavaImpl.asyncInitializeCache();
 		JavaCore.addElementChangedListener(storage2UriMapperJavaImpl);
 	}
 


### PR DESCRIPTION
Reduced the lock size and deferred code that may need
the ws lock to another thread such that deadlocks should
become less likely.

I figured that it's not the JobManager's scheduling rule that's causing trouble
(JDT doesn't even use a SR for the ops that we are calling) but the
workspace lock. Adjusted the change accordingly.