### PR TITLE
[old xtext generator] forward 'CodeConfig's flag 'preferXtendStubs' t…

### DIFF
--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/adapter/FragmentAdapter.xtend
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/adapter/FragmentAdapter.xtend
@@ -42,6 +42,7 @@ import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
 import org.eclipse.xtext.xtext.generator.model.TypeReference
 
 import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
+import org.eclipse.xtext.generator.IStubGenerating
 
 /**
  * @since 2.9
@@ -85,6 +86,11 @@ class FragmentAdapter extends AbstractGeneratorFragment2 {
 	override generate() {
 		if (naming === null)
 			naming = createNaming()
+		
+		if (fragment instanceof IStubGenerating.XtendOption) {
+			fragment.generateXtendStub = codeConfig.preferXtendStubs
+		}
+		
 		val ctx = createExecutionContext()
 		val config1 = createLanguageConfig()
 		if (fragment instanceof IGeneratorFragmentExtension2) {

--- a/plugins/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/adapter/FragmentAdapter.java
+++ b/plugins/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/adapter/FragmentAdapter.java
@@ -38,6 +38,7 @@ import org.eclipse.xtext.generator.IGeneratorFragmentExtension;
 import org.eclipse.xtext.generator.IGeneratorFragmentExtension2;
 import org.eclipse.xtext.generator.IGeneratorFragmentExtension3;
 import org.eclipse.xtext.generator.IGeneratorFragmentExtension4;
+import org.eclipse.xtext.generator.IStubGenerating;
 import org.eclipse.xtext.generator.LanguageConfig;
 import org.eclipse.xtext.generator.Naming;
 import org.eclipse.xtext.generator.NamingAware;
@@ -122,6 +123,10 @@ public class FragmentAdapter extends AbstractGeneratorFragment2 {
     if ((this.naming == null)) {
       Naming _createNaming = this.createNaming();
       this.naming = _createNaming;
+    }
+    if ((this.fragment instanceof IStubGenerating.XtendOption)) {
+      boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
+      ((IStubGenerating.XtendOption)this.fragment).setGenerateXtendStub(_isPreferXtendStubs);
     }
     final XpandExecutionContext ctx = this.createExecutionContext();
     final LanguageConfig config1 = this.createLanguageConfig();


### PR DESCRIPTION
…o instances of 'IStubGenerating.XtendOption'.

What do you think about that? Worked for me during testing. Only problem I saw yet:
The 'GenerateXbase' workflow implementation explicitly states
```
label.setGenerateXtendStub(true);
```
that gets overridden (the general preference is Java). Is that a serious blocker?