### PR TITLE
[xtext generator] Extracted the composition of the generated validator classes' names

### DIFF
--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.xtend
@@ -16,8 +16,9 @@ import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
 import org.eclipse.xtext.xtext.generator.model.TypeReference
-import org.eclipse.xtext.xtext.generator.validation.ValidatorFragment2
+import org.eclipse.xtext.xtext.generator.validation.ValidatorNaming
 
+import static extension org.eclipse.xtext.GrammarUtil.*
 import static extension org.eclipse.xtext.xtext.generator.util.GrammarUtil2.*
 
 /**
@@ -34,7 +35,7 @@ class QuickfixProviderFragment2 extends AbstractGeneratorFragment2 {
 	extension CodeConfig
 	
 	@Inject
-	extension ValidatorFragment2
+	extension ValidatorNaming
 
 	@Inject
 	FileAccessFactory fileAccessFactory

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.xtend
@@ -30,6 +30,7 @@ import static extension org.eclipse.xtext.xtext.generator.util.GrammarUtil2.*
 
 class ValidatorFragment2 extends AbstractGeneratorFragment2 {
 	
+	@Inject extension ValidatorNaming
 	@Inject extension XtextGeneratorNaming
 	@Inject FileAccessFactory fileAccessFactory
 	@Inject CodeConfig codeConfig
@@ -50,18 +51,6 @@ class ValidatorFragment2 extends AbstractGeneratorFragment2 {
 	 */
 	def void addComposedCheck(String composedCheckValidator) {
 		composedChecks += composedCheckValidator
-	}
-	
-	/**
-	 * @return a {@link TypeReference} wrapping the desired validator class' simple name and package name
-	 */
-	public def TypeReference getValidatorClass(Grammar grammar) {
-		// is public for being callable by QuickFixProviderFragement2
-		new TypeReference(grammar.runtimeBasePackage + '.validation.' + getSimpleName(grammar) + 'Validator')
-	}
-	
-	protected def TypeReference getAbstractValidatorClass(Grammar grammar) {
-		new TypeReference(grammar.runtimeBasePackage + '.validation.Abstract' + getSimpleName(grammar) + 'Validator')
 	}
 	
 	protected def TypeReference getValidatorSuperClass(Grammar grammar) {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/validation/ValidatorNaming.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/validation/ValidatorNaming.xtend
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xtext.generator.validation
+
+import com.google.inject.Inject
+import org.eclipse.xtext.Grammar
+import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
+import org.eclipse.xtext.xtext.generator.model.TypeReference
+
+import static extension org.eclipse.xtext.GrammarUtil.*
+
+/**
+ * Separates the composition of the generated validator classes' names from
+ *  the template of those classes (which may be specialized by clients),
+ *  since the name is used in the template of the generated quickfix provider classes, too.
+ * 
+ * @author Christian Schneider - Initial contribution and API
+ */
+class ValidatorNaming {
+
+	@Inject
+	extension XtextGeneratorNaming
+	
+	public def TypeReference getValidatorClass(Grammar grammar) {
+		new TypeReference(grammar.runtimeBasePackage + '.validation.' + grammar.simpleName + 'Validator')
+	}
+	
+	protected def TypeReference getAbstractValidatorClass(Grammar grammar) {
+		new TypeReference(grammar.runtimeBasePackage + '.validation.Abstract' + grammar.simpleName + 'Validator')
+	}
+}

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.java
@@ -33,7 +33,7 @@ import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 import org.eclipse.xtext.xtext.generator.model.XtendFileAccess;
 import org.eclipse.xtext.xtext.generator.util.GrammarUtil2;
-import org.eclipse.xtext.xtext.generator.validation.ValidatorFragment2;
+import org.eclipse.xtext.xtext.generator.validation.ValidatorNaming;
 
 /**
  * Contributes the Quickfix provider stub, either in Xtend or Java language.
@@ -52,7 +52,7 @@ public class QuickfixProviderFragment2 extends AbstractGeneratorFragment2 {
   
   @Inject
   @Extension
-  private ValidatorFragment2 _validatorFragment2;
+  private ValidatorNaming _validatorNaming;
   
   @Inject
   private FileAccessFactory fileAccessFactory;
@@ -193,7 +193,7 @@ public class QuickfixProviderFragment2 extends AbstractGeneratorFragment2 {
         _builder.newLine();
         _builder.append("//\t@Fix(");
         Grammar _grammar_2 = QuickfixProviderFragment2.this.getGrammar();
-        TypeReference _validatorClass = QuickfixProviderFragment2.this._validatorFragment2.getValidatorClass(_grammar_2);
+        TypeReference _validatorClass = QuickfixProviderFragment2.this._validatorNaming.getValidatorClass(_grammar_2);
         _builder.append(_validatorClass, "");
         _builder.append(".INVALID_NAME)");
         _builder.newLineIfNotEmpty();
@@ -258,7 +258,7 @@ public class QuickfixProviderFragment2 extends AbstractGeneratorFragment2 {
         _builder.newLine();
         _builder.append("//\t@Fix(");
         Grammar _grammar_2 = QuickfixProviderFragment2.this.getGrammar();
-        TypeReference _validatorClass = QuickfixProviderFragment2.this._validatorFragment2.getValidatorClass(_grammar_2);
+        TypeReference _validatorClass = QuickfixProviderFragment2.this._validatorNaming.getValidatorClass(_grammar_2);
         _builder.append(_validatorClass, "");
         _builder.append(".INVALID_NAME)");
         _builder.newLineIfNotEmpty();

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.java
@@ -47,9 +47,14 @@ import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 import org.eclipse.xtext.xtext.generator.model.XtendFileAccess;
 import org.eclipse.xtext.xtext.generator.util.GrammarUtil2;
+import org.eclipse.xtext.xtext.generator.validation.ValidatorNaming;
 
 @SuppressWarnings("all")
 public class ValidatorFragment2 extends AbstractGeneratorFragment2 {
+  @Inject
+  @Extension
+  private ValidatorNaming _validatorNaming;
+  
   @Inject
   @Extension
   private XtextGeneratorNaming _xtextGeneratorNaming;
@@ -78,27 +83,6 @@ public class ValidatorFragment2 extends AbstractGeneratorFragment2 {
     this.composedChecks.add(composedCheckValidator);
   }
   
-  /**
-   * @return a {@link TypeReference} wrapping the desired validator class' simple name and package name
-   */
-  public TypeReference getValidatorClass(final Grammar grammar) {
-    String _runtimeBasePackage = this._xtextGeneratorNaming.getRuntimeBasePackage(grammar);
-    String _plus = (_runtimeBasePackage + ".validation.");
-    String _simpleName = GrammarUtil.getSimpleName(grammar);
-    String _plus_1 = (_plus + _simpleName);
-    String _plus_2 = (_plus_1 + "Validator");
-    return new TypeReference(_plus_2);
-  }
-  
-  protected TypeReference getAbstractValidatorClass(final Grammar grammar) {
-    String _runtimeBasePackage = this._xtextGeneratorNaming.getRuntimeBasePackage(grammar);
-    String _plus = (_runtimeBasePackage + ".validation.Abstract");
-    String _simpleName = GrammarUtil.getSimpleName(grammar);
-    String _plus_1 = (_plus + _simpleName);
-    String _plus_2 = (_plus_1 + "Validator");
-    return new TypeReference(_plus_2);
-  }
-  
   protected TypeReference getValidatorSuperClass(final Grammar grammar) {
     TypeReference _xblockexpression = null;
     {
@@ -111,7 +95,7 @@ public class ValidatorFragment2 extends AbstractGeneratorFragment2 {
         _and = (superGrammar != null);
       }
       if (_and) {
-        _xifexpression = this.getValidatorClass(superGrammar);
+        _xifexpression = this._validatorNaming.getValidatorClass(superGrammar);
       } else {
         _xifexpression = this.getDefaultValidatorSuperClass();
       }
@@ -129,15 +113,15 @@ public class ValidatorFragment2 extends AbstractGeneratorFragment2 {
     final GuiceModuleAccess.BindingFactory bindingFactory = new GuiceModuleAccess.BindingFactory();
     if (this.generateStub) {
       Grammar _grammar = this.getGrammar();
-      TypeReference _validatorClass = this.getValidatorClass(_grammar);
+      TypeReference _validatorClass = this._validatorNaming.getValidatorClass(_grammar);
       Grammar _grammar_1 = this.getGrammar();
-      TypeReference _validatorClass_1 = this.getValidatorClass(_grammar_1);
+      TypeReference _validatorClass_1 = this._validatorNaming.getValidatorClass(_grammar_1);
       bindingFactory.addTypeToTypeEagerSingleton(_validatorClass, _validatorClass_1);
     } else {
       Grammar _grammar_2 = this.getGrammar();
-      TypeReference _abstractValidatorClass = this.getAbstractValidatorClass(_grammar_2);
+      TypeReference _abstractValidatorClass = this._validatorNaming.getAbstractValidatorClass(_grammar_2);
       Grammar _grammar_3 = this.getGrammar();
-      TypeReference _abstractValidatorClass_1 = this.getAbstractValidatorClass(_grammar_3);
+      TypeReference _abstractValidatorClass_1 = this._validatorNaming.getAbstractValidatorClass(_grammar_3);
       bindingFactory.addTypeToTypeEagerSingleton(_abstractValidatorClass, _abstractValidatorClass_1);
     }
     ILanguageConfig _language = this.getLanguage();
@@ -162,7 +146,7 @@ public class ValidatorFragment2 extends AbstractGeneratorFragment2 {
       ManifestAccess _manifest_1 = _runtime_1.getManifest();
       Set<String> _exportedPackages = _manifest_1.getExportedPackages();
       Grammar _grammar_4 = this.getGrammar();
-      TypeReference _validatorClass_2 = this.getValidatorClass(_grammar_4);
+      TypeReference _validatorClass_2 = this._validatorNaming.getValidatorClass(_grammar_4);
       String _packageName = _validatorClass_2.getPackageName();
       _exportedPackages.add(_packageName);
     }
@@ -177,7 +161,7 @@ public class ValidatorFragment2 extends AbstractGeneratorFragment2 {
   
   protected void generateXtendValidatorStub() {
     Grammar _grammar = this.getGrammar();
-    TypeReference _validatorClass = this.getValidatorClass(_grammar);
+    TypeReference _validatorClass = this._validatorNaming.getValidatorClass(_grammar);
     StringConcatenationClient _client = new StringConcatenationClient() {
       @Override
       protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
@@ -200,12 +184,12 @@ public class ValidatorFragment2 extends AbstractGeneratorFragment2 {
         _builder.newLine();
         _builder.append("class ");
         Grammar _grammar = ValidatorFragment2.this.getGrammar();
-        TypeReference _validatorClass = ValidatorFragment2.this.getValidatorClass(_grammar);
+        TypeReference _validatorClass = ValidatorFragment2.this._validatorNaming.getValidatorClass(_grammar);
         String _simpleName = _validatorClass.getSimpleName();
         _builder.append(_simpleName, "");
         _builder.append(" extends ");
         Grammar _grammar_1 = ValidatorFragment2.this.getGrammar();
-        TypeReference _abstractValidatorClass = ValidatorFragment2.this.getAbstractValidatorClass(_grammar_1);
+        TypeReference _abstractValidatorClass = ValidatorFragment2.this._validatorNaming.getAbstractValidatorClass(_grammar_1);
         _builder.append(_abstractValidatorClass, "");
         _builder.append(" {");
         _builder.newLineIfNotEmpty();
@@ -246,7 +230,7 @@ public class ValidatorFragment2 extends AbstractGeneratorFragment2 {
   
   protected void generateJavaValidatorStub() {
     Grammar _grammar = this.getGrammar();
-    TypeReference _validatorClass = this.getValidatorClass(_grammar);
+    TypeReference _validatorClass = this._validatorNaming.getValidatorClass(_grammar);
     StringConcatenationClient _client = new StringConcatenationClient() {
       @Override
       protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
@@ -269,12 +253,12 @@ public class ValidatorFragment2 extends AbstractGeneratorFragment2 {
         _builder.newLine();
         _builder.append("public class ");
         Grammar _grammar = ValidatorFragment2.this.getGrammar();
-        TypeReference _validatorClass = ValidatorFragment2.this.getValidatorClass(_grammar);
+        TypeReference _validatorClass = ValidatorFragment2.this._validatorNaming.getValidatorClass(_grammar);
         String _simpleName = _validatorClass.getSimpleName();
         _builder.append(_simpleName, "");
         _builder.append(" extends ");
         Grammar _grammar_1 = ValidatorFragment2.this.getGrammar();
-        TypeReference _abstractValidatorClass = ValidatorFragment2.this.getAbstractValidatorClass(_grammar_1);
+        TypeReference _abstractValidatorClass = ValidatorFragment2.this._validatorNaming.getAbstractValidatorClass(_grammar_1);
         _builder.append(_abstractValidatorClass, "");
         _builder.append(" {");
         _builder.newLineIfNotEmpty();
@@ -307,7 +291,7 @@ public class ValidatorFragment2 extends AbstractGeneratorFragment2 {
   
   protected void generateAbstractValidator() {
     Grammar _grammar = this.getGrammar();
-    TypeReference _abstractValidatorClass = this.getAbstractValidatorClass(_grammar);
+    TypeReference _abstractValidatorClass = this._validatorNaming.getAbstractValidatorClass(_grammar);
     final GeneratedJavaFileAccess javaFile = this.fileAccessFactory.createGeneratedJavaFile(_abstractValidatorClass);
     StringConcatenationClient _client = new StringConcatenationClient() {
       @Override
@@ -344,7 +328,7 @@ public class ValidatorFragment2 extends AbstractGeneratorFragment2 {
         }
         _builder.append("class ");
         Grammar _grammar = ValidatorFragment2.this.getGrammar();
-        TypeReference _abstractValidatorClass = ValidatorFragment2.this.getAbstractValidatorClass(_grammar);
+        TypeReference _abstractValidatorClass = ValidatorFragment2.this._validatorNaming.getAbstractValidatorClass(_grammar);
         String _simpleName = _abstractValidatorClass.getSimpleName();
         _builder.append(_simpleName, "");
         _builder.append(" extends ");

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/validation/ValidatorNaming.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/validation/ValidatorNaming.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xtext.generator.validation;
+
+import com.google.inject.Inject;
+import org.eclipse.xtext.Grammar;
+import org.eclipse.xtext.GrammarUtil;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
+import org.eclipse.xtext.xtext.generator.model.TypeReference;
+
+/**
+ * Separates the composition of the generated validator classes' names from
+ *  the template of those classes (which may be specialized by clients),
+ *  since the name is used in the template of the generated quickfix provider classes, too.
+ * 
+ * @author Christian Schneider - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class ValidatorNaming {
+  @Inject
+  @Extension
+  private XtextGeneratorNaming _xtextGeneratorNaming;
+  
+  public TypeReference getValidatorClass(final Grammar grammar) {
+    String _runtimeBasePackage = this._xtextGeneratorNaming.getRuntimeBasePackage(grammar);
+    String _plus = (_runtimeBasePackage + ".validation.");
+    String _simpleName = GrammarUtil.getSimpleName(grammar);
+    String _plus_1 = (_plus + _simpleName);
+    String _plus_2 = (_plus_1 + "Validator");
+    return new TypeReference(_plus_2);
+  }
+  
+  protected TypeReference getAbstractValidatorClass(final Grammar grammar) {
+    String _runtimeBasePackage = this._xtextGeneratorNaming.getRuntimeBasePackage(grammar);
+    String _plus = (_runtimeBasePackage + ".validation.Abstract");
+    String _simpleName = GrammarUtil.getSimpleName(grammar);
+    String _plus_1 = (_plus + _simpleName);
+    String _plus_2 = (_plus_1 + "Validator");
+    return new TypeReference(_plus_2);
+  }
+}


### PR DESCRIPTION
... from 'ValidatorFragment2' to 'ValidatorNaming'm updated 'QuickfixProviderFragment2' correspondingly.

This is just a follow-up on the migration of the 'QuickfixProviderFragment', which has been suggested by @oehme

Signed-off-by: Christian Schneider <christian.schneider@itemis.de>