### PR TITLE
Domainmodel validator should extend generated validator

### DIFF
--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/src-gen/org/eclipse/xtext/example/domainmodel/validation/AbstractDomainmodelJavaValidator.java
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/src-gen/org/eclipse/xtext/example/domainmodel/validation/AbstractDomainmodelJavaValidator.java
@@ -7,9 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.emf.ecore.EPackage;
-import org.eclipse.xtext.validation.ComposedChecks;
 
-@ComposedChecks(validators= {org.eclipse.xtext.validation.NamesAreUniqueValidator.class})
 public class AbstractDomainmodelJavaValidator extends org.eclipse.xtext.xbase.validation.XbaseJavaValidator {
 
 	@Override

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/GenerateDomainmodel.mwe2
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/GenerateDomainmodel.mwe2
@@ -70,7 +70,7 @@ Workflow {
 
 			// java-based API for validation 
 			fragment = validation.JavaValidatorFragment {
-				composedCheck = "org.eclipse.xtext.validation.NamesAreUniqueValidator"
+				// composedCheck = "org.eclipse.xtext.validation.NamesAreUniqueValidator"
 			}
 
 			// scoping API 

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/validation/DomainmodelJavaValidator.java
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/validation/DomainmodelJavaValidator.java
@@ -7,9 +7,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.example.domainmodel.validation;
 
-import java.util.List;
-
-import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.xtext.example.domainmodel.domainmodel.DomainmodelPackage;
 import org.eclipse.xtext.example.domainmodel.domainmodel.Entity;
 import org.eclipse.xtext.example.domainmodel.domainmodel.Feature;
@@ -17,9 +14,8 @@ import org.eclipse.xtext.example.domainmodel.domainmodel.PackageDeclaration;
 import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.validation.Check;
 import org.eclipse.xtext.validation.ValidationMessageAcceptor;
-import org.eclipse.xtext.xbase.validation.XbaseJavaValidator;
 
-public class DomainmodelJavaValidator extends XbaseJavaValidator {
+public class DomainmodelJavaValidator extends AbstractDomainmodelJavaValidator {
 
     @Check
     public void checkTypeNameStartsWithCapital(Entity entity) {
@@ -53,11 +49,5 @@ public class DomainmodelJavaValidator extends XbaseJavaValidator {
             		DomainmodelPackage.Literals.ABSTRACT_ELEMENT__NAME);
         }
     }
-    
-	@Override
-	protected List<EPackage> getEPackages() {
-		List<EPackage> ePackages = super.getEPackages();
-		ePackages.add(DomainmodelPackage.eINSTANCE);
-		return ePackages;
-	}
+
 }


### PR DESCRIPTION
With this commit, the DomainmodelJavaValidator extends the generated
AbstractDomainmodelJavaValidator (which, in turn, extends
XbaseJavaValidator) instead of extending XbaseJavaValidator directly (as
it is usual in other DSLs, as far as I know). I think the only reason
why it wasn't so before is that in the workflow the
NamesAreUniqueValidator was enabled, making the generated validator use
also NamesAreUniqueValidator, which is known to cause problems with
Xbase model inferred elements. So I disabled the NamesAreUniqueValidator
in the workflow as well.

Tests are still green.


Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>