### PR TITLE
Update 103_domainmodelnextsteps.md

### DIFF
--- a/xtext-website/documentation/103_domainmodelnextsteps.md
+++ b/xtext-website/documentation/103_domainmodelnextsteps.md
@@ -355,12 +355,18 @@ The second validation rule is straight-forward, too. We traverse the inheritance
 ```xtend
 @Check
 def void checkFeatureNameIsUnique(Feature f) {
-	var superEntity = (f.eContainer() as Entity).getSuperType();
+	var superEntity = f.eContainer() as Entity
+	
+	var once = false
 	while (superEntity != null) {
 		for (other : superEntity.getFeatures()) {
 			if (f.getName().equals(other.getName())) {
-				error("Feature names have to be unique", DomainmodelPackage$Literals::FEATURE__NAME);
-				return;
+				if (!once) {
+					once = true
+				} else {
+					error("Feature names have to be unique", DomainmodelPackage$Literals::FEATURE__NAME);
+					return;
+				}
 			}
 		}
 		superEntity = superEntity.getSuperType();


### PR DESCRIPTION
There is a bug in the example.

First when you use `getSuperType()` then `superEntity` is always null.
Second there is always at least one feature with such name, so you should skip at least _once_.

May be it's not the most beautiful solution, but it works :)