### PR TITLE
[xtext generator] added removal of duplicate imports in 'JavaFileAccess', …

### DIFF
--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.xtend
@@ -4,8 +4,6 @@ import java.util.List
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtext.xtext.generator.model.annotations.IClassAnnotation
-import java.util.Collections
-import com.google.common.collect.Lists
 
 class GeneratedJavaFileAccess extends JavaFileAccess {
 	
@@ -28,24 +26,26 @@ class GeneratedJavaFileAccess extends JavaFileAccess {
 			throw new IllegalArgumentException("It's always generated");
 	}
 
+	/**
+	 * prepends the addition of required imports of the employed annotations
+	 */
 	override getContent() {
-		val classAnnotations = annotations + codeConfig.classAnnotations.filter[appliesTo(this)]
-		classAnnotations.forEach[importType(annotationImport)]
-		val sortedImports = Lists.newArrayList(imports.values)
-		Collections.sort(sortedImports)
-		return '''
-			«codeConfig.fileHeader»
-			package «javaType.packageName»«IF appendSemicolons»;«ENDIF»
-			
-			«FOR importName : sortedImports»
-				import «importName»«IF appendSemicolons»;«ENDIF»
-			«ENDFOR»
-			
-			«typeComment»
-			«FOR annot : classAnnotations»
-				«annot.generate()»
-			«ENDFOR»
-			«internalContents»
-		'''
-	}	
+		classAnnotations.forEach[
+			importType(annotationImport)
+		]
+		super.getContent()
+	}
+	
+	private def getClassAnnotations() {
+		annotations + codeConfig.classAnnotations.filter[appliesTo(this)]
+	}
+	
+	override getInternalContent() '''
+		«typeComment»
+		«FOR annot : classAnnotations»
+			«annot.generate()»
+		«ENDFOR»	
+		«super.getInternalContent»
+	'''
+	
 }

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/JavaFileAccess.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/JavaFileAccess.xtend
@@ -7,8 +7,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.generator.model
 
-import com.google.common.collect.Lists
-import java.util.Collections
 import java.util.Map
 import org.eclipse.emf.codegen.util.CodeGenUtil
 import org.eclipse.emf.ecore.EClass
@@ -105,19 +103,19 @@ class JavaFileAccess extends TextFileAccess {
 		true
 	}
 	
-	override getContent() {
-		val sortedImports = Lists.newArrayList(imports.values)
-		Collections.sort(sortedImports)
-		return '''
-			«codeConfig.fileHeader»
-			package «javaType.packageName»«IF appendSemicolons»;«ENDIF»
-			
-			«FOR importName : sortedImports»
-				import «importName»«IF appendSemicolons»;«ENDIF»
-			«ENDFOR»
-			
-			«internalContents»
-		'''
+	override getContent() '''
+		«codeConfig.fileHeader»
+		package «javaType.packageName»«IF appendSemicolons»;«ENDIF»
+
+		«FOR importName : imports.values.toSet.sort»
+			import «importName»«IF appendSemicolons»;«ENDIF»
+		«ENDFOR»
+		
+		«getInternalContent»
+	'''
+	
+	protected def getInternalContent() {
+		internalContents
 	}
 	
 	private static class JavaTypeAwareStringConcatenation extends StringConcatenation {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.java
@@ -1,10 +1,6 @@
 package org.eclipse.xtext.xtext.generator.model;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtend2.lib.StringConcatenation;
@@ -42,8 +38,28 @@ public class GeneratedJavaFileAccess extends JavaFileAccess {
     }
   }
   
+  /**
+   * prepends the addition of required imports of the employed annotations
+   */
   @Override
   public CharSequence getContent() {
+    CharSequence _xblockexpression = null;
+    {
+      Iterable<IClassAnnotation> _classAnnotations = this.getClassAnnotations();
+      final Procedure1<IClassAnnotation> _function = new Procedure1<IClassAnnotation>() {
+        @Override
+        public void apply(final IClassAnnotation it) {
+          TypeReference _annotationImport = it.getAnnotationImport();
+          GeneratedJavaFileAccess.this.importType(_annotationImport);
+        }
+      };
+      IterableExtensions.<IClassAnnotation>forEach(_classAnnotations, _function);
+      _xblockexpression = super.getContent();
+    }
+    return _xblockexpression;
+  }
+  
+  private Iterable<IClassAnnotation> getClassAnnotations() {
     List<IClassAnnotation> _classAnnotations = this.codeConfig.getClassAnnotations();
     final Function1<IClassAnnotation, Boolean> _function = new Function1<IClassAnnotation, Boolean>() {
       @Override
@@ -52,57 +68,24 @@ public class GeneratedJavaFileAccess extends JavaFileAccess {
       }
     };
     Iterable<IClassAnnotation> _filter = IterableExtensions.<IClassAnnotation>filter(_classAnnotations, _function);
-    final Iterable<IClassAnnotation> classAnnotations = Iterables.<IClassAnnotation>concat(this.annotations, _filter);
-    final Procedure1<IClassAnnotation> _function_1 = new Procedure1<IClassAnnotation>() {
-      @Override
-      public void apply(final IClassAnnotation it) {
-        TypeReference _annotationImport = it.getAnnotationImport();
-        GeneratedJavaFileAccess.this.importType(_annotationImport);
-      }
-    };
-    IterableExtensions.<IClassAnnotation>forEach(classAnnotations, _function_1);
-    Collection<String> _values = this.imports.values();
-    final ArrayList<String> sortedImports = Lists.<String>newArrayList(_values);
-    Collections.<String>sort(sortedImports);
+    return Iterables.<IClassAnnotation>concat(this.annotations, _filter);
+  }
+  
+  @Override
+  public CharSequence getInternalContent() {
     StringConcatenation _builder = new StringConcatenation();
-    String _fileHeader = this.codeConfig.getFileHeader();
-    _builder.append(_fileHeader, "");
-    _builder.newLineIfNotEmpty();
-    _builder.append("package ");
-    String _packageName = this.javaType.getPackageName();
-    _builder.append(_packageName, "");
-    {
-      boolean _appendSemicolons = this.appendSemicolons();
-      if (_appendSemicolons) {
-        _builder.append(";");
-      }
-    }
-    _builder.newLineIfNotEmpty();
-    _builder.newLine();
-    {
-      for(final String importName : sortedImports) {
-        _builder.append("import ");
-        _builder.append(importName, "");
-        {
-          boolean _appendSemicolons_1 = this.appendSemicolons();
-          if (_appendSemicolons_1) {
-            _builder.append(";");
-          }
-        }
-        _builder.newLineIfNotEmpty();
-      }
-    }
-    _builder.newLine();
     _builder.append(this.typeComment, "");
     _builder.newLineIfNotEmpty();
     {
-      for(final IClassAnnotation annot : classAnnotations) {
+      Iterable<IClassAnnotation> _classAnnotations = this.getClassAnnotations();
+      for(final IClassAnnotation annot : _classAnnotations) {
         CharSequence _generate = annot.generate();
         _builder.append(_generate, "");
         _builder.newLineIfNotEmpty();
       }
     }
-    _builder.append(this.internalContents, "");
+    CharSequence _internalContent = super.getInternalContent();
+    _builder.append(_internalContent, "");
     _builder.newLineIfNotEmpty();
     return _builder;
   }

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/JavaFileAccess.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/JavaFileAccess.java
@@ -8,8 +8,6 @@
 package org.eclipse.xtext.xtext.generator.model;
 
 import com.google.common.base.Objects;
-import com.google.common.collect.Lists;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -214,9 +212,6 @@ public class JavaFileAccess extends TextFileAccess {
   
   @Override
   public CharSequence getContent() {
-    Collection<String> _values = this.imports.values();
-    final ArrayList<String> sortedImports = Lists.<String>newArrayList(_values);
-    Collections.<String>sort(sortedImports);
     StringConcatenation _builder = new StringConcatenation();
     String _fileHeader = this.codeConfig.getFileHeader();
     _builder.append(_fileHeader, "");
@@ -233,7 +228,10 @@ public class JavaFileAccess extends TextFileAccess {
     _builder.newLineIfNotEmpty();
     _builder.newLine();
     {
-      for(final String importName : sortedImports) {
+      Collection<String> _values = this.imports.values();
+      Set<String> _set = IterableExtensions.<String>toSet(_values);
+      List<String> _sort = IterableExtensions.<String>sort(_set);
+      for(final String importName : _sort) {
         _builder.append("import ");
         _builder.append(importName, "");
         {
@@ -246,9 +244,14 @@ public class JavaFileAccess extends TextFileAccess {
       }
     }
     _builder.newLine();
-    _builder.append(this.internalContents, "");
+    CharSequence _internalContent = this.getInternalContent();
+    _builder.append(_internalContent, "");
     _builder.newLineIfNotEmpty();
     return _builder;
+  }
+  
+  protected CharSequence getInternalContent() {
+    return this.internalContents;
   }
   
   @Pure


### PR DESCRIPTION
and resolved code clone in 'GeneratedJavaFileAccess'.

``getContent()`` in ``JavaFileAccess`` as well as in ``GeneratedJavaFileAccess`` did not check for duplicate class names in ``imports.values``.
Added that filtering in ``JavaFileAccess`` und simplified implementation of ``getContent``.
Resolved the modified clone of ``getContent()`` in ``GeneratedJavaFileAccess``. 

Signed-off-by: Christian Schneider <christian.schneider@itemis.de>