### PR TITLE
Stale JvmTypes in the incremental builder

### DIFF
--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/resource/XtendResourceDescriptionManager.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/resource/XtendResourceDescriptionManager.xtend
@@ -63,10 +63,6 @@ class XtendResourceDescription extends DefaultResourceDescription {
 	
 	Set<QualifiedName> importedNames
 
-	new(Resource resource, IDefaultResourceDescriptionStrategy strategy) {
-		super(resource, strategy)
-	}
-
 	new(Resource resource, IDefaultResourceDescriptionStrategy strategy, IResourceScopeCache cache, IBatchTypeResolver typeResolver, IQualifiedNameConverter nameConverter) {
 		super(resource, strategy, cache)
 		this.typeResolver = typeResolver

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/resource/XtendResourceDescription.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/resource/XtendResourceDescription.java
@@ -48,10 +48,6 @@ public class XtendResourceDescription extends DefaultResourceDescription {
   
   private Set<QualifiedName> importedNames;
   
-  public XtendResourceDescription(final Resource resource, final IDefaultResourceDescriptionStrategy strategy) {
-    super(resource, strategy);
-  }
-  
   public XtendResourceDescription(final Resource resource, final IDefaultResourceDescriptionStrategy strategy, final IResourceScopeCache cache, final IBatchTypeResolver typeResolver, final IQualifiedNameConverter nameConverter) {
     super(resource, strategy, cache);
     this.typeResolver = typeResolver;

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/build/Indexer.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/build/Indexer.xtend
@@ -147,19 +147,20 @@ import org.eclipse.xtext.service.OperationCanceledManager
 		new(IResourceDescription original) {
 			this.URI = original.getURI
 			this.exported = ImmutableList.copyOf(
-			original.exportedObjects.map [ IEObjectDescription from |
-				if (from.getEObjectOrProxy.eIsProxy)
-					return from
-				var result = EcoreUtil.create(from.getEClass()) as InternalEObject
-				result.eSetProxyURI(from.getEObjectURI)
-				var Map<String, String> userData = null
-				for (key : from.userDataKeys) {
-					if (userData == null)
-						userData = Maps.newHashMapWithExpectedSize(2)
-					userData.put(key, from.getUserData(key))
-				}
-				return EObjectDescription.create(from.name, result, userData)
-			])
+				original.exportedObjects.map [ IEObjectDescription from |
+					if (from.getEObjectOrProxy.eIsProxy)
+						return from
+					var result = EcoreUtil.create(from.getEClass()) as InternalEObject
+					result.eSetProxyURI(from.getEObjectURI)
+					var Map<String, String> userData = null
+					for (key : from.userDataKeys) {
+						if (userData == null)
+							userData = Maps.newHashMapWithExpectedSize(2)
+						userData.put(key, from.getUserData(key))
+					}
+					return EObjectDescription.create(from.name, result, userData)
+				]
+			)
 		}
 
 		override protected List<IEObjectDescription> computeExportedObjects() {

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/build/XtendIncrementalBuilderTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/build/XtendIncrementalBuilderTest.xtend
@@ -98,7 +98,7 @@ class XtendIncrementalBuilderTest extends AbstractIncrementalBuilderTest {
 				''',
 				'src/mypack/MyClass.java' - '''
 					package mypack;
-					class MyClass extends Third {
+					public class MyClass extends Third {
 						public A a;
 					}
 				''',

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/build/XtendIncrementalBuilderTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/build/XtendIncrementalBuilderTest.xtend
@@ -118,6 +118,34 @@ class XtendIncrementalBuilderTest extends AbstractIncrementalBuilderTest {
 		assertTrue(generated.values.containsSuffix('xtend-gen/mypack/Third.java'))
 		assertTrue(generated.values.containsSuffix('xtend-gen/mypack/.Third.java._trace'))
 	}
+	
+	@Test 
+	def void testSimpleMixedBuild04() {
+		val buildRequest = newBuildRequest [
+			dirtyFiles = #[
+				'src/A.xtend' - '''
+					import b.B
+					class A {
+					   @Override
+					   def foo() {
+					      B.foo
+					   }
+					}
+				'''
+				,'src/b/B.java' - '''
+					package b;
+					public class B {
+						public static String foo;
+					}
+				'''
+				
+			]
+		]
+		build(buildRequest)
+		assertTrue(issues.toString, issues.isEmpty)
+		assertEquals(2, generated.size)
+		assertTrue(generated.values.containsSuffix('xtend-gen/A.java'))
+	}
 
 	@Test def void testSimpleFullBuild() {
 		val buildRequest = newBuildRequest [

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/build/XtendIncrementalBuilderTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/build/XtendIncrementalBuilderTest.java
@@ -221,6 +221,58 @@ public class XtendIncrementalBuilderTest extends AbstractIncrementalBuilderTest 
   }
   
   @Test
+  public void testSimpleMixedBuild04() {
+    final Procedure1<BuildRequest> _function = new Procedure1<BuildRequest>() {
+      @Override
+      public void apply(final BuildRequest it) {
+        StringConcatenation _builder = new StringConcatenation();
+        _builder.append("import b.B");
+        _builder.newLine();
+        _builder.append("class A {");
+        _builder.newLine();
+        _builder.append("   ");
+        _builder.append("@Override");
+        _builder.newLine();
+        _builder.append("   ");
+        _builder.append("def foo() {");
+        _builder.newLine();
+        _builder.append("      ");
+        _builder.append("B.foo");
+        _builder.newLine();
+        _builder.append("   ");
+        _builder.append("}");
+        _builder.newLine();
+        _builder.append("}");
+        _builder.newLine();
+        URI _minus = XtendIncrementalBuilderTest.this.operator_minus(
+          "src/A.xtend", _builder.toString());
+        StringConcatenation _builder_1 = new StringConcatenation();
+        _builder_1.append("package b;");
+        _builder_1.newLine();
+        _builder_1.append("public class B {");
+        _builder_1.newLine();
+        _builder_1.append("\t");
+        _builder_1.append("public static String foo;");
+        _builder_1.newLine();
+        _builder_1.append("}");
+        _builder_1.newLine();
+        URI _minus_1 = XtendIncrementalBuilderTest.this.operator_minus("src/b/B.java", _builder_1.toString());
+        it.setDirtyFiles(Collections.<URI>unmodifiableList(CollectionLiterals.<URI>newArrayList(_minus, _minus_1)));
+      }
+    };
+    final BuildRequest buildRequest = this.newBuildRequest(_function);
+    this.build(buildRequest);
+    String _string = this.issues.toString();
+    boolean _isEmpty = this.issues.isEmpty();
+    Assert.assertTrue(_string, _isEmpty);
+    int _size = this.generated.size();
+    Assert.assertEquals(2, _size);
+    Collection<URI> _values = this.generated.values();
+    boolean _containsSuffix = this.containsSuffix(_values, "xtend-gen/A.java");
+    Assert.assertTrue(_containsSuffix);
+  }
+  
+  @Test
   public void testSimpleFullBuild() {
     final Procedure1<BuildRequest> _function = new Procedure1<BuildRequest>() {
       @Override

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/build/XtendIncrementalBuilderTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/build/XtendIncrementalBuilderTest.java
@@ -175,7 +175,7 @@ public class XtendIncrementalBuilderTest extends AbstractIncrementalBuilderTest 
         StringConcatenation _builder_1 = new StringConcatenation();
         _builder_1.append("package mypack;");
         _builder_1.newLine();
-        _builder_1.append("class MyClass extends Third {");
+        _builder_1.append("public class MyClass extends Third {");
         _builder_1.newLine();
         _builder_1.append("\t");
         _builder_1.append("public A a;");


### PR DESCRIPTION
JavaResources do not unload their derived state after indexing. They only do so when their getContents()-method is called the next time. That is too late when some referencing file is compiled first and fetches the stubs from the index. See the attached test case. 

We should mimic DerivedStateAwareResource(DescriptionManager).