### PR TITLE
[xtext generator] added missing dependency addition in 'CompareFragment2'

### DIFF
--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/compare/CompareFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/compare/CompareFragment2.xtend
@@ -33,8 +33,10 @@ class CompareFragment2 extends AbstractGeneratorFragment2 {
 			log.info("generating Compare Framework infrastructure");
 		}
 
-		if (projectConfig.eclipsePlugin.manifest != null) {
-			projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtext.ui"
+		if (projectConfig.eclipsePlugin?.manifest != null) {
+			projectConfig.eclipsePlugin.manifest.requiredBundles += #[
+				"org.eclipse.compare", "org.eclipse.xtext.ui"
+			]
 		}
 
 		new GuiceModuleAccess.BindingFactory()
@@ -43,7 +45,7 @@ class CompareFragment2 extends AbstractGeneratorFragment2 {
 					new TypeReference("org.eclipse.xtext.ui.compare.DefaultViewerCreator")
 				).contributeTo(language.eclipsePluginGenModule);
 
-		if (projectConfig.eclipsePlugin.pluginXml != null) {
+		if (projectConfig.eclipsePlugin?.pluginXml != null) {
 			projectConfig.eclipsePlugin.pluginXml.entries += '''
 			<extension point="org.eclipse.compare.contentViewers">
 				<viewer id="«grammar.name».compare.contentViewers"

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/compare/CompareFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/compare/CompareFragment2.java
@@ -8,13 +8,16 @@
 package org.eclipse.xtext.xtext.generator.ui.compare;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.apache.log4j.Logger;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.Grammar;
 import org.eclipse.xtext.GrammarUtil;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xtext.generator.AbstractGeneratorFragment2;
@@ -48,14 +51,17 @@ public class CompareFragment2 extends AbstractGeneratorFragment2 {
     }
     IXtextProjectConfig _projectConfig = this.getProjectConfig();
     IBundleProjectConfig _eclipsePlugin = _projectConfig.getEclipsePlugin();
-    ManifestAccess _manifest = _eclipsePlugin.getManifest();
+    ManifestAccess _manifest = null;
+    if (_eclipsePlugin!=null) {
+      _manifest=_eclipsePlugin.getManifest();
+    }
     boolean _notEquals = (!Objects.equal(_manifest, null));
     if (_notEquals) {
       IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_1 = _projectConfig_1.getEclipsePlugin();
       ManifestAccess _manifest_1 = _eclipsePlugin_1.getManifest();
       Set<String> _requiredBundles = _manifest_1.getRequiredBundles();
-      _requiredBundles.add("org.eclipse.xtext.ui");
+      Iterables.<String>addAll(_requiredBundles, Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("org.eclipse.compare", "org.eclipse.xtext.ui")));
     }
     GuiceModuleAccess.BindingFactory _bindingFactory = new GuiceModuleAccess.BindingFactory();
     TypeReference _typeReference = new TypeReference("org.eclipse.compare.IViewerCreator");
@@ -66,7 +72,10 @@ public class CompareFragment2 extends AbstractGeneratorFragment2 {
     _addTypeToType.contributeTo(_eclipsePluginGenModule);
     IXtextProjectConfig _projectConfig_2 = this.getProjectConfig();
     IBundleProjectConfig _eclipsePlugin_2 = _projectConfig_2.getEclipsePlugin();
-    PluginXmlAccess _pluginXml = _eclipsePlugin_2.getPluginXml();
+    PluginXmlAccess _pluginXml = null;
+    if (_eclipsePlugin_2!=null) {
+      _pluginXml=_eclipsePlugin_2.getPluginXml();
+    }
     boolean _notEquals_1 = (!Objects.equal(_pluginXml, null));
     if (_notEquals_1) {
       IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();


### PR DESCRIPTION
Fixes a mistake in migration of 'CompareFragment'.

Signed-off-by: Christian Schneider <christian.schneider@itemis.de>