### PR TITLE
[generator] Old SyntheticTerminalDetector inherits the new copy

### DIFF
--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/serializer/SerializerFragment.xtend
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/serializer/SerializerFragment.xtend
@@ -23,13 +23,13 @@ import org.eclipse.xtext.generator.Xtend2ExecutionContext
 import org.eclipse.xtext.generator.Xtend2GeneratorFragment
 import org.eclipse.xtext.generator.adapter.Generator2AdapterSetup
 import org.eclipse.xtext.generator.parser.antlr.ex.wsAware.SyntheticTerminalAwareFragmentHelper
+import org.eclipse.xtext.generator.terminals.SyntheticTerminalDetector
 import org.eclipse.xtext.parser.antlr.AbstractSplittingTokenSource
 import org.eclipse.xtext.serializer.ISerializer
 import org.eclipse.xtext.serializer.impl.Serializer
 import org.eclipse.xtext.serializer.sequencer.ISemanticSequencer
 import org.eclipse.xtext.serializer.sequencer.ISyntacticSequencer
 import org.eclipse.xtext.xtext.generator.serializer.SerializerFragment2
-import org.eclipse.xtext.xtext.generator.util.SyntheticTerminalDetector
 
 import static java.util.Collections.*
 

--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/terminals/SyntheticTerminalDetector.java
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/terminals/SyntheticTerminalDetector.java
@@ -7,10 +7,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.generator.terminals;
 
-import org.eclipse.xtext.Keyword;
-import org.eclipse.xtext.TerminalRule;
-import org.eclipse.xtext.generator.parser.antlr.AntlrGrammarGenUtil;
-
 /**
  * Helper to identify synthetic terminal rules.
  * 
@@ -20,19 +16,6 @@ import org.eclipse.xtext.generator.parser.antlr.AntlrGrammarGenUtil;
  * @author Sebastian Zarnekow - Initial contribution and API
  * @since 2.8
  */
-public class SyntheticTerminalDetector {
+public class SyntheticTerminalDetector extends org.eclipse.xtext.xtext.generator.util.SyntheticTerminalDetector {
 
-	/**
-	 * Answers {@code true} if the given terminal rule is synthetic. That is,
-	 * the tokens for this rule will not be produced by the generated Antlr lexer
-	 * but manually in a custom token source.
-	 */
-	public boolean isSyntheticTerminalRule(TerminalRule rule) {
-		if (rule.getAlternatives() instanceof Keyword) {
-			String value = ((Keyword) rule.getAlternatives()).getValue();
-			return ("synthetic:" + AntlrGrammarGenUtil.getOriginalElement(rule).getName()).equals(value);
-		}
-		return false;
-	}
-	
 }

--- a/plugins/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/serializer/SerializerFragment.java
+++ b/plugins/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/serializer/SerializerFragment.java
@@ -30,6 +30,7 @@ import org.eclipse.xtext.generator.Xtend2GeneratorFragment;
 import org.eclipse.xtext.generator.adapter.Generator2AdapterSetup;
 import org.eclipse.xtext.generator.parser.antlr.ex.wsAware.SyntheticTerminalAwareFragmentHelper;
 import org.eclipse.xtext.generator.serializer.SerializerGenFileNames;
+import org.eclipse.xtext.generator.terminals.SyntheticTerminalDetector;
 import org.eclipse.xtext.parser.antlr.AbstractSplittingTokenSource;
 import org.eclipse.xtext.serializer.ISerializer;
 import org.eclipse.xtext.serializer.impl.Serializer;
@@ -39,7 +40,6 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.serializer.SerializerFragment2;
-import org.eclipse.xtext.xtext.generator.util.SyntheticTerminalDetector;
 
 /**
  * @author Moritz Eyshold - Initial contribution and API


### PR DESCRIPTION
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=479919