### PR TITLE
[xtext generator] fragment-wise selection of Java vs. Xtend stubs beyond 'preferXtendStubs'

### DIFF
--- a/plugins/org.eclipse.xtext.xbase/generator/org/eclipse/xtext/xbase/GenerateXbase.java
+++ b/plugins/org.eclipse.xtext.xbase/generator/org/eclipse/xtext/xbase/GenerateXbase.java
@@ -75,6 +75,7 @@ final class GenerateXbase {
 				setGrammarUri("classpath:/org/eclipse/xtext/xbase/Xtype.xtext");
 				getStandaloneSetup().addLoadedResource(xbaseGenModel);
 				setFileExtensions(fileExtensions);
+				setGenerateXtendStubs(true);
 				addFragment(new GrammarAccessFragment2());
 				addFragment(new SerializerFragment2() {{ setGenerateSupportForDeprecatedContextObject(true); }} );
 				addFragment(new Formatter2Fragment2());
@@ -92,6 +93,7 @@ final class GenerateXbase {
 				setGrammarUri("classpath:/org/eclipse/xtext/xbase/Xbase.xtext");
 				getStandaloneSetup().addLoadedResource(xbaseGenModel);
 				setFileExtensions(fileExtensions);
+				setGenerateXtendStubs(true);
 				addFragment(new GrammarAccessFragment2());
 				addFragment(new SerializerFragment2() {{ setGenerateSupportForDeprecatedContextObject(true); }} );
 				addFragment(new ResourceFactoryFragment2());
@@ -129,6 +131,7 @@ final class GenerateXbase {
 				setGrammarUri("classpath:/org/eclipse/xtext/xbase/annotations/XbaseWithAnnotations.xtext");
 				getStandaloneSetup().addLoadedResource(xbaseGenModel);
 				setFileExtensions(fileExtensions);
+				setGenerateXtendStubs(true);
 				addFragment(new GrammarAccessFragment2());
 				addFragment(new SerializerFragment2() {{ setGenerateSupportForDeprecatedContextObject(true); }} );
 				addFragment(new ResourceFactoryFragment2());

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.xtend
@@ -9,7 +9,20 @@ package org.eclipse.xtext.xtext.generator
 
 import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment
 import org.eclipse.xtend.lib.annotations.Accessors
+import com.google.inject.Inject
 
 abstract class AbstractStubGeneratingFragment extends AbstractXtextGeneratorFragment {
-	@Accessors boolean generateStub = true
+
+	@Inject
+	extension CodeConfig
+
+	@Accessors
+	boolean generateStub = true
+	
+	@Accessors(PUBLIC_SETTER)
+	Boolean generateXtendStub = null
+	
+	def isGenerateXtendStub() {
+		if (generateXtendStub != null) generateXtendStub.booleanValue else preferXtendStubs
+	}
 }

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.xtend
@@ -34,4 +34,6 @@ interface IXtextGeneratorLanguage {
 	
 	def ResourceSet getResourceSet()
 	
+	def boolean isGenerateXtendStubs() 
+	
 }

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ImplicitFragment.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ImplicitFragment.xtend
@@ -17,13 +17,11 @@ import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector
 import static extension org.eclipse.xtext.GrammarUtil.*
 import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
 
-package class ImplicitFragment extends AbstractXtextGeneratorFragment {
+package class ImplicitFragment extends AbstractStubGeneratingFragment {
 	
 	@Inject extension XbaseUsageDetector
 	
 	@Inject extension XtextGeneratorNaming naming
-	
-	@Inject extension CodeConfig
 	
 	override generate() {
 		if (projectConfig.runtime.manifest !== null) {
@@ -31,7 +29,7 @@ package class ImplicitFragment extends AbstractXtextGeneratorFragment {
 				'org.eclipse.xtext', 'org.eclipse.xtext.util'
 			])
 			
-			if (preferXtendStubs) {
+			if (generateXtendStub) {
 				projectConfig.runtime.manifest.requiredBundles += 'org.eclipse.xtend.lib' 
 			}
 			
@@ -43,7 +41,7 @@ package class ImplicitFragment extends AbstractXtextGeneratorFragment {
 				'org.eclipse.xtext.ui', 'org.eclipse.xtext.ui.shared', 'org.eclipse.ui.editors', 'org.eclipse.ui'
 			])
 			
-			if (preferXtendStubs) {
+			if (generateXtendStub) {
 				projectConfig.eclipsePlugin.manifest.requiredBundles += 'org.eclipse.xtend.lib' 
 			}
 			

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.xtend
@@ -49,6 +49,9 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 	
 	String name
 	
+	@Accessors(PUBLIC_SETTER)	
+	Boolean generateXtendStubs
+	
 	@Accessors(PUBLIC_GETTER)
 	Grammar grammar
 	
@@ -87,6 +90,8 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 	
 	@Inject IXtextProjectConfig projectConfig
 	
+	@Inject CodeConfig codeConfig
+	
 	def void setGrammarUri(String uri) {
 		this.grammarUri = uri
 	}
@@ -109,6 +114,10 @@ class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implements IXte
 			LOG.info("No explicit fileExtensions configured. Using '*." + fileExtensions + "'.")
 		}
 		return fileExtensions
+	}
+	
+	override isGenerateXtendStubs() {
+		if (generateXtendStubs != null) generateXtendStubs.booleanValue else codeConfig.preferXtendStubs
 	}
 	
 	override initialize(Injector injector) {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
@@ -45,15 +45,13 @@ import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
 @Singleton
 class XtextGeneratorTemplates {
 
-	@Inject CodeConfig codeConfig
-	
 	@Inject FileAccessFactory fileAccessFactory
 	
 	@Inject extension XtextGeneratorNaming naming
 	
 	def JavaFileAccess createRuntimeSetup(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (codeConfig.preferXtendStubs) {
+		if (langConfig.generateXtendStubs) {
 			return fileAccessFactory.createXtendFile(runtimeSetup,'''
 				/**
 				 * Initialization support for running Xtext languages without Equinox extension registry.
@@ -172,7 +170,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createRuntimeModule(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (codeConfig.preferXtendStubs) {
+		if (langConfig.generateXtendStubs) {
 			return fileAccessFactory.createXtendFile(runtimeModule,'''
 				/**
 				 * Use this class to register components to be used at runtime / without the Equinox extension registry.
@@ -235,7 +233,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createEclipsePluginModule(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (codeConfig.preferXtendStubs) {
+		if (langConfig.generateXtendStubs) {
 			return fileAccessFactory.createXtendFile(eclipsePluginModule,'''
 				/**
 				 * Use this class to register components to be used within the Eclipse IDE.
@@ -290,7 +288,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createIdeaModule(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (codeConfig.preferXtendStubs) {			
+		if (langConfig.generateXtendStubs) {
 			return fileAccessFactory.createXtendFile(ideaModule,'''
 				/**
 				 * Use this class to register components to be used within IntelliJ IDEA.
@@ -335,7 +333,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createWebModule(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (codeConfig.preferXtendStubs) {			
+		if (langConfig.generateXtendStubs) {
 			return fileAccessFactory.createXtendFile(webModule,'''
 				/**
 				 * Use this class to register additional components to be used within the web application.
@@ -389,7 +387,7 @@ class XtextGeneratorTemplates {
 	
 	def JavaFileAccess createWebSetup(IXtextGeneratorLanguage langConfig) {
 		val it = langConfig.grammar
-		if (codeConfig.preferXtendStubs) {			
+		if (langConfig.generateXtendStubs) {
 			return fileAccessFactory.createXtendFile(webSetup, '''
 				/**
 				 * Initialization support for running Xtext languages in web applications.

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/generator/GeneratorFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/generator/GeneratorFragment2.xtend
@@ -99,7 +99,7 @@ class GeneratorFragment2 extends AbstractStubGeneratingFragment {
 			if (projectConfig.runtime.manifest !== null)
 				projectConfig.runtime.manifest.requiredBundles += 'org.eclipse.xtext.xbase.lib'
 
-			if (codeConfig.preferXtendStubs) {
+			if (generateXtendStub) {
 				doGenerateXtendStubFile
 			} else {
 				doGenerateJavaStubFile

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.xtend
@@ -19,7 +19,6 @@ import org.eclipse.xtext.scoping.impl.DefaultGlobalScopeProvider
 import org.eclipse.xtext.scoping.impl.DelegatingScopeProvider
 import org.eclipse.xtext.scoping.impl.ImportedNamespaceAwareLocalScopeProvider
 import org.eclipse.xtext.xtext.generator.AbstractInheritingFragment
-import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
@@ -35,7 +34,6 @@ class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment {
 	
 	@Inject extension XtextGeneratorNaming
 	@Inject extension XbaseUsageDetector
-	@Inject CodeConfig codeConfig
 	@Inject FileAccessFactory fileAccessFactory
 
 	@Accessors
@@ -83,14 +81,14 @@ class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment {
 
 		if (generateStub) {
 			
-			if (codeConfig.preferXtendStubs)
+			if (generateXtendStub)
 				generateXtendScopeProvider()
 			else
 				generateJavaScopeProvider()
 			
 			if (projectConfig.runtime.manifest !== null) {
 				projectConfig.runtime.manifest.exportedPackages += grammar.scopeProviderClass.packageName
-				if (codeConfig.preferXtendStubs)
+				if (generateXtendStub)
 					projectConfig.runtime.manifest.requiredBundles += 'org.eclipse.xtext.xbase.lib'
 			}
 		}

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.xtend
@@ -54,7 +54,6 @@ import org.eclipse.xtext.serializer.sequencer.ISyntacticSequencer
 import org.eclipse.xtext.serializer.sequencer.ITransientValueService
 import org.eclipse.xtext.util.Strings
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment
-import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
 import org.eclipse.xtext.xtext.generator.grammarAccess.GrammarAccessExtensions
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
@@ -86,7 +85,6 @@ class SerializerFragment2 extends AbstractStubGeneratingFragment {
 	@Inject extension IGrammarConstraintProvider
 	@Inject DebugGraphGenerator debugGraphGenerator
 	@Inject FileAccessFactory fileAccessFactory
-	@Inject CodeConfig codeConfig
 	
 	@Accessors boolean generateDebugData = false
 	@Accessors boolean generateSupportForDeprecatedContextObject = false
@@ -154,7 +152,7 @@ class SerializerFragment2 extends AbstractStubGeneratingFragment {
 	}
 	
 	protected def generateSemanticSequencer() {
-		if (codeConfig.preferXtendStubs) {
+		if (generateXtendStub) {
 			fileAccessFactory.createXtendFile(grammar.semanticSequencerClass, '''
 				class «grammar.semanticSequencerClass.simpleName» extends «grammar.abstractSemanticSequencerClass» {
 				}
@@ -170,7 +168,7 @@ class SerializerFragment2 extends AbstractStubGeneratingFragment {
 	private def unassignedCalledTokenRuleName(AbstractRule rule) '''get«rule.name»Token'''
 	
 	protected def generateSyntacticSequencer() {
-		if (codeConfig.preferXtendStubs) {
+		if (generateXtendStub) {
 			fileAccessFactory.createXtendFile(grammar.syntacticSequencerClass, '''
 				class «grammar.syntacticSequencerClass.simpleName» extends «grammar.abstractSyntacticSequencerClass» {
 					«IF detectSyntheticTerminals»

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.xtend
@@ -19,7 +19,6 @@ import org.eclipse.xtext.CrossReference
 import org.eclipse.xtext.Grammar
 import org.eclipse.xtext.RuleCall
 import org.eclipse.xtext.xtext.generator.AbstractInheritingFragment
-import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
@@ -38,9 +37,6 @@ class ContentAssistFragment2 extends AbstractInheritingFragment {
 
 	@Inject
 	extension XtextGeneratorNaming
-	
-	@Inject
-	extension CodeConfig
 	
 	@Inject
 	FileAccessFactory fileAccessFactory
@@ -89,7 +85,7 @@ class ContentAssistFragment2 extends AbstractInheritingFragment {
 		}
 
 		if (generateStub && projectConfig.eclipsePlugin.src != null) {
-			if (preferXtendStubs) {
+			if (generateXtendStub) {
 				generateXtendProposalProviderStub
 
 				if (projectConfig.eclipsePlugin.manifest != null) {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.xtend
@@ -10,7 +10,6 @@ package org.eclipse.xtext.xtext.generator.ui.labeling
 import com.google.inject.Inject
 import org.eclipse.xtext.Grammar
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment
-import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
@@ -37,9 +36,6 @@ class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
 
 	@Inject
 	extension XbaseUsageDetector
-
-	@Inject
-	extension CodeConfig
 
 	@Inject
 	FileAccessFactory fileAccessFactory
@@ -112,7 +108,7 @@ class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
 		}
 
 		if (generateStub && projectConfig.eclipsePlugin.src !== null) {
-			if (preferXtendStubs) {
+			if (generateXtendStub) {
 				generateXtendEObjectLabelProvider
 				generateXtendDescriptionLabelProvider
 			} else {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/outline/OutlineTreeProviderFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/outline/OutlineTreeProviderFragment2.xtend
@@ -11,7 +11,6 @@ import com.google.inject.Inject
 import org.eclipse.xtext.Grammar
 import org.eclipse.xtext.GrammarUtil
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment
-import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
@@ -24,7 +23,6 @@ import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.ty
  */
 class OutlineTreeProviderFragment2 extends AbstractStubGeneratingFragment {
 
-	@Inject CodeConfig codeConfig
 	@Inject FileAccessFactory fileAccessFactory
 	@Inject extension XtextGeneratorNaming
 	
@@ -44,7 +42,7 @@ class OutlineTreeProviderFragment2 extends AbstractStubGeneratingFragment {
 		}
 
 		if (projectConfig.eclipsePlugin.src !== null) {
-			if (codeConfig.preferXtendStubs) {
+			if (generateXtendStub) {
 				generateXtendOutlineTreeProvider
 			} else {
 				generateJavaOutlineTreeProvider

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.xtend
@@ -10,7 +10,6 @@ package org.eclipse.xtext.xtext.generator.ui.quickfix
 import javax.inject.Inject
 import org.eclipse.xtext.Grammar
 import org.eclipse.xtext.xtext.generator.AbstractInheritingFragment
-import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
@@ -29,9 +28,6 @@ class QuickfixProviderFragment2 extends AbstractInheritingFragment {
 
 	@Inject
 	extension XtextGeneratorNaming
-
-	@Inject
-	extension CodeConfig
 	
 	@Inject
 	extension ValidatorNaming
@@ -69,7 +65,7 @@ class QuickfixProviderFragment2 extends AbstractInheritingFragment {
 
 		if (generateStub) {
 			if (projectConfig.eclipsePlugin?.src !== null) {
-				if (preferXtendStubs) {
+				if (generateXtendStub) {
 					generateXtendQuickfixProvider
 				} else {
 					generateJavaQuickfixProvider

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.xtend
@@ -16,7 +16,6 @@ import org.eclipse.xtext.Grammar
 import org.eclipse.xtext.validation.AbstractDeclarativeValidator
 import org.eclipse.xtext.validation.ComposedChecks
 import org.eclipse.xtext.xtext.generator.AbstractInheritingFragment
-import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
@@ -32,7 +31,6 @@ class ValidatorFragment2 extends AbstractInheritingFragment {
 	@Inject extension ValidatorNaming
 	@Inject extension XtextGeneratorNaming
 	@Inject FileAccessFactory fileAccessFactory
-	@Inject CodeConfig codeConfig
 	
 	val List<String> composedChecks = newArrayList
 	
@@ -64,7 +62,7 @@ class ValidatorFragment2 extends AbstractInheritingFragment {
 			.contributeTo(language.runtimeGenModule)
 		
 		if (generateStub) {
-			if (codeConfig.preferXtendStubs)
+			if (generateXtendStub)
 				generateXtendValidatorStub()
 			else
 				generateJavaValidatorStub()

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.java
@@ -7,14 +7,37 @@
  */
 package org.eclipse.xtext.xtext.generator;
 
+import com.google.common.base.Objects;
+import com.google.inject.Inject;
+import org.eclipse.xtend.lib.annotations.AccessorType;
 import org.eclipse.xtend.lib.annotations.Accessors;
+import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment;
+import org.eclipse.xtext.xtext.generator.CodeConfig;
 
 @SuppressWarnings("all")
 public abstract class AbstractStubGeneratingFragment extends AbstractXtextGeneratorFragment {
+  @Inject
+  @Extension
+  private CodeConfig _codeConfig;
+  
   @Accessors
   private boolean generateStub = true;
+  
+  @Accessors(AccessorType.PUBLIC_SETTER)
+  private Boolean generateXtendStub = null;
+  
+  public boolean isGenerateXtendStub() {
+    boolean _xifexpression = false;
+    boolean _notEquals = (!Objects.equal(this.generateXtendStub, null));
+    if (_notEquals) {
+      _xifexpression = this.generateXtendStub.booleanValue();
+    } else {
+      _xifexpression = this._codeConfig.isPreferXtendStubs();
+    }
+    return _xifexpression;
+  }
   
   @Pure
   public boolean isGenerateStub() {
@@ -23,5 +46,9 @@ public abstract class AbstractStubGeneratingFragment extends AbstractXtextGenera
   
   public void setGenerateStub(final boolean generateStub) {
     this.generateStub = generateStub;
+  }
+  
+  public void setGenerateXtendStub(final Boolean generateXtendStub) {
+    this.generateXtendStub = generateXtendStub;
   }
 }

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/IXtextGeneratorLanguage.java
@@ -33,4 +33,6 @@ public interface IXtextGeneratorLanguage {
   public abstract GuiceModuleAccess getWebGenModule();
   
   public abstract ResourceSet getResourceSet();
+  
+  public abstract boolean isGenerateXtendStubs();
 }

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ImplicitFragment.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ImplicitFragment.java
@@ -19,8 +19,7 @@ import org.eclipse.xtext.resource.containers.IAllContainersState;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment;
-import org.eclipse.xtext.xtext.generator.CodeConfig;
+import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess;
@@ -33,7 +32,7 @@ import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector;
 
 @SuppressWarnings("all")
-class ImplicitFragment extends AbstractXtextGeneratorFragment {
+class ImplicitFragment extends AbstractStubGeneratingFragment {
   @Inject
   @Extension
   private XbaseUsageDetector _xbaseUsageDetector;
@@ -41,10 +40,6 @@ class ImplicitFragment extends AbstractXtextGeneratorFragment {
   @Inject
   @Extension
   private XtextGeneratorNaming naming;
-  
-  @Inject
-  @Extension
-  private CodeConfig _codeConfig;
   
   @Override
   public void generate() {
@@ -59,8 +54,8 @@ class ImplicitFragment extends AbstractXtextGeneratorFragment {
       Set<String> _requiredBundles = _manifest_1.getRequiredBundles();
       _requiredBundles.addAll(
         Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("org.eclipse.xtext", "org.eclipse.xtext.util")));
-      boolean _isPreferXtendStubs = this._codeConfig.isPreferXtendStubs();
-      if (_isPreferXtendStubs) {
+      boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+      if (_isGenerateXtendStub) {
         IXtextProjectConfig _projectConfig_2 = this.getProjectConfig();
         IRuntimeProjectConfig _runtime_2 = _projectConfig_2.getRuntime();
         ManifestAccess _manifest_2 = _runtime_2.getManifest();
@@ -84,8 +79,8 @@ class ImplicitFragment extends AbstractXtextGeneratorFragment {
       Set<String> _requiredBundles_2 = _manifest_5.getRequiredBundles();
       _requiredBundles_2.addAll(
         Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("org.eclipse.xtext.ui", "org.eclipse.xtext.ui.shared", "org.eclipse.ui.editors", "org.eclipse.ui")));
-      boolean _isPreferXtendStubs_1 = this._codeConfig.isPreferXtendStubs();
-      if (_isPreferXtendStubs_1) {
+      boolean _isGenerateXtendStub_1 = this.isGenerateXtendStub();
+      if (_isGenerateXtendStub_1) {
         IXtextProjectConfig _projectConfig_6 = this.getProjectConfig();
         IBundleProjectConfig _eclipsePlugin_2 = _projectConfig_6.getEclipsePlugin();
         ManifestAccess _manifest_6 = _eclipsePlugin_2.getManifest();

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorLanguage.java
@@ -52,6 +52,7 @@ import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.RuleNames;
+import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.CompositeGeneratorFragment2;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorFragment;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
@@ -72,6 +73,9 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   private String grammarUri;
   
   private String name;
+  
+  @Accessors(AccessorType.PUBLIC_SETTER)
+  private Boolean generateXtendStubs;
   
   @Accessors(AccessorType.PUBLIC_GETTER)
   private Grammar grammar;
@@ -115,6 +119,9 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   
   @Inject
   private IXtextProjectConfig projectConfig;
+  
+  @Inject
+  private CodeConfig codeConfig;
   
   public void setGrammarUri(final String uri) {
     this.grammarUri = uri;
@@ -165,6 +172,18 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
       XtextGeneratorLanguage.LOG.info((("No explicit fileExtensions configured. Using \'*." + this.fileExtensions) + "\'."));
     }
     return this.fileExtensions;
+  }
+  
+  @Override
+  public boolean isGenerateXtendStubs() {
+    boolean _xifexpression = false;
+    boolean _notEquals = (!Objects.equal(this.generateXtendStubs, null));
+    if (_notEquals) {
+      _xifexpression = this.generateXtendStubs.booleanValue();
+    } else {
+      _xifexpression = this.codeConfig.isPreferXtendStubs();
+    }
+    return _xifexpression;
   }
   
   @Override
@@ -388,6 +407,10 @@ public class XtextGeneratorLanguage extends CompositeGeneratorFragment2 implemen
   }
   
   private final static Logger LOG = Logger.getLogger(XtextGeneratorLanguage.class);
+  
+  public void setGenerateXtendStubs(final Boolean generateXtendStubs) {
+    this.generateXtendStubs = generateXtendStubs;
+  }
   
   @Pure
   public Grammar getGrammar() {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
@@ -39,7 +39,6 @@ import org.eclipse.xtext.util.Modules2;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory;
@@ -58,9 +57,6 @@ import org.eclipse.xtext.xtext.generator.model.annotations.SuppressWarningsAnnot
 @SuppressWarnings("all")
 public class XtextGeneratorTemplates {
   @Inject
-  private CodeConfig codeConfig;
-  
-  @Inject
   private FileAccessFactory fileAccessFactory;
   
   @Inject
@@ -69,8 +65,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createRuntimeSetup(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-    if (_isPreferXtendStubs) {
+    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
+    if (_isGenerateXtendStubs) {
       TypeReference _runtimeSetup = this.naming.getRuntimeSetup(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -606,8 +602,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createRuntimeModule(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-    if (_isPreferXtendStubs) {
+    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
+    if (_isGenerateXtendStubs) {
       TypeReference _runtimeModule = this.naming.getRuntimeModule(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -810,8 +806,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createEclipsePluginModule(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-    if (_isPreferXtendStubs) {
+    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
+    if (_isGenerateXtendStubs) {
       TypeReference _eclipsePluginModule = this.naming.getEclipsePluginModule(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -977,8 +973,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createIdeaModule(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-    if (_isPreferXtendStubs) {
+    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
+    if (_isGenerateXtendStubs) {
       TypeReference _ideaModule = this.naming.getIdeaModule(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -1106,8 +1102,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createWebModule(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-    if (_isPreferXtendStubs) {
+    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
+    if (_isGenerateXtendStubs) {
       TypeReference _webModule = this.naming.getWebModule(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
@@ -1275,8 +1271,8 @@ public class XtextGeneratorTemplates {
   
   public JavaFileAccess createWebSetup(final IXtextGeneratorLanguage langConfig) {
     final Grammar it = langConfig.getGrammar();
-    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-    if (_isPreferXtendStubs) {
+    boolean _isGenerateXtendStubs = langConfig.isGenerateXtendStubs();
+    if (_isGenerateXtendStubs) {
       TypeReference _webSetup = this.naming.getWebSetup(it);
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/generator/GeneratorFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/generator/GeneratorFragment2.java
@@ -188,8 +188,8 @@ public class GeneratorFragment2 extends AbstractStubGeneratingFragment {
         Set<String> _requiredBundles = _manifest_1.getRequiredBundles();
         _requiredBundles.add("org.eclipse.xtext.xbase.lib");
       }
-      boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-      if (_isPreferXtendStubs) {
+      boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+      if (_isGenerateXtendStub) {
         this.doGenerateXtendStubFile();
       } else {
         this.doGenerateJavaStubFile();

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.java
@@ -25,7 +25,6 @@ import org.eclipse.xtext.scoping.impl.ImportedNamespaceAwareLocalScopeProvider;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.AbstractInheritingFragment;
-import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory;
@@ -50,9 +49,6 @@ public class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment
   @Inject
   @Extension
   private XbaseUsageDetector _xbaseUsageDetector;
-  
-  @Inject
-  private CodeConfig codeConfig;
   
   @Inject
   private FileAccessFactory fileAccessFactory;
@@ -137,8 +133,8 @@ public class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment
     this.generateGenScopeProvider();
     boolean _isGenerateStub = this.isGenerateStub();
     if (_isGenerateStub) {
-      boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-      if (_isPreferXtendStubs) {
+      boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+      if (_isGenerateXtendStub) {
         this.generateXtendScopeProvider();
       } else {
         this.generateJavaScopeProvider();
@@ -156,8 +152,8 @@ public class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment
         TypeReference _scopeProviderClass = this.getScopeProviderClass(_grammar);
         String _packageName = _scopeProviderClass.getPackageName();
         _exportedPackages.add(_packageName);
-        boolean _isPreferXtendStubs_1 = this.codeConfig.isPreferXtendStubs();
-        if (_isPreferXtendStubs_1) {
+        boolean _isGenerateXtendStub_1 = this.isGenerateXtendStub();
+        if (_isGenerateXtendStub_1) {
           IXtextProjectConfig _projectConfig_2 = this.getProjectConfig();
           IRuntimeProjectConfig _runtime_2 = _projectConfig_2.getRuntime();
           ManifestAccess _manifest_2 = _runtime_2.getManifest();

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.java
@@ -73,7 +73,6 @@ import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment;
-import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
 import org.eclipse.xtext.xtext.generator.grammarAccess.GrammarAccessExtensions;
@@ -142,9 +141,6 @@ public class SerializerFragment2 extends AbstractStubGeneratingFragment {
   
   @Inject
   private FileAccessFactory fileAccessFactory;
-  
-  @Inject
-  private CodeConfig codeConfig;
   
   @Accessors
   private boolean generateDebugData = false;
@@ -264,8 +260,8 @@ public class SerializerFragment2 extends AbstractStubGeneratingFragment {
   }
   
   protected void generateSemanticSequencer() {
-    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-    if (_isPreferXtendStubs) {
+    boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+    if (_isGenerateXtendStub) {
       Grammar _grammar = this.getGrammar();
       TypeReference _semanticSequencerClass = this.getSemanticSequencerClass(_grammar);
       StringConcatenationClient _client = new StringConcatenationClient() {
@@ -330,8 +326,8 @@ public class SerializerFragment2 extends AbstractStubGeneratingFragment {
   }
   
   protected void generateSyntacticSequencer() {
-    boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-    if (_isPreferXtendStubs) {
+    boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+    if (_isGenerateXtendStub) {
       Grammar _grammar = this.getGrammar();
       TypeReference _syntacticSequencerClass = this.getSyntacticSequencerClass(_grammar);
       StringConcatenationClient _client = new StringConcatenationClient() {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.java
@@ -40,7 +40,6 @@ import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.eclipse.xtext.xtext.generator.AbstractInheritingFragment;
-import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory;
@@ -66,10 +65,6 @@ public class ContentAssistFragment2 extends AbstractInheritingFragment {
   @Inject
   @Extension
   private XtextGeneratorNaming _xtextGeneratorNaming;
-  
-  @Inject
-  @Extension
-  private CodeConfig _codeConfig;
   
   @Inject
   private FileAccessFactory fileAccessFactory;
@@ -163,8 +158,8 @@ public class ContentAssistFragment2 extends AbstractInheritingFragment {
       _and = _notEquals_1;
     }
     if (_and) {
-      boolean _isPreferXtendStubs = this._codeConfig.isPreferXtendStubs();
-      if (_isPreferXtendStubs) {
+      boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+      if (_isGenerateXtendStub) {
         this.generateXtendProposalProviderStub();
         IXtextProjectConfig _projectConfig_4 = this.getProjectConfig();
         IBundleProjectConfig _eclipsePlugin_4 = _projectConfig_4.getEclipsePlugin();

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.java
@@ -15,7 +15,6 @@ import org.eclipse.xtext.Grammar;
 import org.eclipse.xtext.GrammarUtil;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment;
-import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory;
@@ -47,10 +46,6 @@ public class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
   @Inject
   @Extension
   private XbaseUsageDetector _xbaseUsageDetector;
-  
-  @Inject
-  @Extension
-  private CodeConfig _codeConfig;
   
   @Inject
   private FileAccessFactory fileAccessFactory;
@@ -184,8 +179,8 @@ public class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
       _and = _tripleNotEquals;
     }
     if (_and) {
-      boolean _isPreferXtendStubs = this._codeConfig.isPreferXtendStubs();
-      if (_isPreferXtendStubs) {
+      boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+      if (_isGenerateXtendStub) {
         this.generateXtendEObjectLabelProvider();
         this.generateXtendDescriptionLabelProvider();
       } else {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/outline/OutlineTreeProviderFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/outline/OutlineTreeProviderFragment2.java
@@ -15,7 +15,6 @@ import org.eclipse.xtext.Grammar;
 import org.eclipse.xtext.GrammarUtil;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment;
-import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory;
@@ -33,9 +32,6 @@ import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
  */
 @SuppressWarnings("all")
 public class OutlineTreeProviderFragment2 extends AbstractStubGeneratingFragment {
-  @Inject
-  private CodeConfig codeConfig;
-  
   @Inject
   private FileAccessFactory fileAccessFactory;
   
@@ -75,8 +71,8 @@ public class OutlineTreeProviderFragment2 extends AbstractStubGeneratingFragment
     IXtextGeneratorFileSystemAccess _src = _eclipsePlugin_2.getSrc();
     boolean _tripleNotEquals = (_src != null);
     if (_tripleNotEquals) {
-      boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-      if (_isPreferXtendStubs) {
+      boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+      if (_isGenerateXtendStub) {
         this.generateXtendOutlineTreeProvider();
       } else {
         this.generateJavaOutlineTreeProvider();

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.java
@@ -17,7 +17,6 @@ import org.eclipse.xtext.Grammar;
 import org.eclipse.xtext.GrammarUtil;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xtext.generator.AbstractInheritingFragment;
-import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory;
@@ -44,10 +43,6 @@ public class QuickfixProviderFragment2 extends AbstractInheritingFragment {
   @Inject
   @Extension
   private XtextGeneratorNaming _xtextGeneratorNaming;
-  
-  @Inject
-  @Extension
-  private CodeConfig _codeConfig;
   
   @Inject
   @Extension
@@ -115,8 +110,8 @@ public class QuickfixProviderFragment2 extends AbstractInheritingFragment {
       }
       boolean _tripleNotEquals = (_src != null);
       if (_tripleNotEquals) {
-        boolean _isPreferXtendStubs = this._codeConfig.isPreferXtendStubs();
-        if (_isPreferXtendStubs) {
+        boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+        if (_isGenerateXtendStub) {
           this.generateXtendQuickfixProvider();
         } else {
           this.generateJavaQuickfixProvider();

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.java
@@ -29,7 +29,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.eclipse.xtext.xtext.generator.AbstractInheritingFragment;
-import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
 import org.eclipse.xtext.xtext.generator.model.FileAccessFactory;
@@ -59,9 +58,6 @@ public class ValidatorFragment2 extends AbstractInheritingFragment {
   
   @Inject
   private FileAccessFactory fileAccessFactory;
-  
-  @Inject
-  private CodeConfig codeConfig;
   
   private final List<String> composedChecks = CollectionLiterals.<String>newArrayList();
   
@@ -114,8 +110,8 @@ public class ValidatorFragment2 extends AbstractInheritingFragment {
     _addTypeToTypeEagerSingleton.contributeTo(_runtimeGenModule);
     boolean _isGenerateStub = this.isGenerateStub();
     if (_isGenerateStub) {
-      boolean _isPreferXtendStubs = this.codeConfig.isPreferXtendStubs();
-      if (_isPreferXtendStubs) {
+      boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+      if (_isGenerateXtendStub) {
         this.generateXtendValidatorStub();
       } else {
         this.generateJavaValidatorStub();


### PR DESCRIPTION
* addition of dedicated field + getter in 'AbstractStubGeneratingFragment'
* addition of dedicated flag 'generateXtendStubs' + getter in 'XtextGeneratorLanguage'
* update of using generator fragments
* update of 'GenerateXbase' Workflow