### PR TITLE
remove dependency from o.e.xtext to org.eclipse.equinox.common

### DIFF
--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/DefaultUiModule.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/DefaultUiModule.java
@@ -42,6 +42,7 @@ import org.eclipse.xtext.resource.impl.LiveShadowedResourceDescriptions;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsProvider;
 import org.eclipse.xtext.service.AbstractGenericModule;
 import org.eclipse.xtext.service.DispatchingProvider;
+import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.service.SingletonBinding;
 import org.eclipse.xtext.ui.IImageHelper.IImageDescriptorHelper;
 import org.eclipse.xtext.ui.containers.ContainerStateProvider;
@@ -106,6 +107,7 @@ import org.eclipse.xtext.ui.markers.IMarkerContributor;
 import org.eclipse.xtext.ui.preferences.EclipsePreferencesProvider;
 import org.eclipse.xtext.ui.resource.IResourceSetProvider;
 import org.eclipse.xtext.ui.resource.XtextResourceSetProvider;
+import org.eclipse.xtext.ui.service.EclipseOperationCanceledManager;
 import org.eclipse.xtext.ui.tasks.TaskMarkerContributor;
 import org.eclipse.xtext.ui.validation.ConfigurableIssueCodesPreferenceStoreInitializer;
 import org.eclipse.xtext.ui.validation.LanguageAwareMarkerTypeProvider;
@@ -435,5 +437,12 @@ public class DefaultUiModule extends AbstractGenericModule {
 	 */
 	public Class<? extends IProjectConfigProvider> bindProjectConfigProvider() {
 		return EclipseProjectConfigProvider.class;
+	}
+	
+	/**
+	 * @since 2.9
+	 */
+	public  Class<? extends OperationCanceledManager> bindOperationCanceledManager() {
+		return EclipseOperationCanceledManager.class;
 	}
 }

--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/service/EclipseOperationCanceledManager.xtend
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/service/EclipseOperationCanceledManager.xtend
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ui.service
+
+import org.eclipse.core.runtime.OperationCanceledException
+import org.eclipse.xtext.service.OperationCanceledManager
+
+/**
+ * @author Moritz Eysholdt - Initial contribution and API
+ */
+class EclipseOperationCanceledManager extends OperationCanceledManager {
+	override protected getPlatformSpecificOperationCanceledException() {
+		new OperationCanceledException
+	}
+}

--- a/plugins/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/service/EclipseOperationCanceledManager.java
+++ b/plugins/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/service/EclipseOperationCanceledManager.java
@@ -5,15 +5,18 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.xtext.idea.service;
+package org.eclipse.xtext.ui.service;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.xtext.service.OperationCanceledManager;
 
+/**
+ * @author Moritz Eysholdt - Initial contribution and API
+ */
 @SuppressWarnings("all")
-public class IdeaOperationCanceledManager extends OperationCanceledManager {
+public class EclipseOperationCanceledManager extends OperationCanceledManager {
   @Override
   protected Throwable getPlatformSpecificOperationCanceledException() {
-    return new ProcessCanceledException();
+    return new OperationCanceledException();
   }
 }

--- a/plugins/org.eclipse.xtext/.settings/.api_filters
+++ b/plugins/org.eclipse.xtext/.settings/.api_filters
@@ -677,6 +677,12 @@
                 <message_argument value="checkCanceled(IProgressMonitor)"/>
             </message_arguments>
         </filter>
+        <filter comment="type widening" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.xtext.service.OperationCanceledManager"/>
+                <message_argument value="getPlatformSpecificOperationCanceledException()"/>
+            </message_arguments>
+        </filter>
     </resource>
     <resource path="xtend-gen/org/eclipse/xtext/workspace/FileProjectConfig.java" type="org.eclipse.xtext.workspace.FileProjectConfig">
         <filter id="640712815">

--- a/plugins/org.eclipse.xtext/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.xtext/META-INF/MANIFEST.MF
@@ -105,8 +105,7 @@ Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.10.2";visibility:=re
  org.eclipse.xtext.util;visibility:=reexport,
  org.eclipse.xtext.smap;x-installation:=greedy,
  org.eclipse.core.runtime;bundle-version="3.6.0";resolution:=optional;x-installation:=greedy,
- org.eclipse.xtend.lib;resolution:=optional,
- org.eclipse.equinox.common;bundle-version="3.5.0"
+ org.eclipse.xtend.lib;resolution:=optional
 Import-Package: org.apache.log4j;version="1.2.15",org.osgi.framework
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.xtext.internal.Activator

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/EcoreUtil2.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/EcoreUtil2.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.common.util.AbstractTreeIterator;
 import org.eclipse.emf.common.util.EList;
@@ -52,6 +51,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.xtext.linking.lazy.LazyLinkingResource;
 import org.eclipse.xtext.resource.ClassloaderClasspathUriResolver;
 import org.eclipse.xtext.resource.DerivedStateAwareResource;
+import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.Strings;
 
@@ -482,7 +482,7 @@ public class EcoreUtil2 extends EcoreUtil {
 	public static void resolveAll(Resource resource, CancelIndicator monitor) {
 		for (Iterator<EObject> i = resource.getAllContents(); i.hasNext();) {
 			if (monitor.isCanceled())
-				throw new OperationCanceledException();
+				throw new OperationCanceledError();
 			EObject eObject = i.next();
 			resolveCrossReferences(eObject, monitor);
 		}
@@ -508,7 +508,7 @@ public class EcoreUtil2 extends EcoreUtil {
 		resolveCrossReferences(eObject, monitor);
 		for (Iterator<EObject> i = eObject.eAllContents(); i.hasNext();) {
 			if (monitor.isCanceled())
-				throw new OperationCanceledException();
+				throw new OperationCanceledError();
 			EObject childEObject = i.next();
 			resolveCrossReferences(childEObject, monitor);
 		}
@@ -518,7 +518,7 @@ public class EcoreUtil2 extends EcoreUtil {
 		for (Iterator<EObject> i = eObject.eCrossReferences().iterator(); i.hasNext(); i
 				.next()) {
 			if (monitor.isCanceled()) {
-				throw new OperationCanceledException();
+				throw new OperationCanceledError();
 			}
 			// The loop resolves the cross references by visiting them.
 		}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/generator/FileSystemAccessQueue.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/generator/FileSystemAccessQueue.xtend
@@ -1,11 +1,11 @@
 package org.eclipse.xtext.generator
 
 import java.util.concurrent.BlockingQueue
-import org.eclipse.core.runtime.OperationCanceledException
 import org.eclipse.emf.common.notify.impl.AdapterImpl
 import org.eclipse.emf.common.util.URI
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.xtext.service.OperationCanceledError
 
 /**
  * @author Anton Kosyakov
@@ -32,12 +32,12 @@ class FileSystemAccessQueue extends AdapterImpl {
 	protected def send(FileSystemAccessRequest request) {
 		try {
 			if (monitor.isCanceled) {
-				throw new OperationCanceledException
+				throw new OperationCanceledError()
 			}
 			requestQueue.put(request)
 			return request
 		} catch (InterruptedException e) {
-			throw new OperationCanceledException
+			throw new OperationCanceledError()
 		}
 	}
 

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/service/OperationCanceledManager.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/service/OperationCanceledManager.xtend
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.service
 
-import org.eclipse.core.runtime.OperationCanceledException
 import org.eclipse.xtext.util.CancelIndicator
 
 /**
@@ -21,7 +20,7 @@ class OperationCanceledManager {
 	
 	protected def RuntimeException getPlatformOperationCanceledException(Throwable t) {
 		switch t {
-			OperationCanceledException : t
+			RuntimeException case t.class.name == 'org.eclipse.core.runtime.OperationCanceledException' : t
 			RuntimeException case t.class.name == 'com.intellij.openapi.progress.ProcessCanceledException' : t
 			OperationCanceledError : t.wrapped
 			default : null
@@ -68,8 +67,11 @@ class OperationCanceledManager {
 		throw asWrappingOperationCanceledException(platformSpecificOperationCanceledException)
 	}
 	
-	protected def RuntimeException getPlatformSpecificOperationCanceledException() {
-		return new OperationCanceledException()
+	/**
+	 * @since 2.9
+	 */
+	protected def Throwable getPlatformSpecificOperationCanceledException() {
+		return new OperationCanceledError(null)
 	}
 	
 	def void checkCanceled(CancelIndicator indicator) {
@@ -84,6 +86,12 @@ class OperationCanceledManager {
  * @since 2.8
  */
 class OperationCanceledError extends Error {
+	/**
+	 * @since 2.9
+	 */
+ 	new() {
+		super()
+	}
 	new(RuntimeException cause) {
 		super(cause)
 	}

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/FileSystemAccessQueue.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/generator/FileSystemAccessQueue.java
@@ -2,11 +2,11 @@ package org.eclipse.xtext.generator;
 
 import java.util.concurrent.BlockingQueue;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtext.generator.FileSystemAccessRequest;
+import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 
 /**
@@ -41,14 +41,14 @@ public class FileSystemAccessQueue extends AdapterImpl {
     try {
       boolean _isCanceled = this.monitor.isCanceled();
       if (_isCanceled) {
-        throw new OperationCanceledException();
+        throw new OperationCanceledError();
       }
       this.requestQueue.put(request);
       return request;
     } catch (final Throwable _t) {
       if (_t instanceof InterruptedException) {
         final InterruptedException e = (InterruptedException)_t;
-        throw new OperationCanceledException();
+        throw new OperationCanceledError();
       } else {
         throw Exceptions.sneakyThrow(_t);
       }

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/service/OperationCanceledError.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/service/OperationCanceledError.java
@@ -12,6 +12,13 @@ package org.eclipse.xtext.service;
  */
 @SuppressWarnings("all")
 public class OperationCanceledError extends Error {
+  /**
+   * @since 2.9
+   */
+  public OperationCanceledError() {
+    super();
+  }
+  
   public OperationCanceledError(final RuntimeException cause) {
     super(cause);
   }

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/service/OperationCanceledManager.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/service/OperationCanceledManager.java
@@ -8,7 +8,6 @@
 package org.eclipse.xtext.service;
 
 import com.google.common.base.Objects;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.util.CancelIndicator;
 
@@ -25,9 +24,14 @@ public class OperationCanceledManager {
     RuntimeException _switchResult = null;
     boolean _matched = false;
     if (!_matched) {
-      if (t instanceof OperationCanceledException) {
-        _matched=true;
-        _switchResult = ((RuntimeException)t);
+      if (t instanceof RuntimeException) {
+        Class<? extends RuntimeException> _class = ((RuntimeException)t).getClass();
+        String _name = _class.getName();
+        boolean _equals = Objects.equal(_name, "org.eclipse.core.runtime.OperationCanceledException");
+        if (_equals) {
+          _matched=true;
+          _switchResult = ((RuntimeException)t);
+        }
       }
     }
     if (!_matched) {
@@ -94,12 +98,15 @@ public class OperationCanceledManager {
   }
   
   public void throwOperationCanceledException() {
-    RuntimeException _platformSpecificOperationCanceledException = this.getPlatformSpecificOperationCanceledException();
+    Throwable _platformSpecificOperationCanceledException = this.getPlatformSpecificOperationCanceledException();
     throw this.asWrappingOperationCanceledException(_platformSpecificOperationCanceledException);
   }
   
-  protected RuntimeException getPlatformSpecificOperationCanceledException() {
-    return new OperationCanceledException();
+  /**
+   * @since 2.9
+   */
+  protected Throwable getPlatformSpecificOperationCanceledException() {
+    return new OperationCanceledError(null);
   }
   
   public void checkCanceled(final CancelIndicator indicator) {


### PR DESCRIPTION
This simplifies the classpath for Standalone, IntelliJ and Web.

However, it's still on the classpath as re-exported dependency of 
xtext's optional dependency org.eclipse.core.runtime.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@itemis.de>