### PR TITLE
Fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=478024

### DIFF
--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
@@ -122,9 +122,13 @@ class JvmModelGenerator implements IGenerator {
 		if(type.qualifiedName != null)
 			fsa.generateFile(type.qualifiedName.replace('.', '/') + '.java', type.generateType(generatorConfigProvider.get(type)))
 	}
+
+	protected def ImportManager createImportManager(JvmDeclaredType type) {
+		new ImportManager(true, type)
+	}
 	
 	def CharSequence generateType(JvmDeclaredType type, GeneratorConfig config) {
-		val importManager = new ImportManager(true, type)
+		val importManager = createImportManager()
 		val bodyAppendable = createAppendable(type, importManager, config)
 		bodyAppendable.openScope
 		bodyAppendable.assignThisAndSuper(type, config)


### PR DESCRIPTION
Makes organizing imports in the JvmModelGenerator better configurable

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>