### PR TITLE
[480118] Fixed regression in new grammar access fragment

### DIFF
--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.xtend
@@ -81,7 +81,7 @@ class GrammarAccessExtensions {
 	}
 
 	/**
-	 * Converts an arbitary string to a valid Java identifier.
+	 * Converts an arbitary string to a valid Java identifier that is valid in an Antlr grammar action context, too.
 	 * The string is split up along the the characters that are not valid as java 
 	 * identifier. The first character of each segments is made upper case which 
 	 * leads to a camel-case style.
@@ -133,7 +133,7 @@ class GrammarAccessExtensions {
 		var up = true
 		val builder = new StringBuilder
 		for (c : text.toCharArray) {
-			val valid = if (start) c.isJavaIdentifierStart else c.isJavaIdentifierPart
+			val valid = c.isValidJavaLatinIdentifier(start)
 			if (valid) {
 				if (start)
 					builder.append(if (uppercaseFirst) c.toUpperCase else c.toLowerCase)
@@ -145,6 +145,21 @@ class GrammarAccessExtensions {
 				up = true
 		}
 		return builder.toString
+	}
+	
+	def boolean isValidJavaLatinIdentifier(char c, boolean start) {
+		var boolean valid = c >= 'A' && c<= 'Z';
+		valid = valid || c >= 'a' && c<= 'z';
+		valid = valid || c.eq('ä') || c.eq('ö') || c.eq('ü') || c.eq('Ä') || c.eq('Ö') || c.eq('Ü');
+		valid = valid || c.eq('_');
+		if (!start) {
+			valid = valid || c>='0' && c<='9';
+		}
+		return valid;
+	}
+	
+	private def static eq(char c1, char c2) {
+		c1 == c2
 	}
 		
 	/** 

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.java
@@ -135,7 +135,7 @@ public class GrammarAccessExtensions {
   }
   
   /**
-   * Converts an arbitary string to a valid Java identifier.
+   * Converts an arbitary string to a valid Java identifier that is valid in an Antlr grammar action context, too.
    * The string is split up along the the characters that are not valid as java
    * identifier. The first character of each segments is made upper case which
    * leads to a camel-case style.
@@ -213,30 +213,24 @@ public class GrammarAccessExtensions {
     char[] _charArray = text.toCharArray();
     for (final char c : _charArray) {
       {
-        boolean _xifexpression = false;
-        if (start) {
-          _xifexpression = Character.isJavaIdentifierStart(c);
-        } else {
-          _xifexpression = Character.isJavaIdentifierPart(c);
-        }
-        final boolean valid = _xifexpression;
+        final boolean valid = this.isValidJavaLatinIdentifier(c, start);
         if (valid) {
           if (start) {
-            char _xifexpression_1 = (char) 0;
+            char _xifexpression = (char) 0;
             if (uppercaseFirst) {
+              _xifexpression = Character.toUpperCase(c);
+            } else {
+              _xifexpression = Character.toLowerCase(c);
+            }
+            builder.append(_xifexpression);
+          } else {
+            char _xifexpression_1 = (char) 0;
+            if (up) {
               _xifexpression_1 = Character.toUpperCase(c);
             } else {
-              _xifexpression_1 = Character.toLowerCase(c);
+              _xifexpression_1 = c;
             }
             builder.append(_xifexpression_1);
-          } else {
-            char _xifexpression_2 = (char) 0;
-            if (up) {
-              _xifexpression_2 = Character.toUpperCase(c);
-            } else {
-              _xifexpression_2 = c;
-            }
-            builder.append(_xifexpression_2);
           }
           up = false;
           start = false;
@@ -246,6 +240,70 @@ public class GrammarAccessExtensions {
       }
     }
     return builder.toString();
+  }
+  
+  public boolean isValidJavaLatinIdentifier(final char c, final boolean start) {
+    boolean valid = ((c >= 'A') && (c <= 'Z'));
+    valid = (valid || ((c >= 'a') && (c <= 'z')));
+    boolean _or = false;
+    boolean _or_1 = false;
+    boolean _or_2 = false;
+    boolean _or_3 = false;
+    boolean _or_4 = false;
+    boolean _or_5 = false;
+    if (valid) {
+      _or_5 = true;
+    } else {
+      boolean _eq = GrammarAccessExtensions.eq(c, 'ä');
+      _or_5 = _eq;
+    }
+    if (_or_5) {
+      _or_4 = true;
+    } else {
+      boolean _eq_1 = GrammarAccessExtensions.eq(c, 'ö');
+      _or_4 = _eq_1;
+    }
+    if (_or_4) {
+      _or_3 = true;
+    } else {
+      boolean _eq_2 = GrammarAccessExtensions.eq(c, 'ü');
+      _or_3 = _eq_2;
+    }
+    if (_or_3) {
+      _or_2 = true;
+    } else {
+      boolean _eq_3 = GrammarAccessExtensions.eq(c, 'Ä');
+      _or_2 = _eq_3;
+    }
+    if (_or_2) {
+      _or_1 = true;
+    } else {
+      boolean _eq_4 = GrammarAccessExtensions.eq(c, 'Ö');
+      _or_1 = _eq_4;
+    }
+    if (_or_1) {
+      _or = true;
+    } else {
+      boolean _eq_5 = GrammarAccessExtensions.eq(c, 'Ü');
+      _or = _eq_5;
+    }
+    valid = _or;
+    boolean _or_6 = false;
+    if (valid) {
+      _or_6 = true;
+    } else {
+      boolean _eq_6 = GrammarAccessExtensions.eq(c, '_');
+      _or_6 = _eq_6;
+    }
+    valid = _or_6;
+    if ((!start)) {
+      valid = (valid || ((c >= '0') && (c <= '9')));
+    }
+    return valid;
+  }
+  
+  private static boolean eq(final char c1, final char c2) {
+    return (c1 == c2);
   }
   
   /**

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/grammarAccess/GrammarAccessUtilTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/grammarAccess/GrammarAccessUtilTest.java
@@ -26,6 +26,7 @@ public class GrammarAccessUtilTest extends Assert {
 		assertEquals("Semicolon",toJavaIdentifier(";", false));
 		assertEquals("CommercialAtApostrophe",toJavaIdentifier("@'", false));
 		assertEquals("Grün",toJavaIdentifier("Grün", true));
+		assertEquals("DollarSign",toJavaIdentifier("$", true));
 	}
 	
 	/**

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/GrammarAccessExtensionsTest.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/generator/GrammarAccessExtensionsTest.xtend
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xtext.generator
+
+import org.junit.Test
+import static org.junit.Assert.*
+import org.eclipse.xtext.xtext.generator.grammarAccess.GrammarAccessExtensions
+
+/**
+ * @author Sebastian Zarnekow - Initial contribution and API
+ */
+class GrammarAccessExtensionsTest {
+	
+	extension GrammarAccessExtensions = new GrammarAccessExtensions  
+	
+	@Test def void testToJavaIdentifier() {
+		assertEquals("FooBar", toJavaIdentifier("foo Bar", true));
+		assertEquals("Foo", toJavaIdentifier("foo;", true));
+		assertEquals("foo", toJavaIdentifier("foo;", false));
+		assertEquals("Colon", toJavaIdentifier(":", true));
+		assertEquals("Colon", toJavaIdentifier(":", false));
+		assertEquals("Semicolon", toJavaIdentifier(";", false));
+		assertEquals("CommercialAtApostrophe", toJavaIdentifier("@'", false));
+		assertEquals("Grün", toJavaIdentifier("Grün", true));
+		assertEquals("DollarSign", toJavaIdentifier("$", true));
+		assertEquals("_", toJavaIdentifier("_", true));
+	}
+	
+	/**
+	 * see https://bugs.eclipse.org/bugs/show_bug.cgi?id=298492
+	 */
+	@Test def void testBug() throws Exception {
+		assertEquals("HiraganaLetterRu", toJavaIdentifier("\u308B",true));
+	}
+	
+	@Test def void testSmoke() throws Exception {
+		for (var int i = 0; i < 4000; i++) {
+			val identifier = toJavaIdentifier(String.valueOf(i as char), false)
+			
+			for (var int j = 0; j < identifier.length(); j++) {
+				val char charAt = identifier.charAt(j)
+				assertTrue(identifier+":"+charAt, charAt.isValidJavaLatinIdentifier(j==0))
+			}
+		}
+	}
+	
+}

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/GrammarAccessExtensionsTest.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/generator/GrammarAccessExtensionsTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xtext.generator;
+
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xtext.generator.grammarAccess.GrammarAccessExtensions;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Sebastian Zarnekow - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class GrammarAccessExtensionsTest {
+  @Extension
+  private GrammarAccessExtensions _grammarAccessExtensions = new GrammarAccessExtensions();
+  
+  @Test
+  public void testToJavaIdentifier() {
+    String _javaIdentifier = this._grammarAccessExtensions.toJavaIdentifier("foo Bar", true);
+    Assert.assertEquals("FooBar", _javaIdentifier);
+    String _javaIdentifier_1 = this._grammarAccessExtensions.toJavaIdentifier("foo;", true);
+    Assert.assertEquals("Foo", _javaIdentifier_1);
+    String _javaIdentifier_2 = this._grammarAccessExtensions.toJavaIdentifier("foo;", false);
+    Assert.assertEquals("foo", _javaIdentifier_2);
+    String _javaIdentifier_3 = this._grammarAccessExtensions.toJavaIdentifier(":", true);
+    Assert.assertEquals("Colon", _javaIdentifier_3);
+    String _javaIdentifier_4 = this._grammarAccessExtensions.toJavaIdentifier(":", false);
+    Assert.assertEquals("Colon", _javaIdentifier_4);
+    String _javaIdentifier_5 = this._grammarAccessExtensions.toJavaIdentifier(";", false);
+    Assert.assertEquals("Semicolon", _javaIdentifier_5);
+    String _javaIdentifier_6 = this._grammarAccessExtensions.toJavaIdentifier("@\'", false);
+    Assert.assertEquals("CommercialAtApostrophe", _javaIdentifier_6);
+    String _javaIdentifier_7 = this._grammarAccessExtensions.toJavaIdentifier("Grün", true);
+    Assert.assertEquals("Grün", _javaIdentifier_7);
+    String _javaIdentifier_8 = this._grammarAccessExtensions.toJavaIdentifier("$", true);
+    Assert.assertEquals("DollarSign", _javaIdentifier_8);
+    String _javaIdentifier_9 = this._grammarAccessExtensions.toJavaIdentifier("_", true);
+    Assert.assertEquals("_", _javaIdentifier_9);
+  }
+  
+  /**
+   * see https://bugs.eclipse.org/bugs/show_bug.cgi?id=298492
+   */
+  @Test
+  public void testBug() throws Exception {
+    String _javaIdentifier = this._grammarAccessExtensions.toJavaIdentifier("\u308b", true);
+    Assert.assertEquals("HiraganaLetterRu", _javaIdentifier);
+  }
+  
+  @Test
+  public void testSmoke() throws Exception {
+    for (int i = 0; (i < 4000); i++) {
+      {
+        String _valueOf = String.valueOf(((char) i));
+        final String identifier = this._grammarAccessExtensions.toJavaIdentifier(_valueOf, false);
+        for (int j = 0; (j < identifier.length()); j++) {
+          {
+            final char charAt = identifier.charAt(j);
+            boolean _isValidJavaLatinIdentifier = this._grammarAccessExtensions.isValidJavaLatinIdentifier(charAt, (j == 0));
+            Assert.assertTrue(((identifier + ":") + Character.valueOf(charAt)), _isValidJavaLatinIdentifier);
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Not all valid java identifiers are valid in Antlr
action contexts.