### PR TITLE
Null guard in JvmTypesBuilder.isPrimitiveBoolean

### DIFF
--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/jvmmodel/JvmTypesBuilder.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/jvmmodel/JvmTypesBuilder.java
@@ -766,7 +766,9 @@ public class JvmTypesBuilder {
 			return false;
 		}
 		
-		return typeRef.getType() != null && !typeRef.getType().eIsProxy() && "boolean".equals(typeRef.getType().getIdentifier());
+		return typeRef != null && typeRef.getType() != null &&
+				!typeRef.getType().eIsProxy() &&
+				"boolean".equals(typeRef.getType().getIdentifier());
 	}
 
 	/**

--- a/tests/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/jvmmodel/JvmTypesBuilderTest.xtend
+++ b/tests/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/jvmmodel/JvmTypesBuilderTest.xtend
@@ -257,7 +257,14 @@ class JvmTypesBuilderTest extends AbstractXbaseTestCase {
 		list += otherList
 		assertTrue(list.empty)
 	}
-	
+
+	@Test
+	def void testToGetterWithNullTypeRef() {
+		val e = expression("''")
+		// there should be no NPE
+		e.toGetter("foo", null)
+	}
+
 	@Test
 	def void testInitializeSafely_0() {
 		expectErrorLogging(2) [

--- a/tests/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/jvmmodel/JvmTypesBuilderTest.java
+++ b/tests/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/jvmmodel/JvmTypesBuilderTest.java
@@ -532,6 +532,16 @@ public class JvmTypesBuilderTest extends AbstractXbaseTestCase {
   }
   
   @Test
+  public void testToGetterWithNullTypeRef() {
+    try {
+      final XExpression e = this.expression("\'\'");
+      this._jvmTypesBuilder.toGetter(e, "foo", null);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
   public void testInitializeSafely_0() {
     final Runnable _function = new Runnable() {
       @Override


### PR DESCRIPTION
The type reference could be null and a NPE should be avoided; this is
called by toGetter, and the problem is a regression due to my commit
4308750

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>