### PR TITLE
Fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=478024

### DIFF
--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
@@ -130,8 +130,12 @@ class JvmModelGenerator implements IGenerator {
 			fsa.generateFile(type.qualifiedName.replace('.', '/') + '.java', type.generateType(generatorConfigProvider.get(type)))
 	}
 	
+	protected def createImportManager(JvmDeclaredType type) {
+		new ImportManager(true, type)
+	}
+	
 	def CharSequence generateType(JvmDeclaredType type, GeneratorConfig config) {
-		val importManager = new ImportManager(true, type)
+		val importManager = createImportManager(type)
 		val bodyAppendable = createAppendable(type, importManager, config)
 		bodyAppendable.openScope
 		bodyAppendable.assignThisAndSuper(type, config)

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
@@ -219,8 +219,12 @@ public class JvmModelGenerator implements IGenerator {
     }
   }
   
+  protected ImportManager createImportManager(final JvmDeclaredType type) {
+    return new ImportManager(true, type);
+  }
+  
   public CharSequence generateType(final JvmDeclaredType type, final GeneratorConfig config) {
-    final ImportManager importManager = new ImportManager(true, type);
+    final ImportManager importManager = this.createImportManager(type);
     final TreeAppendable bodyAppendable = this.createAppendable(type, importManager, config);
     bodyAppendable.openScope();
     this.assignThisAndSuper(bodyAppendable, type, config);


### PR DESCRIPTION
Add Option to JvmModelGenerator to make the ImportManager configurable

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>