### PR TITLE
Conditionaly split switch in specialStateTransition method

### DIFF
--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/AbstractAntlrGeneratorFragment.java
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/AbstractAntlrGeneratorFragment.java
@@ -156,6 +156,7 @@ public abstract class AbstractAntlrGeneratorFragment extends AbstractGeneratorFr
 	protected void splitLexerClassFile(String filename, Charset encoding) throws IOException {
 		String content = readFileIntoString(filename, encoding);
 		AntlrLexerSplitter splitter = new AntlrLexerSplitter(content);
+		splitter.setCasesPerSpecialStateSwitch(options.getCasesPerSpecialStateSwitch());
 		writeStringIntoFile(filename, splitter.transform(), encoding);
 	}
 

--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/AbstractAntlrGeneratorFragment.java
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/AbstractAntlrGeneratorFragment.java
@@ -156,6 +156,7 @@ public abstract class AbstractAntlrGeneratorFragment extends AbstractGeneratorFr
 	protected void splitLexerClassFile(String filename, Charset encoding) throws IOException {
 		String content = readFileIntoString(filename, encoding);
 		AntlrLexerSplitter splitter = new AntlrLexerSplitter(content);
+		splitter.setSpecialStateSwitchSplitting(options.isSpecialStateSwitchSplitting());
 		splitter.setCasesPerSpecialStateSwitch(options.getCasesPerSpecialStateSwitch());
 		writeStringIntoFile(filename, splitter.transform(), encoding);
 	}

--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/ex/ExternalAntlrLexerFragment.java
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/ex/ExternalAntlrLexerFragment.java
@@ -29,6 +29,7 @@ import org.eclipse.xtext.generator.NewlineNormalizer;
 import org.eclipse.xtext.generator.parser.antlr.AntlrToolFacade;
 import org.eclipse.xtext.generator.parser.antlr.postProcessing.SuppressWarningsProcessor;
 import org.eclipse.xtext.xtext.generator.parser.antlr.splitting.AntlrLexerSplitter;
+import org.eclipse.xtext.xtext.generator.parser.antlr.splitting.internal.LexerSpecialStateTransitionSplitter;
 import org.eclipse.xtext.parser.antlr.Lexer;
 import org.eclipse.xtext.util.Strings;
 
@@ -50,6 +51,8 @@ public class ExternalAntlrLexerFragment extends DefaultGeneratorFragment impleme
 	private boolean contentAssist;
 	
 	private boolean classSplitting = false;
+	
+	private int casesPerSpecialStateSwitch = LexerSpecialStateTransitionSplitter.CASES_PER_SPECIAL_STATE_SWITCH;
 
 	private List<String> antlrParams = Lists.newArrayList();
 	
@@ -131,6 +134,7 @@ public class ExternalAntlrLexerFragment extends DefaultGeneratorFragment impleme
 			String content = readFileIntoString(lexerJavaFile, encoding);
 			AntlrLexerSplitter splitter = new AntlrLexerSplitter(content);
 			splitter.setAllowDFAStaticClasses(false);
+			splitter.setCasesPerSpecialStateSwitch(casesPerSpecialStateSwitch);
 			writeStringIntoFile(lexerJavaFile, splitter.transform(), encoding);
 		}
 	}
@@ -280,6 +284,20 @@ public class ExternalAntlrLexerFragment extends DefaultGeneratorFragment impleme
 		this.classSplitting = value;
 	}
 
+	/**
+	 * @since 2.9
+	 */
+	public int getCasesPerSpecialStateSwitch(){
+		return casesPerSpecialStateSwitch;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public void setCasesPerSpecialStateSwitch(final String casesPerSpecialStateSwitch){
+	    int _parseInt = Integer.parseInt(casesPerSpecialStateSwitch);
+	    this.casesPerSpecialStateSwitch = _parseInt;
+	}
 	
 	private String readFileIntoString(String filename, Charset encoding) {
 		try {

--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/ex/ExternalAntlrLexerFragment.java
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/ex/ExternalAntlrLexerFragment.java
@@ -52,6 +52,8 @@ public class ExternalAntlrLexerFragment extends DefaultGeneratorFragment impleme
 	
 	private boolean classSplitting = false;
 	
+	private boolean specialStateSwitchSplitting = false;
+	
 	private int casesPerSpecialStateSwitch = LexerSpecialStateTransitionSplitter.CASES_PER_SPECIAL_STATE_SWITCH;
 
 	private List<String> antlrParams = Lists.newArrayList();
@@ -134,6 +136,7 @@ public class ExternalAntlrLexerFragment extends DefaultGeneratorFragment impleme
 			String content = readFileIntoString(lexerJavaFile, encoding);
 			AntlrLexerSplitter splitter = new AntlrLexerSplitter(content);
 			splitter.setAllowDFAStaticClasses(false);
+			splitter.setSpecialStateSwitchSplitting(specialStateSwitchSplitting);
 			splitter.setCasesPerSpecialStateSwitch(casesPerSpecialStateSwitch);
 			writeStringIntoFile(lexerJavaFile, splitter.transform(), encoding);
 		}
@@ -282,6 +285,20 @@ public class ExternalAntlrLexerFragment extends DefaultGeneratorFragment impleme
 	 */
 	public void setClassSplitting(boolean value) {
 		this.classSplitting = value;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public boolean isSpecialStateSwitchSplitting() {
+		return specialStateSwitchSplitting;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public void setSpecialStateSwitchSplitting(boolean value) {
+		this.specialStateSwitchSplitting = value;
 	}
 
 	/**

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrOptions.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrOptions.xtend
@@ -10,6 +10,7 @@ package org.eclipse.xtext.xtext.generator.parser.antlr
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.xtext.generator.parser.antlr.splitting.AntlrParserSplitter
 import org.eclipse.xtext.xtext.generator.parser.antlr.splitting.PartialClassExtractor
+import org.eclipse.xtext.xtext.generator.parser.antlr.splitting.internal.LexerSpecialStateTransitionSplitter
 
 @Accessors
 class AntlrOptions {
@@ -19,10 +20,13 @@ class AntlrOptions {
 	int k = -1
 	boolean ignoreCase = false
 	boolean classSplitting = false
+	boolean specialStateSwitchSplitting = false
 	@Accessors(PUBLIC_GETTER)
 	int fieldsPerClass = AntlrParserSplitter.FIELDS_PER_CLASS
 	@Accessors(PUBLIC_GETTER)
 	int methodsPerClass = PartialClassExtractor.METHODS_PER_CLASS
+	@Accessors(PUBLIC_GETTER)
+	int casesPerSpecialStateSwitch = LexerSpecialStateTransitionSplitter.CASES_PER_SPECIAL_STATE_SWITCH
 	boolean skipUnusedRules = false
 	boolean optimizeCodeQuality = true
 	boolean stripAllComments = false
@@ -35,6 +39,10 @@ class AntlrOptions {
 
 	def void setMethodsPerClass(String methodsPerClass) {
 		this.methodsPerClass = Integer.parseInt(methodsPerClass)
+	}
+	
+	def void setCasesPerSpecialStateSwitch(String casesPerSpecialStateSwitch) {
+		this.casesPerSpecialStateSwitch = Integer.parseInt(casesPerSpecialStateSwitch)
 	}
 
 	def void setKAsString(String k) {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/splitting/AntlrLexerSplitter.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/splitting/AntlrLexerSplitter.java
@@ -46,6 +46,8 @@ public class AntlrLexerSplitter {
 	
 	private boolean allowDFAStaticClasses = true;
 	
+	private int casesPerSpecialStateSwitch = LexerSpecialStateTransitionSplitter.CASES_PER_SPECIAL_STATE_SWITCH;
+	
 	public AntlrLexerSplitter(String content) {
 		scanner = new Scanner(content);
 	}
@@ -75,6 +77,7 @@ public class AntlrLexerSplitter {
 		LexerSpecialStateTransitionSplitter lexerSplitter;
 		lexerSplitter = new LexerSpecialStateTransitionSplitter(false);
 		lexerSplitter.setAllowDFAStaticClasses(allowDFAStaticClasses);
+		lexerSplitter.setCasesPerSpecialStateSwitch(casesPerSpecialStateSwitch);
 		result = lexerSplitter.transform(result);
 		return result;
 	}
@@ -231,6 +234,20 @@ public class AntlrLexerSplitter {
 	 */
 	public void setAllowDFAStaticClasses(boolean value) {
 		this.allowDFAStaticClasses = value;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public int getCasesPerSpecialStateSwitch(){
+		return casesPerSpecialStateSwitch;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public void setCasesPerSpecialStateSwitch(int value){
+		this.casesPerSpecialStateSwitch = value;
 	}
 
 	static public class ExtractedMethod {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/splitting/AntlrLexerSplitter.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/splitting/AntlrLexerSplitter.java
@@ -45,6 +45,7 @@ public class AntlrLexerSplitter {
 	private final Scanner scanner;
 	
 	private boolean allowDFAStaticClasses = true;
+	private boolean specialStateSwitchSplitting = false;
 	
 	private int casesPerSpecialStateSwitch = LexerSpecialStateTransitionSplitter.CASES_PER_SPECIAL_STATE_SWITCH;
 	
@@ -77,6 +78,7 @@ public class AntlrLexerSplitter {
 		LexerSpecialStateTransitionSplitter lexerSplitter;
 		lexerSplitter = new LexerSpecialStateTransitionSplitter(false);
 		lexerSplitter.setAllowDFAStaticClasses(allowDFAStaticClasses);
+		lexerSplitter.setSpecialStateSwitchSplitting(specialStateSwitchSplitting);
 		lexerSplitter.setCasesPerSpecialStateSwitch(casesPerSpecialStateSwitch);
 		result = lexerSplitter.transform(result);
 		return result;
@@ -234,6 +236,20 @@ public class AntlrLexerSplitter {
 	 */
 	public void setAllowDFAStaticClasses(boolean value) {
 		this.allowDFAStaticClasses = value;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public boolean isSpecialStateSwitchSplitting() {
+		return specialStateSwitchSplitting;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public void setSpecialStateSwitchSplitting(boolean value) {
+		this.specialStateSwitchSplitting = value;
 	}
 	
 	/**

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/splitting/internal/LexerSpecialStateTransitionSplitter.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/splitting/internal/LexerSpecialStateTransitionSplitter.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.generator.parser.antlr.splitting.internal;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,6 +16,8 @@ import java.util.regex.Pattern;
  * @author Sebastian Zarnekow - Initial contribution and API
  */
 public class LexerSpecialStateTransitionSplitter {
+	
+	public static final int CASES_PER_SPECIAL_STATE_SWITCH = 1000;
 
 	public static final Pattern DFA_PATTERN = Pattern.compile(
 			"(class DFA\\d+ extends DFA \\{.*" +
@@ -34,6 +38,26 @@ public class LexerSpecialStateTransitionSplitter {
 			"^\\s*break;$)" // break, end case
 			, Pattern.DOTALL | Pattern.MULTILINE);
 	
+	public static final Pattern TRANSORMED_SPECIAL_STATE_TRANSITION_METHOD = Pattern.compile(
+			"((public int specialStateTransition\\(int s, IntStream _input\\) throws NoViableAltException\\s*\\{" +
+			"\\s+IntStream[^;]*;\\s*" +
+			"int[^;]*;\\s*)" +
+			"(switch\\s*\\( s \\)\\s*" + // switch -> $3
+			"(case\\s+\\d+\\s*:\\s*" + // case #
+			"\\s*s\\s*=\\s*specialStateTransition\\d+\\(\\s*input\\s*\\)\\s*;" + // test transition # $2
+			"\\s*if\\s*\\(\\s*s\\s*>=0\\s*\\)\\s*return\\s*s;\\s*" + // if ( s>=0 ) return s;
+			"^\\s*break;\\s*)*" + // end case
+			"[^}]*\\})" + // end switch
+			"(\\s*NoViableAltException\\s+nvae\\s*=[^}]*\\}))" // $5
+			,Pattern.DOTALL | Pattern.MULTILINE);
+	
+	public static final Pattern TRANSFORMED_CASE_PATTERN = Pattern.compile(
+			"(^\\s*case\\s+(\\d+)\\s*:\\s*" + // case #
+			"\\s*s\\s*=\\s*specialStateTransition\\d+\\(\\s*input\\s*\\)\\s*;" + // test transition # $2
+			"\\s*if\\s*\\(\\s*s\\s*>=0\\s*\\)\\s*return\\s*s;\\s*" + // if ( s>=0 ) return s; $10
+			"^\\s*break;)" // end case
+			,Pattern.DOTALL | Pattern.MULTILINE);
+	
 	public static final Pattern STATE_PATTERN = Pattern.compile(
 			Pattern.quote("if (state.backtracking>0) {state.failed=true; return -1;}"));
 
@@ -44,6 +68,8 @@ public class LexerSpecialStateTransitionSplitter {
 	private final boolean ignoreCaseCountGuard;
 	
 	private boolean allowDFAStaticClasses = true;
+	
+	private int casesPerSpecialStateSwitch = CASES_PER_SPECIAL_STATE_SWITCH;
 	
 	public LexerSpecialStateTransitionSplitter(boolean ignoreCaseCountGuard) {
 		this.ignoreCaseCountGuard = ignoreCaseCountGuard;
@@ -57,7 +83,8 @@ public class LexerSpecialStateTransitionSplitter {
 			String staticOrNot = "$1";
 			if (allowDFAStaticClasses && !STATE_PATTERN.matcher(specialStateTransition).find())
 				staticOrNot = "static $1";
-			String transformedDfa = staticOrNot + extractSpecialStateMethods(specialStateTransition) + "$3";
+			String tmpSpecialStateTransition = extractSpecialStateMethods(specialStateTransition);
+			String transformedDfa = staticOrNot + splitSpecialStateSwitch(tmpSpecialStateTransition) + "$3";
 			dfaMatcher.appendReplacement(result, transformedDfa);
 		}
 		dfaMatcher.appendTail(result);
@@ -77,7 +104,7 @@ public class LexerSpecialStateTransitionSplitter {
 			extractedMethods.append(caseMatcher.group(2));
 			extractedMethods.append("(IntStream input) {\n");
 			extractedMethods.append("            int s = -1;\n            ");
-			extractedMethods.append(caseMatcher.group(4));
+			extractedMethods.append(caseMatcher.group(4).replaceAll("(^|\n)\\s+", "$1"));
 			extractedMethods.append("\n");
 			extractedMethods.append(caseMatcher.group(6).replaceAll("(^|\n)\\s+", "$1            "));
 			extractedMethods.append("\n            return s;\n");
@@ -88,6 +115,89 @@ public class LexerSpecialStateTransitionSplitter {
 		result.append(extractedMethods);
 		result.append("\n");
 		return result.toString().replace("\\", "\\\\").replace("$", "\\$");
+	}
+	
+	private static void generateExtractedSwitch(List<String> extractedCasesList, String from, String to,
+			StringBuffer extractedMethods, StringBuffer switchReplacementBuffer){
+		String extractedMethodName = String.format("specialStateTransitionFrom%sTo%s", from, to);
+		extractedMethods.append("\n        protected int ");
+		extractedMethods.append(extractedMethodName);
+		extractedMethods.append("(int s, IntStream input) {\n");
+		extractedMethods.append("            int _s = s;\n");
+		extractedMethods.append("            switch( s ) {\n");
+		for(String extractedCase : extractedCasesList ){
+			extractedMethods.append(extractedCase);
+			extractedMethods.append("\n");
+		}
+		extractedMethods.append("            }\n");
+		extractedMethods.append("            return -1;\n");
+		extractedMethods.append("        }\n");
+		
+		switchReplacementBuffer.append("            s = ");
+		switchReplacementBuffer.append(extractedMethodName);
+		switchReplacementBuffer.append("( _s, input );\n");
+		switchReplacementBuffer.append("            if ( s >= 0 ) return s;\n");
+	}	
+
+	/**
+	 * Splits switch in specialStateTransition containing more than maxCasesPerSwitch
+	 * cases into several methods each containing maximum of maxCasesPerSwitch cases
+	 * or less.
+	 * @since 2.9
+	 */
+	public String splitSpecialStateSwitch(String specialStateTransition){
+		Matcher transformedSpecialStateMatcher =
+				TRANSORMED_SPECIAL_STATE_TRANSITION_METHOD.matcher(specialStateTransition);
+		if( !transformedSpecialStateMatcher.find() ){
+			return specialStateTransition;
+		}
+		
+		String specialStateSwitch = transformedSpecialStateMatcher.group(3);
+		
+		Matcher transformedCaseMatcher = TRANSFORMED_CASE_PATTERN.matcher(specialStateSwitch);
+		
+		StringBuffer switchReplacementBuffer = new StringBuffer();
+		StringBuffer extractedMethods = new StringBuffer();
+		List<String> extractedCasesList = new ArrayList<String>();
+
+		switchReplacementBuffer.append("$2\n");
+		
+		boolean methodExtracted = false;
+		boolean isFirst = true;
+		String from = "0";
+		String to = "0";
+		//Process individual case statements
+		while(transformedCaseMatcher.find()){
+			if(isFirst){
+				isFirst = false;
+				from = transformedCaseMatcher.group(2);
+			}
+			to = transformedCaseMatcher.group(2);
+			extractedCasesList.add(transformedCaseMatcher.group());
+			//If the list of not processed extracted cases exceeds the maximal allowed number
+			//generate individual method for those cases
+			if (extractedCasesList.size() >= casesPerSpecialStateSwitch ){
+				generateExtractedSwitch(extractedCasesList, from, to, extractedMethods, switchReplacementBuffer);
+				extractedCasesList.clear();
+				isFirst = true;
+				methodExtracted = true;
+			}
+		}
+		
+		//If no method was extracted return the input unchanged
+		//or process rest of cases by generating method for them
+		if(!methodExtracted){
+			return specialStateTransition;
+		}else if(!extractedCasesList.isEmpty() && methodExtracted){
+			generateExtractedSwitch(extractedCasesList, from, to, extractedMethods, switchReplacementBuffer);
+		}
+		switchReplacementBuffer.append("$5");
+		
+		StringBuffer result = new StringBuffer();
+		transformedSpecialStateMatcher.appendReplacement( result, switchReplacementBuffer.toString());
+		result.append(extractedMethods);
+		transformedSpecialStateMatcher.appendTail(result);
+		return result.toString();
 	}
 	
 	/**
@@ -102,6 +212,20 @@ public class LexerSpecialStateTransitionSplitter {
 	 */
 	public void setAllowDFAStaticClasses(boolean value) {
 		this.allowDFAStaticClasses = value;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public void setCasesPerSpecialStateSwitch(int maxCasesPerSwitch){
+		this.casesPerSpecialStateSwitch = maxCasesPerSwitch;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public int getCasesPerSpecialStateSwitch(){
+		return casesPerSpecialStateSwitch;
 	}
 
 

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/splitting/internal/LexerSpecialStateTransitionSplitter.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/splitting/internal/LexerSpecialStateTransitionSplitter.java
@@ -69,6 +69,8 @@ public class LexerSpecialStateTransitionSplitter {
 	
 	private boolean allowDFAStaticClasses = true;
 	
+	private boolean specialStateSwitchSplitting = false;
+	
 	private int casesPerSpecialStateSwitch = CASES_PER_SPECIAL_STATE_SWITCH;
 	
 	public LexerSpecialStateTransitionSplitter(boolean ignoreCaseCountGuard) {
@@ -84,7 +86,12 @@ public class LexerSpecialStateTransitionSplitter {
 			if (allowDFAStaticClasses && !STATE_PATTERN.matcher(specialStateTransition).find())
 				staticOrNot = "static $1";
 			String tmpSpecialStateTransition = extractSpecialStateMethods(specialStateTransition);
-			String transformedDfa = staticOrNot + splitSpecialStateSwitch(tmpSpecialStateTransition) + "$3";
+			String transformedDfa;
+			if(specialStateSwitchSplitting){
+				transformedDfa = staticOrNot + splitSpecialStateSwitch(tmpSpecialStateTransition) + "$3";
+			}else{
+				transformedDfa = staticOrNot + tmpSpecialStateTransition + "$3";
+			}
 			dfaMatcher.appendReplacement(result, transformedDfa);
 		}
 		dfaMatcher.appendTail(result);
@@ -212,6 +219,20 @@ public class LexerSpecialStateTransitionSplitter {
 	 */
 	public void setAllowDFAStaticClasses(boolean value) {
 		this.allowDFAStaticClasses = value;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public boolean isSpecialStateSwitchSplitting() {
+		return specialStateSwitchSplitting;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public void setSpecialStateSwitchSplitting(boolean value) {
+		this.specialStateSwitchSplitting = value;
 	}
 	
 	/**

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrOptions.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrOptions.java
@@ -12,6 +12,7 @@ import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.parser.antlr.splitting.AntlrParserSplitter;
 import org.eclipse.xtext.xtext.generator.parser.antlr.splitting.PartialClassExtractor;
+import org.eclipse.xtext.xtext.generator.parser.antlr.splitting.internal.LexerSpecialStateTransitionSplitter;
 
 @Accessors
 @SuppressWarnings("all")
@@ -34,6 +35,9 @@ public class AntlrOptions {
   @Accessors(AccessorType.PUBLIC_GETTER)
   private int methodsPerClass = PartialClassExtractor.METHODS_PER_CLASS;
   
+  @Accessors(AccessorType.PUBLIC_GETTER)
+  private int casesPerSpecialStateSwitch = LexerSpecialStateTransitionSplitter.CASES_PER_SPECIAL_STATE_SWITCH;
+  
   private boolean skipUnusedRules = false;
   
   private boolean optimizeCodeQuality = true;
@@ -52,6 +56,14 @@ public class AntlrOptions {
   public void setMethodsPerClass(final String methodsPerClass) {
     int _parseInt = Integer.parseInt(methodsPerClass);
     this.methodsPerClass = _parseInt;
+  }
+  
+  /**
+   * @since 2.9
+   */
+  public void setCasesPerSpecialStateSwitch(final String casesPerSpecialStateSwitch){
+    int _parseInt = Integer.parseInt(casesPerSpecialStateSwitch);
+    this.casesPerSpecialStateSwitch = _parseInt;
   }
   
   public void setKAsString(final String k) {
@@ -121,6 +133,14 @@ public class AntlrOptions {
   @Pure
   public int getMethodsPerClass() {
     return this.methodsPerClass;
+  }
+  
+  /**
+   * @since 2.9
+   */
+  @Pure
+  public int getCasesPerSpecialStateSwitch(){
+	return this.casesPerSpecialStateSwitch;
   }
   
   @Pure

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrOptions.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrOptions.java
@@ -29,6 +29,8 @@ public class AntlrOptions {
   
   private boolean classSplitting = false;
   
+  private boolean specialStateSwitchSplitting = false;
+  
   @Accessors(AccessorType.PUBLIC_GETTER)
   private int fieldsPerClass = AntlrParserSplitter.FIELDS_PER_CLASS;
   
@@ -58,10 +60,7 @@ public class AntlrOptions {
     this.methodsPerClass = _parseInt;
   }
   
-  /**
-   * @since 2.9
-   */
-  public void setCasesPerSpecialStateSwitch(final String casesPerSpecialStateSwitch){
+  public void setCasesPerSpecialStateSwitch(final String casesPerSpecialStateSwitch) {
     int _parseInt = Integer.parseInt(casesPerSpecialStateSwitch);
     this.casesPerSpecialStateSwitch = _parseInt;
   }
@@ -126,6 +125,15 @@ public class AntlrOptions {
   }
   
   @Pure
+  public boolean isSpecialStateSwitchSplitting() {
+    return this.specialStateSwitchSplitting;
+  }
+  
+  public void setSpecialStateSwitchSplitting(final boolean specialStateSwitchSplitting) {
+    this.specialStateSwitchSplitting = specialStateSwitchSplitting;
+  }
+  
+  @Pure
   public int getFieldsPerClass() {
     return this.fieldsPerClass;
   }
@@ -135,12 +143,9 @@ public class AntlrOptions {
     return this.methodsPerClass;
   }
   
-  /**
-   * @since 2.9
-   */
   @Pure
-  public int getCasesPerSpecialStateSwitch(){
-	return this.casesPerSpecialStateSwitch;
+  public int getCasesPerSpecialStateSwitch() {
+    return this.casesPerSpecialStateSwitch;
   }
   
   @Pure

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/parser/splitting/LexerSpecialStateTransitionSplitterTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/parser/splitting/LexerSpecialStateTransitionSplitterTest.java
@@ -63,6 +63,43 @@ public class LexerSpecialStateTransitionSplitterTest extends Assert {
 			"\n" + 
 			"                        if ( s>=0 ) return s;\n" + 
 			"                        break;\n" +
+			"                    case 2 : \n" +
+			"                        int LA12_0 = input.LA(1);\n" +
+			"\n" +
+			"                        s = -1;" +
+			"                        if ( (LA12_0=='+'||LA12_0=='-') && (( currentState() == State.STATE_A ))) {s = 125;}\n" +
+			"\n" +
+			"                        else if ( ((LA12_0>='0' && LA12_0<='9')) && (( currentState() == State.STATE_A ))) {s = 126;}\n" +
+			"\n" +
+			"                        else if ( (LA12_0=='.') && (( currentState() == State.STATE_A ))) {s = 127;}\n" +
+			"\n" +
+			"\n" +
+			"                        if ( s>=0 ) return s;\n" +
+			"                        break;\n" +
+			"                    case 3 : \n" +
+			"                        int LA12_2 = input.LA(1);\n" +
+			"\n" +
+			"                        s = -1;\n" +
+			"                        if ( (LA12_2=='.') && (( currentState() == State.STATE_A ))) {s = 128;}\n" +
+			"\n" +
+			"                        else if ( ((LA12_2>='0' && LA12_2<='9')) && (( currentState() == State.STATE_A ))) {s = 126;}\n" +
+			"\n" +
+			"                        else if ( (LA12_2=='E'||LA12_2=='e') && (( currentState() == State.STATE_A ))) {s = 128;}\n" +
+			"\n" +
+			"                        if ( s>=0 ) return s;\n" +
+			"                        break;\n" +
+			"                    case 4 : \n" +
+			"                        int LA12_1 = input.LA(1);\n" +
+			"\n" +
+			"                        s = -1;\n" +
+			"                        if ( ((LA12_1>='0' && LA12_1<='9')) && (( currentState() == State.STATE_A ))) {s = 126;}\n" +
+			"\n" +
+			"                        else if ( (LA12_1=='.') && (( currentState() == State.STATE_A ))) {s = 127;}\n" +
+			"\n" +
+			"                        else if ( (LA12_1=='+'||LA12_1=='-') && (( currentState() == State.STATE_A ))) {s = 125;}\n" +
+			"\n" +
+			"                        if ( s>=0 ) return s;\n" +
+			"                        break;\n" +
 			"            }\n" + 
 			"            NoViableAltException nvae =\n" + 
 			"                new NoViableAltException(getDescription(), 12, _s, input);\n" + 
@@ -102,6 +139,18 @@ public class LexerSpecialStateTransitionSplitterTest extends Assert {
 			"                        s = specialStateTransition1(input); \n" +
 			"                        if ( s>=0 ) return s;\n" + 
 			"                        break;\n" +
+			"                    case 2 : \n" +
+			"                        s = specialStateTransition2(input); \n" +
+			"                        if ( s>=0 ) return s;\n" +
+			"                        break;\n" +
+			"                    case 3 : \n" +
+			"                        s = specialStateTransition3(input); \n" +
+			"                        if ( s>=0 ) return s;\n" +
+			"                        break;\n" +
+			"                    case 4 : \n" +
+			"                        s = specialStateTransition4(input); \n" +
+			"                        if ( s>=0 ) return s;\n" +
+			"                        break;\n" +
 			"            }\n" + 
 			"            NoViableAltException nvae =\n" + 
 			"                new NoViableAltException(getDescription(), 12, _s, input);\n" + 
@@ -123,10 +172,142 @@ public class LexerSpecialStateTransitionSplitterTest extends Assert {
 			"            else s = 50;\n" +
 			"            return s;\n" +
 			"        }\n" +
-			"\n" +  
+			"        protected int specialStateTransition2(IntStream input) {\n" +
+			"            int s = -1;\n" +
+			"            int LA12_0 = input.LA(1);\n" +
+			"            if ( (LA12_0=='+'||LA12_0=='-') && (( currentState() == State.STATE_A ))) {s = 125;}\n" +
+			"            else if ( ((LA12_0>='0' && LA12_0<='9')) && (( currentState() == State.STATE_A ))) {s = 126;}\n" +
+			"            else if ( (LA12_0=='.') && (( currentState() == State.STATE_A ))) {s = 127;}\n" +
+			"            return s;\n" +
+			"        }\n" +
+			"        protected int specialStateTransition3(IntStream input) {\n" +
+			"            int s = -1;\n" +
+			"            int LA12_2 = input.LA(1);\n" +
+			"            if ( (LA12_2=='.') && (( currentState() == State.STATE_A ))) {s = 128;}\n" +
+			"            else if ( ((LA12_2>='0' && LA12_2<='9')) && (( currentState() == State.STATE_A ))) {s = 126;}\n" +
+			"            else if ( (LA12_2=='E'||LA12_2=='e') && (( currentState() == State.STATE_A ))) {s = 128;}\n" +
+			"            return s;\n" +
+			"        }\n" +
+			"        protected int specialStateTransition4(IntStream input) {\n" +
+			"            int s = -1;\n" +
+			"            int LA12_1 = input.LA(1);\n" +
+			"            if ( ((LA12_1>='0' && LA12_1<='9')) && (( currentState() == State.STATE_A ))) {s = 126;}\n" +
+			"            else if ( (LA12_1=='.') && (( currentState() == State.STATE_A ))) {s = 127;}\n" +
+			"            else if ( (LA12_1=='+'||LA12_1=='-') && (( currentState() == State.STATE_A ))) {s = 125;}\n" +
+			"            return s;\n" +
+			"        }\n" +
+			"\n" +
 			"    }\n" +
 			"}";
 	
+	private String transformedSpecialStateSplit = "public class InternalMyDslLexer extends Lexer {\n" +
+			"    static class DFA12 extends DFA {\n" +
+			"\n" +
+			"        public DFA12(BaseRecognizer recognizer) {\n" +
+			"            this.recognizer = recognizer;\n" +
+			"            this.decisionNumber = 12;\n" +
+			"            this.eot = DFA12_eot;\n" +
+			"            this.eof = DFA12_eof;\n" +
+			"            this.min = DFA12_min;\n" +
+			"            this.max = DFA12_max;\n" +
+			"            this.accept = DFA12_accept;\n" +
+			"            this.special = DFA12_special;\n" +
+			"            this.transition = DFA12_transition;\n" +
+			"        }\n" +
+			"        public String getDescription() {\n" +
+			"            return \"1:1: Tokens : ( T__11 | T__12 | T__13 | T__14 | T__15 | T__16 | T__17 | T__18 | T__19 | T__20 | T__21 | T__22 | T__23 | T__24 | T__25 | T__26 | T__27 | T__28 | T__29 | T__30 | T__31 | T__32 | T__33 | T__34 | T__35 | T__36 | T__37 | T__38 | T__39 | T__40 | T__41 | T__42 | T__43 | T__44 | T__45 | T__46 | T__47 | T__48 | T__49 | T__50 | T__51 | T__52 | T__53 | T__54 | T__55 | T__56 | T__57 | T__58 | T__59 | T__60 | T__61 | T__62 | T__63 | T__64 | T__65 | T__66 | T__67 | T__68 | T__69 | T__70 | T__71 | T__72 | T__73 | T__74 | T__75 | T__76 | T__77 | T__78 | T__79 | T__80 | T__81 | T__82 | T__83 | T__84 | T__85 | T__86 | T__87 | T__88 | T__89 | T__90 | T__91 | T__92 | T__93 | T__94 | T__95 | T__96 | T__97 | T__98 | T__99 | T__100 | T__101 | T__102 | T__103 | T__104 | T__105 | T__106 | T__107 | T__108 | T__109 | T__110 | T__111 | T__112 | T__113 | T__114 | T__115 | T__116 | T__117 | T__118 | T__119 | T__120 | T__121 | T__122 | T__123 | T__124 | T__125 | T__126 | T__127 | T__128 | T__129 | T__130 | T__131 | T__132 | T__133 | T__134 | T__135 | T__136 | T__137 | T__138 | T__139 | T__140 | T__141 | T__142 | T__143 | T__144 | T__145 | T__146 | T__147 | T__148 | T__149 | T__150 | T__151 | T__152 | T__153 | T__154 | T__155 | T__156 | T__157 | T__158 | T__159 | T__160 | T__161 | T__162 | T__163 | T__164 | T__165 | T__166 | T__167 | T__168 | T__169 | T__170 | T__171 | T__172 | T__173 | T__174 | T__175 | T__176 | T__177 | T__178 | T__179 | T__180 | T__181 | T__182 | T__183 | T__184 | T__185 | T__186 | T__187 | T__188 | RULE_ID | RULE_INT | RULE_STRING | RULE_ML_COMMENT | RULE_SL_COMMENT | RULE_WS | RULE_ANY_OTHER );\";\n" +
+			"        }\n" +
+			"        public int specialStateTransition(int s, IntStream _input) throws NoViableAltException {\n" +
+			"            IntStream input = _input;\n" +
+			"        \tint _s = s;\n" +
+			"            \n" +
+			"            s = specialStateTransitionFrom0To2( _s, input );\n" +
+			"            if ( s >= 0 ) return s;\n" +
+			"            s = specialStateTransitionFrom3To4( _s, input );\n" +
+			"            if ( s >= 0 ) return s;\n" +
+			"\n" +
+			"            NoViableAltException nvae =\n" +
+			"                new NoViableAltException(getDescription(), 12, _s, input);\n" +
+			"            error(nvae);\n" +
+			"            throw nvae;\n" +
+			"        }\n" +
+			"        protected int specialStateTransitionFrom0To2(int s, IntStream input) {\n" +
+			"            int _s = s;\n" +
+			"            switch( s ) {\n" +
+			"                    case 0 : \n" +
+			"                        s = specialStateTransition0(input); \n" +
+			"                        if ( s>=0 ) return s;\n" +
+			"                        break;\n" +
+			"                    case 1 : \n" +
+			"                        s = specialStateTransition1(input); \n" +
+			"                        if ( s>=0 ) return s;\n" +
+			"                        break;\n" +
+			"                    case 2 : \n" +
+			"                        s = specialStateTransition2(input); \n" +
+			"                        if ( s>=0 ) return s;\n" +
+			"                        break;\n" +
+			"            }\n" +
+			"            return -1;\n" +
+			"        }\n" +
+			"\n" +
+			"        protected int specialStateTransitionFrom3To4(int s, IntStream input) {\n" +
+			"            int _s = s;\n" +
+			"            switch( s ) {\n" +
+			"                    case 3 : \n" +
+			"                        s = specialStateTransition3(input); \n" +
+			"                        if ( s>=0 ) return s;\n" +
+			"                        break;\n" +
+			"                    case 4 : \n" +
+			"                        s = specialStateTransition4(input); \n" +
+			"                        if ( s>=0 ) return s;\n" +
+			"                        break;\n" +
+			"            }\n" +
+			"            return -1;\n" +
+			"        }\n" +
+			"\n" +
+			"        protected int specialStateTransition0(IntStream input) {\n" +
+			"            int s = -1;\n" +
+			"            int LA12_144 = input.LA(1);\n" +
+			"            if ( (LA12_144=='p') ) {s = 276;}\n" +
+			"            else if ( ((LA12_144>='\\u0000' && LA12_144<='o')||(LA12_144>='q' && LA12_144<='$')) ) {s = 51;}\n" +
+			"            return s;\n" +
+			"        }\n" +
+			"        protected int specialStateTransition1(IntStream input) {\n" +
+			"            int s = -1;\n" +
+			"            int LA12_176 = input.LA(1);\n" +
+			"            if ( (LA12_176=='t') ) {s = 306;}\n" +
+			"            else if ( ((LA12_176>='\\u0000' && LA12_176<='s')||(LA12_176>='u' && LA12_176<='\\uFFFF')) ) {s = 51;}\n" +
+			"            else s = 50;\n" +
+			"            return s;\n" +
+			"        }\n" +
+			"        protected int specialStateTransition2(IntStream input) {\n" +
+			"            int s = -1;\n" +
+			"            int LA12_0 = input.LA(1);\n" +
+			"            if ( (LA12_0=='+'||LA12_0=='-') && (( currentState() == State.STATE_A ))) {s = 125;}\n" +
+			"            else if ( ((LA12_0>='0' && LA12_0<='9')) && (( currentState() == State.STATE_A ))) {s = 126;}\n" +
+			"            else if ( (LA12_0=='.') && (( currentState() == State.STATE_A ))) {s = 127;}\n" +
+			"            return s;\n" +
+			"        }\n" +
+			"        protected int specialStateTransition3(IntStream input) {\n" +
+			"            int s = -1;\n" +
+			"            int LA12_2 = input.LA(1);\n" +
+			"            if ( (LA12_2=='.') && (( currentState() == State.STATE_A ))) {s = 128;}\n" +
+			"            else if ( ((LA12_2>='0' && LA12_2<='9')) && (( currentState() == State.STATE_A ))) {s = 126;}\n" +
+			"            else if ( (LA12_2=='E'||LA12_2=='e') && (( currentState() == State.STATE_A ))) {s = 128;}\n" +
+			"            return s;\n" +
+			"        }\n" +
+			"        protected int specialStateTransition4(IntStream input) {\n" +
+			"            int s = -1;\n" +
+			"            int LA12_1 = input.LA(1);\n" +
+			"            if ( ((LA12_1>='0' && LA12_1<='9')) && (( currentState() == State.STATE_A ))) {s = 126;}\n" +
+			"            else if ( (LA12_1=='.') && (( currentState() == State.STATE_A ))) {s = 127;}\n" +
+			"            else if ( (LA12_1=='+'||LA12_1=='-') && (( currentState() == State.STATE_A ))) {s = 125;}\n" +
+			"            return s;\n" +
+			"        }\n" +
+			"\n" +
+			"    }\n" +
+			"}";
+
 	private LexerSpecialStateTransitionSplitter testMe;
 
 	@Before
@@ -145,4 +326,15 @@ public class LexerSpecialStateTransitionSplitterTest extends Assert {
 		assertEquals(transformed, actual);
 	}
 	
+	@Test public void testSpecialStateSwitchTransformation(){
+		int tmpCasesLimit = testMe.getCasesPerSpecialStateSwitch();
+		
+		testMe.setCasesPerSpecialStateSwitch(3);
+		String actualSpecialStateSwitchSplit = testMe.transform(original);
+		assertEquals(transformedSpecialStateSplit,actualSpecialStateSwitchSplit);
+		
+		testMe.setCasesPerSpecialStateSwitch(tmpCasesLimit);
+	}
+
+
 }

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/parser/splitting/LexerSpecialStateTransitionSplitterTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/parser/splitting/LexerSpecialStateTransitionSplitterTest.java
@@ -329,6 +329,7 @@ public class LexerSpecialStateTransitionSplitterTest extends Assert {
 	@Test public void testSpecialStateSwitchTransformation(){
 		int tmpCasesLimit = testMe.getCasesPerSpecialStateSwitch();
 		
+		testMe.setSpecialStateSwitchSplitting(true);
 		testMe.setCasesPerSpecialStateSwitch(3);
 		String actualSpecialStateSwitchSplit = testMe.transform(original);
 		assertEquals(transformedSpecialStateSplit,actualSpecialStateSwitchSplit);


### PR DESCRIPTION
Switch in lexer in specialStateTransition can get really big, even after pulling code from case statements into separate methods.

Somewhere slightly over 1500 cases the specialStateTransition method can exceed 64kB limit. 

Implemented transformation will split such a method into several methods with defined maximal number of case statements (1000 by default).

Signed-off-by: Jan Sebechlebsky <jan.sebechlebsky@cz.ibm.com>