### PR TITLE
[generator] Introduced GeneratorOption

### DIFF
--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.xtend
@@ -7,22 +7,37 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.generator
 
-import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment
-import org.eclipse.xtend.lib.annotations.Accessors
 import com.google.inject.Inject
+import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption
 
 abstract class AbstractStubGeneratingFragment extends AbstractXtextGeneratorFragment {
 
 	@Inject
 	extension CodeConfig
 
-	@Accessors
-	boolean generateStub = true
+	@Accessors(PUBLIC_GETTER)
+	val generateStub = new BooleanGeneratorOption(true)
 	
-	@Accessors(PUBLIC_SETTER)
-	Boolean generateXtendStub = null
+	val generateXtendStub = new BooleanGeneratorOption
 	
-	def isGenerateXtendStub() {
-		if (generateXtendStub != null) generateXtendStub.booleanValue else preferXtendStubs
+	def boolean isGenerateStub() {
+		generateStub.get
 	}
+	
+	def void setGenerateStub(boolean generateStub) {
+		this.generateStub.set(generateStub)
+	}
+	
+	def boolean isGenerateXtendStub() {
+		if (generateXtendStub.isSet)
+			generateXtendStub.get
+		else
+			preferXtendStubs
+	}
+	
+	def void setGenerateXtendStub(boolean generateXtendStub) {
+		this.generateXtendStub.set(generateXtendStub)
+	}
+	
 }

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/StandardLanguage.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/StandardLanguage.xtend
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.generator
 
+import com.google.inject.Injector
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.util.internal.Log
 import org.eclipse.xtext.xtext.generator.builder.BuilderIntegrationFragment2
@@ -44,20 +45,18 @@ import org.eclipse.xtext.xtext.generator.xbase.XtypeGeneratorFragment2
 @Log class StandardLanguage extends XtextGeneratorLanguage {
 	
 	GrammarAccessFragment2 grammarAccess = new GrammarAccessFragment2
-	 
+	
 	SerializerFragment2 serializer = new SerializerFragment2
 	
 	ResourceFactoryFragment2 resourceFactoryFragment = new ResourceFactoryFragment2
-
+	
 	EMFGeneratorFragment2 emfGenerator = new EMFGeneratorFragment2
 	
 	XtextAntlrGeneratorFragment2 parserGenerator = new XtextAntlrGeneratorFragment2
 	
 	ValidatorFragment2 validator = new ValidatorFragment2
 	
-	Formatter2Fragment2 formatter = new Formatter2Fragment2  => [
-		generateStub = false
-	]
+	Formatter2Fragment2 formatter = new Formatter2Fragment2
 	
 	GeneratorFragment2 generator = new GeneratorFragment2 
 	
@@ -66,7 +65,6 @@ import org.eclipse.xtext.xtext.generator.xbase.XtypeGeneratorFragment2
 	ImportNamespacesScopingFragment2 scopeProvider = new ImportNamespacesScopingFragment2
 	
 	QualifiedNamesFragment2 qualifiedNamesProvider = new QualifiedNamesFragment2
-	
 	
 	Junit4Fragment2 junitSupport = new Junit4Fragment2
 	
@@ -88,9 +86,7 @@ import org.eclipse.xtext.xtext.generator.xbase.XtypeGeneratorFragment2
 	 
 	XtextAntlrIDEAGeneratorFragment ideaParser = new XtextAntlrIDEAGeneratorFragment
 	
-	TypesGeneratorFragment2 commonTypesSupport = new TypesGeneratorFragment2 => [
-		onlyEnabledIfGrammarIsUsed = true
-	]
+	TypesGeneratorFragment2 commonTypesSupport = new TypesGeneratorFragment2
 	
 	XtypeGeneratorFragment2 xtypeSupport = new XtypeGeneratorFragment2
 	
@@ -98,12 +94,7 @@ import org.eclipse.xtext.xtext.generator.xbase.XtypeGeneratorFragment2
 	
 	IdeaPluginGenerator ideaPlugin = new IdeaPluginGenerator
 	
-	WebIntegrationFragment webSupport = new WebIntegrationFragment => [
-		framework = "Ace"
-		generateServlet = true
-		generateJettyLauncher = true
-		generateHtmlExample = true
-	]
+	WebIntegrationFragment webSupport = new WebIntegrationFragment
 	
 	new() {
 		try {
@@ -112,6 +103,22 @@ import org.eclipse.xtext.xtext.generator.xbase.XtypeGeneratorFragment2
 		} catch (ClassNotFoundException e) {
 			LOG.info("Skipping registration of Xbase genmodel. Xbase is not on the classpath.")
 		}
+	}
+	
+	override initialize(Injector injector) {
+		if (!formatter.getGenerateStub.isSet)
+			formatter.generateStub = false
+		if (!commonTypesSupport.onlyEnabledIfGrammarIsUsed.isSet)
+			commonTypesSupport.onlyEnabledIfGrammarIsUsed = true
+		if (!webSupport.framework.isSet)
+			webSupport.framework = 'Ace'
+		if (!webSupport.generateServlet.isSet)
+			webSupport.generateServlet = true
+		if (!webSupport.generateJettyLauncher.isSet)
+			webSupport.generateJettyLauncher = true
+		if (!webSupport.generateHtmlExample.isSet)
+			webSupport.generateHtmlExample = true
+		super.initialize(injector)
 	}
 	
 	override protected getImplicitFragments() {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.xtend
@@ -49,7 +49,7 @@ class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
 	}
 	
 	override generate() {
-		if (!generateStub) 
+		if (!isGenerateStub)
 			return;
 		val StringConcatenationClient statement =
 			'''binder.bind(«IPreferenceValuesProvider».class).annotatedWith(«FormatterPreferences».class).to(«FormatterPreferenceValuesProvider».class);'''

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/generator/GeneratorFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/generator/GeneratorFragment2.xtend
@@ -60,7 +60,7 @@ class GeneratorFragment2 extends AbstractStubGeneratingFragment {
 	boolean generateXtendMain = false
 	
 	override boolean isGenerateStub() {
-		!grammar.inheritsXbase && super.generateStub
+		!grammar.inheritsXbase && super.isGenerateStub
 	}
 	
 	def boolean isGenerateJavaMain() {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessFragment2.xtend
@@ -49,13 +49,13 @@ import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
 @Log
 class GrammarAccessFragment2 extends AbstractXtextGeneratorFragment {
 	
-	@Accessors
-	String xmlVersion
-	
 	@Inject FileAccessFactory fileAccessFactory
 	
 	@Inject extension GrammarAccessExtensions
 	@Inject extension XtextGeneratorNaming
+	
+	@Accessors(PUBLIC_SETTER)
+	String xmlVersion
 	
 	override generate() {
 		val bindingFactory = new GuiceModuleAccess.BindingFactory()

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/XtextAntlrGeneratorFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/XtextAntlrGeneratorFragment2.xtend
@@ -44,26 +44,27 @@ import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
 import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess
 import org.eclipse.xtext.xtext.generator.model.JavaFileAccess
+import org.eclipse.xtext.xtext.generator.model.TypeReference
+import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption
+import org.eclipse.xtext.xtext.generator.util.SyntheticTerminalDetector
 
 import static extension org.eclipse.xtext.GrammarUtil.*
 import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
 import static extension org.eclipse.xtext.xtext.generator.parser.antlr.AntlrGrammarGenUtil.*
-import org.eclipse.xtext.xtext.generator.util.SyntheticTerminalDetector
-import org.eclipse.xtext.xtext.generator.model.TypeReference
 
 class XtextAntlrGeneratorFragment2 extends AbstractAntlrGeneratorFragment2 {
-	@Accessors
+	
+	@Accessors(PUBLIC_SETTER)
 	boolean debugGrammar
 	
-	@Accessors
-	Boolean combinedGrammar = null
+	val combinedGrammar = new BooleanGeneratorOption
 	
-	@Accessors
+	@Accessors(PUBLIC_SETTER)
 	boolean removeBacktrackingGuards
 	
 	int lookaheadThreshold
 	
-	@Accessors
+	@Accessors(PUBLIC_SETTER)
 	boolean partialParsing
 
 	@Inject AntlrGrammarGenerator productionGenerator
@@ -77,6 +78,17 @@ class XtextAntlrGeneratorFragment2 extends AbstractAntlrGeneratorFragment2 {
 	
 	@Inject extension GrammarAccessExtensions grammarUtil
 	@Inject extension SyntheticTerminalDetector
+	
+	def setCombinedGrammar(boolean combinedGrammar) {
+		this.combinedGrammar.set(combinedGrammar)
+	}
+	
+	protected def isCombinedGrammar() {
+		if (combinedGrammar.isSet)
+			combinedGrammar.get
+		else
+			!options.backtrackLexer && !options.ignoreCase
+	}
 
 	override protected doGenerate() {
 		new KeywordHelper(grammar, options.ignoreCase, grammarUtil)
@@ -159,10 +171,6 @@ class XtextAntlrGeneratorFragment2 extends AbstractAntlrGeneratorFragment2 {
 		if (!isCombinedGrammar) {
 			cleanupParserTokensFile(lexerGrammar, parserGrammar, KeywordHelper.getHelper(grammar), fsa)
 		}
-	}
-	
-	def isCombinedGrammar() {
-		combinedGrammar == null && !options.backtrackLexer && !options.ignoreCase || combinedGrammar == Boolean.TRUE
 	}
 	
 	protected def generateDebugGrammar() {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.xtend
@@ -36,7 +36,7 @@ class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment {
 	@Inject extension XbaseUsageDetector
 	@Inject FileAccessFactory fileAccessFactory
 
-	@Accessors
+	@Accessors(PUBLIC_SETTER)
 	boolean ignoreCase = false
 	
 	protected def TypeReference getScopeProviderClass(Grammar grammar) {
@@ -79,7 +79,7 @@ class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment {
 		
 		generateGenScopeProvider()
 
-		if (generateStub) {
+		if (isGenerateStub) {
 			
 			if (generateXtendStub)
 				generateXtendScopeProvider()
@@ -108,11 +108,11 @@ class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment {
 	}
 	
 	def generateGenScopeProvider() {
-		val genClass = if (generateStub) grammar.abstractScopeProviderClass else grammar.scopeProviderClass		
+		val genClass = if (isGenerateStub) grammar.abstractScopeProviderClass else grammar.scopeProviderClass		
 		val file = fileAccessFactory.createGeneratedJavaFile(genClass)
 		
 		file.content = '''
-			public «IF generateStub»abstract «ENDIF»class «genClass.simpleName» extends «grammar.scopeProviderSuperClass» {
+			public «IF isGenerateStub»abstract «ENDIF»class «genClass.simpleName» extends «grammar.scopeProviderSuperClass» {
 			}
 		'''
 		file.writeTo(projectConfig.runtime.srcGen)

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.xtend
@@ -138,7 +138,7 @@ class SerializerFragment2 extends AbstractStubGeneratingFragment {
 		
 		generateAbstractSemanticSequencer()
 		generateAbstractSyntacticSequencer()
-		if (generateStub) {
+		if (isGenerateStub) {
 			generateSemanticSequencer()
 			generateSyntacticSequencer()
 		}
@@ -210,7 +210,7 @@ class SerializerFragment2 extends AbstractStubGeneratingFragment {
 		val localConstraints = grammar.grammarConstraints
 		val superConstraints = grammar.superGrammar.grammarConstraints
 		val newLocalConstraints = localConstraints.filter[type !== null && !superConstraints.contains(it)].toSet
-		val clazz = if (generateStub) grammar.abstractSemanticSequencerClass else grammar.semanticSequencerClass
+		val clazz = if (isGenerateStub) grammar.abstractSemanticSequencerClass else grammar.semanticSequencerClass
 		val superClazz = if (localConstraints.exists[superConstraints.contains(it)]) 
 				grammar.usedGrammars.head.semanticSequencerClass
 			else
@@ -219,7 +219,7 @@ class SerializerFragment2 extends AbstractStubGeneratingFragment {
 		javaFile.resourceSet = language.resourceSet
 		
 		javaFile.content = '''
-			public «IF generateStub»abstract «ENDIF»class «clazz.simpleName» extends «superClazz» {
+			public «IF isGenerateStub»abstract «ENDIF»class «clazz.simpleName» extends «superClazz» {
 			
 				@«Inject»
 				private «grammar.grammarAccess» grammarAccess;
@@ -406,12 +406,12 @@ class SerializerFragment2 extends AbstractStubGeneratingFragment {
 	}
 	
 	protected def generateAbstractSyntacticSequencer() {
-		val clazz = if (generateStub) grammar.abstractSyntacticSequencerClass else grammar.syntacticSequencerClass
+		val clazz = if (isGenerateStub) grammar.abstractSyntacticSequencerClass else grammar.syntacticSequencerClass
 		val javaFile = fileAccessFactory.createGeneratedJavaFile(clazz)
 		javaFile.resourceSet = language.resourceSet
 		
 		javaFile.content = '''
-			public «IF generateStub»abstract «ENDIF»class «clazz.simpleName» extends «AbstractSyntacticSequencer» {
+			public «IF isGenerateStub»abstract «ENDIF»class «clazz.simpleName» extends «AbstractSyntacticSequencer» {
 			
 				protected «grammar.grammarAccess» grammarAccess;
 				«FOR group : allAmbiguousTransitionsBySyntax»
@@ -505,9 +505,9 @@ class SerializerFragment2 extends AbstractStubGeneratingFragment {
 				return '''
 					/**
 					 * Synthetic terminal rule. The concrete syntax is to be specified by clients.
-					«IF !generateStub» * Defaults to the empty string.«ENDIF»
+					«IF !isGenerateStub» * Defaults to the empty string.«ENDIF»
 					 */
-					protected «IF generateStub»abstract «ENDIF»String «rule.unassignedCalledTokenRuleName»(«EObject» semanticObject, «RuleCall» ruleCall, «INode» node)«IF generateStub»;«ELSE» { return ""; }«ENDIF»
+					protected «IF isGenerateStub»abstract «ENDIF»String «rule.unassignedCalledTokenRuleName»(«EObject» semanticObject, «RuleCall» ruleCall, «INode» node)«IF isGenerateStub»;«ELSE» { return ""; }«ENDIF»
 				'''
 			}
 		}

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/types/TypesGeneratorFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/types/TypesGeneratorFragment2.xtend
@@ -7,23 +7,29 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.generator.types
 
-import org.eclipse.xtext.scoping.IGlobalScopeProvider
-import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
-
-import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
-import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector
 import com.google.inject.Inject
 import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtext.scoping.IGlobalScopeProvider
 import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment
+import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
+import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption
+import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector
+
+import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
 
 class TypesGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 	
 	@Inject XbaseUsageDetector xbaseUsageDetector
 	
-	@Accessors boolean onlyEnabledIfGrammarIsUsed = false
+	@Accessors(PUBLIC_GETTER)
+	val onlyEnabledIfGrammarIsUsed = new BooleanGeneratorOption(false)
+	
+	def void setOnlyEnabledIfGrammarIsUsed(boolean onlyEnabledIfGrammarIsUsed) {
+		this.onlyEnabledIfGrammarIsUsed.set(onlyEnabledIfGrammarIsUsed)
+	}
 	
 	override generate() {
-		if (onlyEnabledIfGrammarIsUsed && !xbaseUsageDetector.inheritsXtype(language.grammar)) {
+		if (onlyEnabledIfGrammarIsUsed.get && !xbaseUsageDetector.inheritsXtype(language.grammar)) {
 			return;
 		}
 		new GuiceModuleAccess.BindingFactory()

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/contentAssist/ContentAssistFragment2.xtend
@@ -84,7 +84,7 @@ class ContentAssistFragment2 extends AbstractInheritingFragment {
 			generateGenJavaProposalProvider
 		}
 
-		if (generateStub && projectConfig.eclipsePlugin.src != null) {
+		if (isGenerateStub && projectConfig.eclipsePlugin.src != null) {
 			if (generateXtendStub) {
 				generateXtendProposalProviderStub
 
@@ -159,7 +159,7 @@ class ContentAssistFragment2 extends AbstractInheritingFragment {
 		//  as proposalProviders of sub languages refer to 'grammar.proposalProviderClass',
 		//  see 'getGenProposalProviderSuperClass(...)'
 		val genClass =
-			if (generateStub) grammar.genProposalProviderClass else grammar.proposalProviderClass;
+			if (isGenerateStub) grammar.genProposalProviderClass else grammar.proposalProviderClass;
 		
 		fileAccessFactory.createGeneratedJavaFile(genClass) => [
 			val superClass = grammar.genProposalProviderSuperClass
@@ -173,7 +173,7 @@ class ContentAssistFragment2 extends AbstractInheritingFragment {
 			'''
 
 			content = '''
-				public «IF generateStub»abstract «ENDIF»class «genClass.simpleName» extends «superClass» {
+				public «IF isGenerateStub»abstract «ENDIF»class «genClass.simpleName» extends «superClass» {
 
 					«IF !assignments.empty»
 						«FOR assignment : assignments»

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/labeling/LabelProviderFragment2.xtend
@@ -81,18 +81,18 @@ class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
 
 
 	override generate() {
-		if (generateStub || grammar.inheritsXbase) {
+		if (isGenerateStub || grammar.inheritsXbase) {
 
 			if (projectConfig.eclipsePlugin.manifest != null) {
 				projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtext.ui"
 			}
 	
 			val labelProviderClass =
-				if (generateStub) grammar.EObjectLabelProviderClass
+				if (isGenerateStub) grammar.EObjectLabelProviderClass
 				else new TypeReference(XBASE_LABEL_PROVIDER)
 	
 			val descriptionLabelProviderClass =
-				if (generateStub) grammar.descriptionLabelProviderClass
+				if (isGenerateStub) grammar.descriptionLabelProviderClass
 				else new TypeReference(XBASE_DESCRIPTION_LABEL_PROVIDER)			 
 	
 			val iLabelProviderClass = new TypeReference("org.eclipse.jface.viewers.ILabelProvider")
@@ -107,7 +107,7 @@ class LabelProviderFragment2 extends AbstractStubGeneratingFragment {
 					''').contributeTo(language.eclipsePluginGenModule)			
 		}
 
-		if (generateStub && projectConfig.eclipsePlugin.src !== null) {
+		if (isGenerateStub && projectConfig.eclipsePlugin.src !== null) {
 			if (generateXtendStub) {
 				generateXtendEObjectLabelProvider
 				generateXtendDescriptionLabelProvider

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/outline/OutlineTreeProviderFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/outline/OutlineTreeProviderFragment2.xtend
@@ -37,7 +37,7 @@ class OutlineTreeProviderFragment2 extends AbstractStubGeneratingFragment {
 			projectConfig.eclipsePlugin.manifest.requiredBundles += "org.eclipse.xtext.ui"
 		}
 		
-		if (!generateStub) {
+		if (!isGenerateStub) {
 			return;
 		}
 

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.xtend
@@ -63,7 +63,7 @@ class QuickfixProviderFragment2 extends AbstractInheritingFragment {
 					grammar.quickfixProviderClass
 				).contributeTo(language.eclipsePluginGenModule);
 
-		if (generateStub) {
+		if (isGenerateStub) {
 			if (projectConfig.eclipsePlugin?.src !== null) {
 				if (generateXtendStub) {
 					generateXtendQuickfixProvider
@@ -72,11 +72,11 @@ class QuickfixProviderFragment2 extends AbstractInheritingFragment {
 				}
 			}
 
-			if (projectConfig.eclipsePlugin.manifest != null) {
+			if (projectConfig.eclipsePlugin.manifest !== null) {
 				projectConfig.eclipsePlugin.manifest.exportedPackages += grammar.quickfixProviderClass.packageName
 			}
 
-			if (projectConfig.eclipsePlugin.pluginXml != null) {
+			if (projectConfig.eclipsePlugin.pluginXml !== null) {
 				addRegistrationToPluginXml
 			}
 
@@ -85,7 +85,7 @@ class QuickfixProviderFragment2 extends AbstractInheritingFragment {
 				generateGenQuickfixProvider
 			}
 
-			if (projectConfig.eclipsePlugin.manifest != null) {
+			if (projectConfig.eclipsePlugin.manifest !== null) {
 				projectConfig.eclipsePlugin.manifest.exportedPackages += grammar.quickfixProviderClass.packageName
 			}
 		}

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/refactoring/RefactorElementNameFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/ui/refactoring/RefactorElementNameFragment2.xtend
@@ -9,16 +9,16 @@ package org.eclipse.xtext.xtext.generator.ui.refactoring
 
 import com.google.inject.Inject
 import com.google.inject.name.Names
-import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.Grammar
+import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
+import org.eclipse.xtext.xtext.generator.model.TypeReference
+import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption
 import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector
 
 import static extension org.eclipse.xtext.GrammarUtil.*
 import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
-import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment
-import org.eclipse.xtext.xtext.generator.model.TypeReference
 
 /**
  * Contributes the registration of element renaming infrastructure.
@@ -33,15 +33,17 @@ class RefactorElementNameFragment2 extends AbstractXtextGeneratorFragment {
 	@Inject
 	extension XbaseUsageDetector
 
-	@Accessors
-	private Boolean useJdtRefactoring = null; // no default (depends on whether xbase is used or not)	
+	val useJdtRefactoring = new BooleanGeneratorOption
 
 	protected def isUseJdtRefactoring(Grammar grammar) {
-		if (useJdtRefactoring == null) {
+		if (useJdtRefactoring.isSet)
+			useJdtRefactoring.get
+		else
 			grammar.inheritsXbase
-		} else {
-			return useJdtRefactoring.booleanValue()
-		}
+	}
+	
+	def void setUseJdtRefactoring(boolean useJdtRefactoring) {
+		this.useJdtRefactoring.set(useJdtRefactoring)
 	}
 
 	override generate() {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/util/BooleanGeneratorOption.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/util/BooleanGeneratorOption.xtend
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xtext.generator.util
+
+/**
+ * A Boolean-valued option with default value for use in generator fragments.
+ */
+class BooleanGeneratorOption {
+	
+	val boolean defaultValue
+	
+	Boolean value
+	
+	new() {
+		this(false)
+	}
+	
+	new(boolean defaultValue) {
+		this.defaultValue = defaultValue
+	}
+	
+	def boolean get() {
+		value ?: defaultValue
+	}
+	
+	def void set(boolean value) {
+		this.value = value
+	}
+	
+	def boolean isSet() {
+		value !== null
+	}
+	
+}

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/util/GeneratorOption.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/util/GeneratorOption.xtend
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xtext.generator.util
+
+/**
+ * An object-valued option with default value for use in generator fragments.
+ */
+class GeneratorOption <T> {
+	
+	val T defaultValue
+	
+	T value
+	
+	/**
+	 * Create an option with no default value.
+	 */
+	new() {
+		this.defaultValue = null
+	}
+	
+	/**
+	 * Create an option with a default value.
+	 */
+	new(T defaultValue) {
+		this.defaultValue = defaultValue
+	}
+	
+	def T get() {
+		value ?: defaultValue
+	}
+	
+	def void set(T value) {
+		this.value = value
+	}
+	
+	def boolean isSet() {
+		value !== null
+	}
+	
+}

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/validation/ValidatorFragment2.xtend
@@ -61,7 +61,7 @@ class ValidatorFragment2 extends AbstractInheritingFragment {
 			.addTypeToTypeEagerSingleton(grammar.validatorClass, grammar.validatorClass)
 			.contributeTo(language.runtimeGenModule)
 		
-		if (generateStub) {
+		if (isGenerateStub) {
 			if (generateXtendStub)
 				generateXtendValidatorStub()
 			else
@@ -128,7 +128,7 @@ class ValidatorFragment2 extends AbstractInheritingFragment {
 		// take the non-abstract class signature for the src-gen class in case of !generateStub
 		//  as validators of sub languages refer to 'superGrammar.validatorClass',
 		//  see 'getGenValidatorSuperClass(...)'
-		val genClass = if (generateStub) grammar.abstractValidatorClass else grammar.validatorClass
+		val genClass = if (isGenerateStub) grammar.abstractValidatorClass else grammar.validatorClass
 
 		val javaFile = fileAccessFactory.createGeneratedJavaFile(genClass)
 		
@@ -136,7 +136,7 @@ class ValidatorFragment2 extends AbstractInheritingFragment {
 			«IF !composedChecks.empty»
 			@«ComposedChecks»(validators = {«FOR validator: composedChecks SEPARATOR ", "»«validator.typeRef».class«ENDFOR»})
 			«ENDIF»
-			public «IF generateStub»abstract «ENDIF»class «genClass.simpleName» extends «grammar.genValidatorSuperClass» {
+			public «IF isGenerateStub»abstract «ENDIF»class «genClass.simpleName» extends «grammar.genValidatorSuperClass» {
 				
 				@Override
 				protected «List»<«EPackage»> getEPackages() {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.xtend
@@ -26,6 +26,7 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend2.lib.StringConcatenationClient
 import org.eclipse.xtext.Grammar
 import org.eclipse.xtext.GrammarUtil
+import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment
 import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtext.xtext.generator.Issues
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming
@@ -33,20 +34,21 @@ import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
 import org.eclipse.xtext.xtext.generator.model.TypeReference
 import org.eclipse.xtext.xtext.generator.parser.antlr.ContentAssistGrammarNaming
+import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption
+import org.eclipse.xtext.xtext.generator.util.GeneratorOption
 import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector
 
 import static extension org.eclipse.xtext.GrammarUtil.*
 import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
 import static extension org.eclipse.xtext.xtext.generator.util.GrammarUtil2.*
 import static extension org.eclipse.xtext.xtext.generator.web.RegexpExtensions.*
-import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment
 
 /**
  * Main generator fragment for web integration.
  */
 class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 	
-	private static enum Framework {
+	public static enum Framework {
 		ORION, ACE, CODEMIRROR
 	}
 	
@@ -65,16 +67,28 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 	val enabledPatterns = new HashSet<String>
 	val suppressedPatterns = new HashSet<String>
 	
-	Framework framework
-	boolean generateJsHighlighting = true
+	@Accessors(PUBLIC_GETTER)
+	val framework = new GeneratorOption<Framework>
+	
+	@Accessors(PUBLIC_GETTER)
+	val generateJsHighlighting = new BooleanGeneratorOption(true)
+	
+	@Accessors(PUBLIC_GETTER)
+	val generateServlet = new BooleanGeneratorOption(false)
+	
+	@Accessors(PUBLIC_GETTER)
+	val generateJettyLauncher = new BooleanGeneratorOption(false)
+	
+	@Accessors(PUBLIC_GETTER)
+	val generateWebXml = new BooleanGeneratorOption(false)
+	
+	@Accessors(PUBLIC_GETTER)
+	val generateHtmlExample = new BooleanGeneratorOption(false)
+	
 	String highlightingModuleName
 	String highlightingPath
 	String keywordsFilter = '\\w+'
-	boolean generateServlet = false
-	boolean generateWebXml = false
 	boolean useServlet3Api = true
-	boolean generateJettyLauncher = false
-	boolean generateHtmlExample = false
 	
 	@Accessors(PUBLIC_SETTER)
 	String requireJsVersion = REQUIREJS_VERSION
@@ -96,14 +110,14 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 	 */
 	@Mandatory
 	def void setFramework(String frameworkName) {
-		this.framework = Framework.valueOf(frameworkName.toUpperCase)
+		this.framework.set(Framework.valueOf(frameworkName.toUpperCase))
 	}
 	
 	/**
 	 * Whether JavaScript-based syntax highlighting should be generated. The default is {@code true}.
 	 */
 	def void setGenerateJsHighlighting(boolean generateJsHighlighting) {
-		this.generateJsHighlighting = generateJsHighlighting
+		this.generateJsHighlighting.set(generateJsHighlighting)
 	}
 	
 	/**
@@ -133,14 +147,14 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 	 * Whether a servlet for DSL-specific services should be generated. The default is {@code false}.
 	 */
 	def void setGenerateServlet(boolean generateServlet) {
-		this.generateServlet = generateServlet
+		this.generateServlet.set(generateServlet)
 	}
 	
 	/**
 	 * Whether a web.xml file should be generated. The default is {@code false} (not necessary for Servlet 3 compatible containers).
 	 */
 	def void setGenerateWebXml(boolean generateWebXml) {
-		this.generateWebXml = generateWebXml
+		this.generateWebXml.set(generateWebXml)
 	}
 	
 	/**
@@ -156,7 +170,7 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 	 * is {@code false}.
 	 */
 	def void setGenerateJettyLauncher(boolean generateJettyLauncher) {
-		this.generateJettyLauncher = generateJettyLauncher
+		this.generateJettyLauncher.set(generateJettyLauncher)
 	}
 	
 	/**
@@ -164,7 +178,7 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 	 * The default is {@code false}.
 	 */
 	def void setGenerateHtmlExample(boolean generateHtmlExample) {
-		this.generateHtmlExample = generateHtmlExample
+		this.generateHtmlExample.set(generateHtmlExample)
 	}
 	
 	/**
@@ -193,7 +207,7 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 	
 	override checkConfiguration(Issues issues) {
 		super.checkConfiguration(issues)
-		if (framework === null)
+		if (!framework.isSet)
 			issues.addError('The property \'framework\' is required.')
 		for (pattern : enabledPatterns.filter[suppressedPatterns.contains(it)]) {
 			issues.addError('The pattern \'' + pattern + '\' cannot be enabled and suppressed.')
@@ -201,10 +215,10 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 	}
 	
 	override generate() {
-		if (generateJsHighlighting && projectConfig.web.assets !== null) {
+		if (generateJsHighlighting.get && projectConfig.web.assets !== null) {
 			val langId = language.fileExtensions.head
 			if (highlightingModuleName.nullOrEmpty) {
-				highlightingModuleName = switch framework {
+				highlightingModuleName = switch framework.get {
 					case ORION: 'xtext-resources/generated/' + langId + '-syntax'
 					case ACE, case CODEMIRROR: 'xtext-resources/generated/mode-' + langId
 				}
@@ -216,17 +230,17 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 			generateJsHighlighting(langId)
 		}
 		
-		if (generateServlet && projectConfig.web.src !== null) {
+		if (generateServlet.get && projectConfig.web.src !== null) {
 			generateServlet()
 		}
-		if (generateJettyLauncher && projectConfig.web.src !== null) {
+		if (generateJettyLauncher.get && projectConfig.web.src !== null) {
 			generateServerLauncher()
 		}
-		if (generateHtmlExample && projectConfig.web.assets !== null) {
+		if (generateHtmlExample.get && projectConfig.web.assets !== null) {
 			generateIndexDoc()
 			generateStyleSheet()
 		}
-		if (generateWebXml && projectConfig.web.assets !== null) {
+		if (generateWebXml.get && projectConfig.web.assets !== null) {
 			generateWebXml()
 		}
 		
@@ -257,7 +271,7 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 		Collections.sort(nonWordKeywords)
 		val jsFile = fileAccessFactory.createTextFile()
 		jsFile.path = highlightingPath
-		switch framework {
+		switch framework.get {
 			
 			case ORION: {
 				val patterns = createOrionPatterns(langId, allKeywords)
@@ -458,9 +472,9 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 		if (bracketClose || parenClose || braceClose)
 			patterns.put('start', '''{token: "rparen", regex: "[«IF bracketClose»\\]«ENDIF»«IF parenClose»)«ENDIF»«IF braceClose»}«ENDIF»]"}''')
 		
-		if (framework == Framework.CODEMIRROR && patterns.containsKey('comment'))
+		if (framework.get == Framework.CODEMIRROR && patterns.containsKey('comment'))
 			patterns.put('meta', '''dontIndentStates: ["comment"]''')
-		if (framework == Framework.CODEMIRROR && hasSingleLineComment)
+		if (framework.get == Framework.CODEMIRROR && hasSingleLineComment)
 			patterns.put('meta', '''lineComment: "//"''')
 		
 		return patterns
@@ -480,12 +494,12 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 				<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 				<meta http-equiv="Content-Language" content="en-us">
 				<title>Example Web Editor</title>
-				«IF framework == Framework.ORION»
+				«IF framework.get == Framework.ORION»
 					<link rel="stylesheet" type="text/css" href="orion/code_edit/built-codeEdit.css"/>
 					<link rel="stylesheet" type="text/css" href="xtext/«codeConfig.xtextVersion»/xtext-orion.css"/>
-				«ELSEIF framework == Framework.ACE»
+				«ELSEIF framework.get == Framework.ACE»
 					<link rel="stylesheet" type="text/css" href="xtext/«codeConfig.xtextVersion»/xtext-ace.css"/>
-				«ELSEIF framework == Framework.CODEMIRROR»
+				«ELSEIF framework.get == Framework.CODEMIRROR»
 					<link rel="stylesheet" type="text/css" href="webjars/codemirror/«codeMirrorVersion»/lib/codemirror.css"/>
 					<link rel="stylesheet" type="text/css" href="webjars/codemirror/«codeMirrorVersion»/addon/hint/show-hint.css"/>
 					<link rel="stylesheet" type="text/css" href="xtext/«codeConfig.xtextVersion»/xtext-codemirror.css"/>
@@ -497,7 +511,7 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 					var fileIndex = baseUrl.indexOf("index.html");
 					if (fileIndex > 0)
 						baseUrl = baseUrl.slice(0, fileIndex);
-					«IF framework == Framework.ORION»
+					«IF framework.get == Framework.ORION»
 						require.config({
 							baseUrl: baseUrl,
 							paths: {
@@ -510,11 +524,11 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 							require(["xtext/xtext-orion"], function(xtext) {
 								xtext.createEditor({
 									baseUrl: baseUrl,
-									syntaxDefinition: "«if (generateJsHighlighting) highlightingModuleName else 'none'»"
+									syntaxDefinition: "«if (generateJsHighlighting.get) highlightingModuleName else 'none'»"
 								});
 							});
 						});
-					«ELSEIF framework == Framework.ACE»
+					«ELSEIF framework.get == Framework.ACE»
 						require.config({
 							baseUrl: baseUrl,
 							paths: {
@@ -527,11 +541,11 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 							require(["xtext/xtext-ace"], function(xtext) {
 								xtext.createEditor({
 									baseUrl: baseUrl,
-									syntaxDefinition: "«if (generateJsHighlighting) highlightingModuleName else 'none'»"
+									syntaxDefinition: "«if (generateJsHighlighting.get) highlightingModuleName else 'none'»"
 								});
 							});
 						});
-					«ELSEIF framework == Framework.CODEMIRROR»
+					«ELSEIF framework.get == Framework.CODEMIRROR»
 						require.config({
 							baseUrl: baseUrl,
 							paths: {
@@ -544,9 +558,9 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 								main: "lib/codemirror"
 							}]
 						});
-						require([«IF generateJsHighlighting»"«highlightingModuleName»", «ENDIF»"xtext/xtext-codemirror"], function(«IF generateJsHighlighting»mode, «ENDIF»xtext) {
+						require([«IF generateJsHighlighting.get»"«highlightingModuleName»", «ENDIF»"xtext/xtext-codemirror"], function(«IF generateJsHighlighting.get»mode, «ENDIF»xtext) {
 							xtext.createEditor({
-								baseUrl: baseUrl«IF !generateJsHighlighting»,
+								baseUrl: baseUrl«IF !generateJsHighlighting.get»,
 								syntaxDefinition: "none"
 								«ENDIF»
 							});
@@ -636,7 +650,7 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 				padding: 4px;
 				border: 1px solid #aaa;
 			}
-			«IF framework == Framework.ORION»
+			«IF framework.get == Framework.ORION»
 				
 				/************* Examples for custom icons *************/
 				
@@ -745,7 +759,7 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 				<description>
 					This Example demonstrates the usage of Xtext with a servlet container.
 				</description>
-				«IF generateServlet»
+				«IF generateServlet.get»
 					
 					<servlet>
 						<servlet-name>XtextServices</servlet-name>
@@ -782,7 +796,7 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 						<url-pattern>/webjars/*</url-pattern>
 					</servlet-mapping>
 				«ENDIF»
-				«IF generateHtmlExample»
+				«IF generateHtmlExample.get»
 					
 					<welcome-file-list>
 						<welcome-file>index.html</welcome-file>

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/AbstractStubGeneratingFragment.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xtext.generator;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.xtend.lib.annotations.AccessorType;
 import org.eclipse.xtend.lib.annotations.Accessors;
@@ -15,6 +14,7 @@ import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment;
 import org.eclipse.xtext.xtext.generator.CodeConfig;
+import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption;
 
 @SuppressWarnings("all")
 public abstract class AbstractStubGeneratingFragment extends AbstractXtextGeneratorFragment {
@@ -22,33 +22,36 @@ public abstract class AbstractStubGeneratingFragment extends AbstractXtextGenera
   @Extension
   private CodeConfig _codeConfig;
   
-  @Accessors
-  private boolean generateStub = true;
+  @Accessors(AccessorType.PUBLIC_GETTER)
+  private final BooleanGeneratorOption generateStub = new BooleanGeneratorOption(true);
   
-  @Accessors(AccessorType.PUBLIC_SETTER)
-  private Boolean generateXtendStub = null;
+  private final BooleanGeneratorOption generateXtendStub = new BooleanGeneratorOption();
+  
+  public boolean isGenerateStub() {
+    return this.generateStub.get();
+  }
+  
+  public void setGenerateStub(final boolean generateStub) {
+    this.generateStub.set(generateStub);
+  }
   
   public boolean isGenerateXtendStub() {
     boolean _xifexpression = false;
-    boolean _notEquals = (!Objects.equal(this.generateXtendStub, null));
-    if (_notEquals) {
-      _xifexpression = this.generateXtendStub.booleanValue();
+    boolean _isSet = this.generateXtendStub.isSet();
+    if (_isSet) {
+      _xifexpression = this.generateXtendStub.get();
     } else {
       _xifexpression = this._codeConfig.isPreferXtendStubs();
     }
     return _xifexpression;
   }
   
+  public void setGenerateXtendStub(final boolean generateXtendStub) {
+    this.generateXtendStub.set(generateXtendStub);
+  }
+  
   @Pure
-  public boolean isGenerateStub() {
+  public BooleanGeneratorOption getGenerateStub() {
     return this.generateStub;
-  }
-  
-  public void setGenerateStub(final boolean generateStub) {
-    this.generateStub = generateStub;
-  }
-  
-  public void setGenerateXtendStub(final Boolean generateXtendStub) {
-    this.generateXtendStub = generateXtendStub;
   }
 }

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/StandardLanguage.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/StandardLanguage.java
@@ -8,6 +8,7 @@
 package org.eclipse.xtext.xtext.generator;
 
 import com.google.common.collect.Iterables;
+import com.google.inject.Injector;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
@@ -42,6 +43,8 @@ import org.eclipse.xtext.xtext.generator.ui.outline.QuickOutlineFragment2;
 import org.eclipse.xtext.xtext.generator.ui.quickfix.QuickfixProviderFragment2;
 import org.eclipse.xtext.xtext.generator.ui.refactoring.RefactorElementNameFragment2;
 import org.eclipse.xtext.xtext.generator.ui.templates.CodetemplatesGeneratorFragment2;
+import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption;
+import org.eclipse.xtext.xtext.generator.util.GeneratorOption;
 import org.eclipse.xtext.xtext.generator.validation.ValidatorFragment2;
 import org.eclipse.xtext.xtext.generator.web.WebIntegrationFragment;
 import org.eclipse.xtext.xtext.generator.xbase.XbaseGeneratorFragment2;
@@ -67,12 +70,7 @@ public class StandardLanguage extends XtextGeneratorLanguage {
   
   private ValidatorFragment2 validator = new ValidatorFragment2();
   
-  private Formatter2Fragment2 formatter = ObjectExtensions.<Formatter2Fragment2>operator_doubleArrow(new Formatter2Fragment2(), new Procedure1<Formatter2Fragment2>() {
-    @Override
-    public void apply(final Formatter2Fragment2 it) {
-      it.setGenerateStub(false);
-    }
-  });
+  private Formatter2Fragment2 formatter = new Formatter2Fragment2();
   
   private GeneratorFragment2 generator = new GeneratorFragment2();
   
@@ -102,12 +100,7 @@ public class StandardLanguage extends XtextGeneratorLanguage {
   
   private XtextAntlrIDEAGeneratorFragment ideaParser = new XtextAntlrIDEAGeneratorFragment();
   
-  private TypesGeneratorFragment2 commonTypesSupport = ObjectExtensions.<TypesGeneratorFragment2>operator_doubleArrow(new TypesGeneratorFragment2(), new Procedure1<TypesGeneratorFragment2>() {
-    @Override
-    public void apply(final TypesGeneratorFragment2 it) {
-      it.setOnlyEnabledIfGrammarIsUsed(true);
-    }
-  });
+  private TypesGeneratorFragment2 commonTypesSupport = new TypesGeneratorFragment2();
   
   private XtypeGeneratorFragment2 xtypeSupport = new XtypeGeneratorFragment2();
   
@@ -115,15 +108,7 @@ public class StandardLanguage extends XtextGeneratorLanguage {
   
   private IdeaPluginGenerator ideaPlugin = new IdeaPluginGenerator();
   
-  private WebIntegrationFragment webSupport = ObjectExtensions.<WebIntegrationFragment>operator_doubleArrow(new WebIntegrationFragment(), new Procedure1<WebIntegrationFragment>() {
-    @Override
-    public void apply(final WebIntegrationFragment it) {
-      it.setFramework("Ace");
-      it.setGenerateServlet(true);
-      it.setGenerateJettyLauncher(true);
-      it.setGenerateHtmlExample(true);
-    }
-  });
+  private WebIntegrationFragment webSupport = new WebIntegrationFragment();
   
   public StandardLanguage() {
     try {
@@ -139,6 +124,47 @@ public class StandardLanguage extends XtextGeneratorLanguage {
         throw Exceptions.sneakyThrow(_t);
       }
     }
+  }
+  
+  @Override
+  public void initialize(final Injector injector) {
+    BooleanGeneratorOption _generateStub = this.formatter.getGenerateStub();
+    boolean _isSet = _generateStub.isSet();
+    boolean _not = (!_isSet);
+    if (_not) {
+      this.formatter.setGenerateStub(false);
+    }
+    BooleanGeneratorOption _onlyEnabledIfGrammarIsUsed = this.commonTypesSupport.getOnlyEnabledIfGrammarIsUsed();
+    boolean _isSet_1 = _onlyEnabledIfGrammarIsUsed.isSet();
+    boolean _not_1 = (!_isSet_1);
+    if (_not_1) {
+      this.commonTypesSupport.setOnlyEnabledIfGrammarIsUsed(true);
+    }
+    GeneratorOption<WebIntegrationFragment.Framework> _framework = this.webSupport.getFramework();
+    boolean _isSet_2 = _framework.isSet();
+    boolean _not_2 = (!_isSet_2);
+    if (_not_2) {
+      this.webSupport.setFramework("Ace");
+    }
+    BooleanGeneratorOption _generateServlet = this.webSupport.getGenerateServlet();
+    boolean _isSet_3 = _generateServlet.isSet();
+    boolean _not_3 = (!_isSet_3);
+    if (_not_3) {
+      this.webSupport.setGenerateServlet(true);
+    }
+    BooleanGeneratorOption _generateJettyLauncher = this.webSupport.getGenerateJettyLauncher();
+    boolean _isSet_4 = _generateJettyLauncher.isSet();
+    boolean _not_4 = (!_isSet_4);
+    if (_not_4) {
+      this.webSupport.setGenerateJettyLauncher(true);
+    }
+    BooleanGeneratorOption _generateHtmlExample = this.webSupport.getGenerateHtmlExample();
+    boolean _isSet_5 = _generateHtmlExample.isSet();
+    boolean _not_5 = (!_isSet_5);
+    if (_not_5) {
+      this.webSupport.setGenerateHtmlExample(true);
+    }
+    super.initialize(injector);
   }
   
   @Override

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessFragment2.java
@@ -30,6 +30,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.BinaryResourceImpl;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.xmi.XMLResource;
+import org.eclipse.xtend.lib.annotations.AccessorType;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.AbstractElement;
@@ -51,7 +52,6 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
@@ -71,9 +71,6 @@ import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 @Log
 @SuppressWarnings("all")
 public class GrammarAccessFragment2 extends AbstractXtextGeneratorFragment {
-  @Accessors
-  private String xmlVersion;
-  
   @Inject
   private FileAccessFactory fileAccessFactory;
   
@@ -84,6 +81,9 @@ public class GrammarAccessFragment2 extends AbstractXtextGeneratorFragment {
   @Inject
   @Extension
   private XtextGeneratorNaming _xtextGeneratorNaming;
+  
+  @Accessors(AccessorType.PUBLIC_SETTER)
+  private String xmlVersion;
   
   @Override
   public void generate() {
@@ -1190,11 +1190,6 @@ public class GrammarAccessFragment2 extends AbstractXtextGeneratorFragment {
   }
   
   private final static Logger LOG = Logger.getLogger(GrammarAccessFragment2.class);
-  
-  @Pure
-  public String getXmlVersion() {
-    return this.xmlVersion;
-  }
   
   public void setXmlVersion(final String xmlVersion) {
     this.xmlVersion = xmlVersion;

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/XtextAntlrGeneratorFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/XtextAntlrGeneratorFragment2.java
@@ -23,6 +23,7 @@ import org.antlr.runtime.CharStream;
 import org.antlr.runtime.RecognitionException;
 import org.antlr.runtime.Token;
 import org.antlr.runtime.TokenSource;
+import org.eclipse.xtend.lib.annotations.AccessorType;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
@@ -59,7 +60,6 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
-import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.Issues;
@@ -86,22 +86,22 @@ import org.eclipse.xtext.xtext.generator.parser.antlr.CombinedGrammarMarker;
 import org.eclipse.xtext.xtext.generator.parser.antlr.ContentAssistGrammarNaming;
 import org.eclipse.xtext.xtext.generator.parser.antlr.GrammarNaming;
 import org.eclipse.xtext.xtext.generator.parser.antlr.KeywordHelper;
+import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption;
 import org.eclipse.xtext.xtext.generator.util.SyntheticTerminalDetector;
 
 @SuppressWarnings("all")
 public class XtextAntlrGeneratorFragment2 extends AbstractAntlrGeneratorFragment2 {
-  @Accessors
+  @Accessors(AccessorType.PUBLIC_SETTER)
   private boolean debugGrammar;
   
-  @Accessors
-  private Boolean combinedGrammar = null;
+  private final BooleanGeneratorOption combinedGrammar = new BooleanGeneratorOption();
   
-  @Accessors
+  @Accessors(AccessorType.PUBLIC_SETTER)
   private boolean removeBacktrackingGuards;
   
   private int lookaheadThreshold;
   
-  @Accessors
+  @Accessors(AccessorType.PUBLIC_SETTER)
   private boolean partialParsing;
   
   @Inject
@@ -129,6 +129,33 @@ public class XtextAntlrGeneratorFragment2 extends AbstractAntlrGeneratorFragment
   @Inject
   @Extension
   private SyntheticTerminalDetector _syntheticTerminalDetector;
+  
+  public void setCombinedGrammar(final boolean combinedGrammar) {
+    this.combinedGrammar.set(combinedGrammar);
+  }
+  
+  protected boolean isCombinedGrammar() {
+    boolean _xifexpression = false;
+    boolean _isSet = this.combinedGrammar.isSet();
+    if (_isSet) {
+      _xifexpression = this.combinedGrammar.get();
+    } else {
+      boolean _and = false;
+      AntlrOptions _options = this.getOptions();
+      boolean _isBacktrackLexer = _options.isBacktrackLexer();
+      boolean _not = (!_isBacktrackLexer);
+      if (!_not) {
+        _and = false;
+      } else {
+        AntlrOptions _options_1 = this.getOptions();
+        boolean _isIgnoreCase = _options_1.isIgnoreCase();
+        boolean _not_1 = (!_isIgnoreCase);
+        _and = _not_1;
+      }
+      _xifexpression = _and;
+    }
+    return _xifexpression;
+  }
   
   @Override
   protected void doGenerate() {
@@ -340,36 +367,6 @@ public class XtextAntlrGeneratorFragment2 extends AbstractAntlrGeneratorFragment
       KeywordHelper _helper_1 = KeywordHelper.getHelper(_grammar_1);
       this.cleanupParserTokensFile(lexerGrammar, parserGrammar, _helper_1, fsa);
     }
-  }
-  
-  public boolean isCombinedGrammar() {
-    boolean _or = false;
-    boolean _and = false;
-    boolean _and_1 = false;
-    boolean _equals = Objects.equal(this.combinedGrammar, null);
-    if (!_equals) {
-      _and_1 = false;
-    } else {
-      AntlrOptions _options = this.getOptions();
-      boolean _isBacktrackLexer = _options.isBacktrackLexer();
-      boolean _not = (!_isBacktrackLexer);
-      _and_1 = _not;
-    }
-    if (!_and_1) {
-      _and = false;
-    } else {
-      AntlrOptions _options_1 = this.getOptions();
-      boolean _isIgnoreCase = _options_1.isIgnoreCase();
-      boolean _not_1 = (!_isIgnoreCase);
-      _and = _not_1;
-    }
-    if (_and) {
-      _or = true;
-    } else {
-      boolean _equals_1 = Objects.equal(this.combinedGrammar, Boolean.TRUE);
-      _or = _equals_1;
-    }
-    return _or;
   }
   
   protected void generateDebugGrammar() {
@@ -1631,36 +1628,12 @@ public class XtextAntlrGeneratorFragment2 extends AbstractAntlrGeneratorFragment
     uiBindings.contributeTo(_eclipsePluginGenModule);
   }
   
-  @Pure
-  public boolean isDebugGrammar() {
-    return this.debugGrammar;
-  }
-  
   public void setDebugGrammar(final boolean debugGrammar) {
     this.debugGrammar = debugGrammar;
   }
   
-  @Pure
-  public Boolean getCombinedGrammar() {
-    return this.combinedGrammar;
-  }
-  
-  public void setCombinedGrammar(final Boolean combinedGrammar) {
-    this.combinedGrammar = combinedGrammar;
-  }
-  
-  @Pure
-  public boolean isRemoveBacktrackingGuards() {
-    return this.removeBacktrackingGuards;
-  }
-  
   public void setRemoveBacktrackingGuards(final boolean removeBacktrackingGuards) {
     this.removeBacktrackingGuards = removeBacktrackingGuards;
-  }
-  
-  @Pure
-  public boolean isPartialParsing() {
-    return this.partialParsing;
   }
   
   public void setPartialParsing(final boolean partialParsing) {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/scoping/ImportNamespacesScopingFragment2.java
@@ -11,6 +11,7 @@ import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.name.Names;
 import java.util.Set;
+import org.eclipse.xtend.lib.annotations.AccessorType;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.Grammar;
@@ -23,7 +24,6 @@ import org.eclipse.xtext.scoping.impl.DefaultGlobalScopeProvider;
 import org.eclipse.xtext.scoping.impl.DelegatingScopeProvider;
 import org.eclipse.xtext.scoping.impl.ImportedNamespaceAwareLocalScopeProvider;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.AbstractInheritingFragment;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
@@ -53,7 +53,7 @@ public class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment
   @Inject
   private FileAccessFactory fileAccessFactory;
   
-  @Accessors
+  @Accessors(AccessorType.PUBLIC_SETTER)
   private boolean ignoreCase = false;
   
   protected TypeReference getScopeProviderClass(final Grammar grammar) {
@@ -340,11 +340,6 @@ public class ImportNamespacesScopingFragment2 extends AbstractInheritingFragment
     IRuntimeProjectConfig _runtime = _projectConfig.getRuntime();
     IXtextGeneratorFileSystemAccess _src = _runtime.getSrc();
     _createXtendFile.writeTo(_src);
-  }
-  
-  @Pure
-  public boolean isIgnoreCase() {
-    return this.ignoreCase;
   }
   
   public void setIgnoreCase(final boolean ignoreCase) {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/types/TypesGeneratorFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/types/TypesGeneratorFragment2.java
@@ -9,6 +9,7 @@ package org.eclipse.xtext.xtext.generator.types;
 
 import com.google.inject.Inject;
 import java.util.Set;
+import org.eclipse.xtend.lib.annotations.AccessorType;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtext.Grammar;
 import org.eclipse.xtext.scoping.IGlobalScopeProvider;
@@ -22,6 +23,7 @@ import org.eclipse.xtext.xtext.generator.model.TypeReference;
 import org.eclipse.xtext.xtext.generator.model.project.IBundleProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.IRuntimeProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
+import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption;
 import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector;
 
 @SuppressWarnings("all")
@@ -29,13 +31,18 @@ public class TypesGeneratorFragment2 extends AbstractXtextGeneratorFragment {
   @Inject
   private XbaseUsageDetector xbaseUsageDetector;
   
-  @Accessors
-  private boolean onlyEnabledIfGrammarIsUsed = false;
+  @Accessors(AccessorType.PUBLIC_GETTER)
+  private final BooleanGeneratorOption onlyEnabledIfGrammarIsUsed = new BooleanGeneratorOption(false);
+  
+  public void setOnlyEnabledIfGrammarIsUsed(final boolean onlyEnabledIfGrammarIsUsed) {
+    this.onlyEnabledIfGrammarIsUsed.set(onlyEnabledIfGrammarIsUsed);
+  }
   
   @Override
   public void generate() {
     boolean _and = false;
-    if (!this.onlyEnabledIfGrammarIsUsed) {
+    boolean _get = this.onlyEnabledIfGrammarIsUsed.get();
+    if (!_get) {
       _and = false;
     } else {
       IXtextGeneratorLanguage _language = this.getLanguage();
@@ -109,11 +116,7 @@ public class TypesGeneratorFragment2 extends AbstractXtextGeneratorFragment {
   }
   
   @Pure
-  public boolean isOnlyEnabledIfGrammarIsUsed() {
+  public BooleanGeneratorOption getOnlyEnabledIfGrammarIsUsed() {
     return this.onlyEnabledIfGrammarIsUsed;
-  }
-  
-  public void setOnlyEnabledIfGrammarIsUsed(final boolean onlyEnabledIfGrammarIsUsed) {
-    this.onlyEnabledIfGrammarIsUsed = onlyEnabledIfGrammarIsUsed;
   }
 }

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/quickfix/QuickfixProviderFragment2.java
@@ -120,8 +120,8 @@ public class QuickfixProviderFragment2 extends AbstractInheritingFragment {
       IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_1 = _projectConfig_1.getEclipsePlugin();
       ManifestAccess _manifest = _eclipsePlugin_1.getManifest();
-      boolean _notEquals = (!Objects.equal(_manifest, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals_1 = (_manifest != null);
+      if (_tripleNotEquals_1) {
         IXtextProjectConfig _projectConfig_2 = this.getProjectConfig();
         IBundleProjectConfig _eclipsePlugin_2 = _projectConfig_2.getEclipsePlugin();
         ManifestAccess _manifest_1 = _eclipsePlugin_2.getManifest();
@@ -134,8 +134,8 @@ public class QuickfixProviderFragment2 extends AbstractInheritingFragment {
       IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_3 = _projectConfig_3.getEclipsePlugin();
       PluginXmlAccess _pluginXml = _eclipsePlugin_3.getPluginXml();
-      boolean _notEquals_1 = (!Objects.equal(_pluginXml, null));
-      if (_notEquals_1) {
+      boolean _tripleNotEquals_2 = (_pluginXml != null);
+      if (_tripleNotEquals_2) {
         this.addRegistrationToPluginXml();
       }
     } else {
@@ -145,15 +145,15 @@ public class QuickfixProviderFragment2 extends AbstractInheritingFragment {
       if (_eclipsePlugin_4!=null) {
         _srcGen=_eclipsePlugin_4.getSrcGen();
       }
-      boolean _tripleNotEquals_1 = (_srcGen != null);
-      if (_tripleNotEquals_1) {
+      boolean _tripleNotEquals_3 = (_srcGen != null);
+      if (_tripleNotEquals_3) {
         this.generateGenQuickfixProvider();
       }
       IXtextProjectConfig _projectConfig_5 = this.getProjectConfig();
       IBundleProjectConfig _eclipsePlugin_5 = _projectConfig_5.getEclipsePlugin();
       ManifestAccess _manifest_2 = _eclipsePlugin_5.getManifest();
-      boolean _notEquals_2 = (!Objects.equal(_manifest_2, null));
-      if (_notEquals_2) {
+      boolean _tripleNotEquals_4 = (_manifest_2 != null);
+      if (_tripleNotEquals_4) {
         IXtextProjectConfig _projectConfig_6 = this.getProjectConfig();
         IBundleProjectConfig _eclipsePlugin_6 = _projectConfig_6.getEclipsePlugin();
         ManifestAccess _manifest_3 = _eclipsePlugin_6.getManifest();

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/refactoring/RefactorElementNameFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/ui/refactoring/RefactorElementNameFragment2.java
@@ -12,14 +12,12 @@ import com.google.inject.Inject;
 import com.google.inject.name.Names;
 import java.util.List;
 import java.util.Set;
-import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.Grammar;
 import org.eclipse.xtext.GrammarUtil;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
 import org.eclipse.xtext.xtext.generator.XtextGeneratorNaming;
@@ -29,6 +27,7 @@ import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess;
 import org.eclipse.xtext.xtext.generator.model.TypeReference;
 import org.eclipse.xtext.xtext.generator.model.project.IBundleProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
+import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption;
 import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector;
 
 /**
@@ -46,18 +45,21 @@ public class RefactorElementNameFragment2 extends AbstractXtextGeneratorFragment
   @Extension
   private XbaseUsageDetector _xbaseUsageDetector;
   
-  @Accessors
-  private Boolean useJdtRefactoring = null;
+  private final BooleanGeneratorOption useJdtRefactoring = new BooleanGeneratorOption();
   
   protected boolean isUseJdtRefactoring(final Grammar grammar) {
     boolean _xifexpression = false;
-    boolean _equals = Objects.equal(this.useJdtRefactoring, null);
-    if (_equals) {
-      _xifexpression = this._xbaseUsageDetector.inheritsXbase(grammar);
+    boolean _isSet = this.useJdtRefactoring.isSet();
+    if (_isSet) {
+      _xifexpression = this.useJdtRefactoring.get();
     } else {
-      return this.useJdtRefactoring.booleanValue();
+      _xifexpression = this._xbaseUsageDetector.inheritsXbase(grammar);
     }
     return _xifexpression;
+  }
+  
+  public void setUseJdtRefactoring(final boolean useJdtRefactoring) {
+    this.useJdtRefactoring.set(useJdtRefactoring);
   }
   
   @Override
@@ -294,14 +296,5 @@ public class RefactorElementNameFragment2 extends AbstractXtextGeneratorFragment
       _builder.newLine();
       _entries.add(_builder.toString());
     }
-  }
-  
-  @Pure
-  public Boolean getUseJdtRefactoring() {
-    return this.useJdtRefactoring;
-  }
-  
-  public void setUseJdtRefactoring(final Boolean useJdtRefactoring) {
-    this.useJdtRefactoring = useJdtRefactoring;
   }
 }

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/util/BooleanGeneratorOption.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/util/BooleanGeneratorOption.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xtext.generator.util;
+
+/**
+ * A Boolean-valued option with default value for use in generator fragments.
+ */
+@SuppressWarnings("all")
+public class BooleanGeneratorOption {
+  private final boolean defaultValue;
+  
+  private Boolean value;
+  
+  public BooleanGeneratorOption() {
+    this(false);
+  }
+  
+  public BooleanGeneratorOption(final boolean defaultValue) {
+    this.defaultValue = defaultValue;
+  }
+  
+  public boolean get() {
+    Boolean _elvis = null;
+    if (this.value != null) {
+      _elvis = this.value;
+    } else {
+      _elvis = Boolean.valueOf(this.defaultValue);
+    }
+    return (boolean) _elvis;
+  }
+  
+  public void set(final boolean value) {
+    this.value = Boolean.valueOf(value);
+  }
+  
+  public boolean isSet() {
+    return (this.value != null);
+  }
+}

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/util/GeneratorOption.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/util/GeneratorOption.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.xtext.generator.util;
+
+/**
+ * An object-valued option with default value for use in generator fragments.
+ */
+@SuppressWarnings("all")
+public class GeneratorOption<T extends Object> {
+  private final T defaultValue;
+  
+  private T value;
+  
+  /**
+   * Create an option with no default value.
+   */
+  public GeneratorOption() {
+    this.defaultValue = null;
+  }
+  
+  /**
+   * Create an option with a default value.
+   */
+  public GeneratorOption(final T defaultValue) {
+    this.defaultValue = defaultValue;
+  }
+  
+  public T get() {
+    T _elvis = null;
+    if (this.value != null) {
+      _elvis = this.value;
+    } else {
+      _elvis = this.defaultValue;
+    }
+    return _elvis;
+  }
+  
+  public void set(final T value) {
+    this.value = value;
+  }
+  
+  public boolean isSet() {
+    return (this.value != null);
+  }
+}

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.java
@@ -37,6 +37,7 @@ import org.eclipse.xtext.xbase.lib.Functions.Function0;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment;
 import org.eclipse.xtext.xtext.generator.CodeConfig;
@@ -52,6 +53,8 @@ import org.eclipse.xtext.xtext.generator.model.XtendFileAccess;
 import org.eclipse.xtext.xtext.generator.model.project.IWebProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 import org.eclipse.xtext.xtext.generator.parser.antlr.ContentAssistGrammarNaming;
+import org.eclipse.xtext.xtext.generator.util.BooleanGeneratorOption;
+import org.eclipse.xtext.xtext.generator.util.GeneratorOption;
 import org.eclipse.xtext.xtext.generator.util.GrammarUtil2;
 import org.eclipse.xtext.xtext.generator.web.RegexpExtensions;
 import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector;
@@ -61,7 +64,7 @@ import org.eclipse.xtext.xtext.generator.xbase.XbaseUsageDetector;
  */
 @SuppressWarnings("all")
 public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
-  private enum Framework {
+  public enum Framework {
     ORION,
     
     ACE,
@@ -100,9 +103,23 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
   
   private final HashSet<String> suppressedPatterns = new HashSet<String>();
   
-  private WebIntegrationFragment.Framework framework;
+  @Accessors(AccessorType.PUBLIC_GETTER)
+  private final GeneratorOption<WebIntegrationFragment.Framework> framework = new GeneratorOption<WebIntegrationFragment.Framework>();
   
-  private boolean generateJsHighlighting = true;
+  @Accessors(AccessorType.PUBLIC_GETTER)
+  private final BooleanGeneratorOption generateJsHighlighting = new BooleanGeneratorOption(true);
+  
+  @Accessors(AccessorType.PUBLIC_GETTER)
+  private final BooleanGeneratorOption generateServlet = new BooleanGeneratorOption(false);
+  
+  @Accessors(AccessorType.PUBLIC_GETTER)
+  private final BooleanGeneratorOption generateJettyLauncher = new BooleanGeneratorOption(false);
+  
+  @Accessors(AccessorType.PUBLIC_GETTER)
+  private final BooleanGeneratorOption generateWebXml = new BooleanGeneratorOption(false);
+  
+  @Accessors(AccessorType.PUBLIC_GETTER)
+  private final BooleanGeneratorOption generateHtmlExample = new BooleanGeneratorOption(false);
   
   private String highlightingModuleName;
   
@@ -110,15 +127,7 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
   
   private String keywordsFilter = "\\w+";
   
-  private boolean generateServlet = false;
-  
-  private boolean generateWebXml = false;
-  
   private boolean useServlet3Api = true;
-  
-  private boolean generateJettyLauncher = false;
-  
-  private boolean generateHtmlExample = false;
   
   @Accessors(AccessorType.PUBLIC_SETTER)
   private String requireJsVersion = WebIntegrationFragment.REQUIREJS_VERSION;
@@ -142,14 +151,14 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
   public void setFramework(final String frameworkName) {
     String _upperCase = frameworkName.toUpperCase();
     WebIntegrationFragment.Framework _valueOf = WebIntegrationFragment.Framework.valueOf(_upperCase);
-    this.framework = _valueOf;
+    this.framework.set(_valueOf);
   }
   
   /**
    * Whether JavaScript-based syntax highlighting should be generated. The default is {@code true}.
    */
   public void setGenerateJsHighlighting(final boolean generateJsHighlighting) {
-    this.generateJsHighlighting = generateJsHighlighting;
+    this.generateJsHighlighting.set(generateJsHighlighting);
   }
   
   /**
@@ -179,14 +188,14 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
    * Whether a servlet for DSL-specific services should be generated. The default is {@code false}.
    */
   public void setGenerateServlet(final boolean generateServlet) {
-    this.generateServlet = generateServlet;
+    this.generateServlet.set(generateServlet);
   }
   
   /**
    * Whether a web.xml file should be generated. The default is {@code false} (not necessary for Servlet 3 compatible containers).
    */
   public void setGenerateWebXml(final boolean generateWebXml) {
-    this.generateWebXml = generateWebXml;
+    this.generateWebXml.set(generateWebXml);
   }
   
   /**
@@ -202,7 +211,7 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
    * is {@code false}.
    */
   public void setGenerateJettyLauncher(final boolean generateJettyLauncher) {
-    this.generateJettyLauncher = generateJettyLauncher;
+    this.generateJettyLauncher.set(generateJettyLauncher);
   }
   
   /**
@@ -210,7 +219,7 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
    * The default is {@code false}.
    */
   public void setGenerateHtmlExample(final boolean generateHtmlExample) {
-    this.generateHtmlExample = generateHtmlExample;
+    this.generateHtmlExample.set(generateHtmlExample);
   }
   
   /**
@@ -248,7 +257,9 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
   @Override
   public void checkConfiguration(final Issues issues) {
     super.checkConfiguration(issues);
-    if ((this.framework == null)) {
+    boolean _isSet = this.framework.isSet();
+    boolean _not = (!_isSet);
+    if (_not) {
       issues.addError("The property \'framework\' is required.");
     }
     final Function1<String, Boolean> _function = new Function1<String, Boolean>() {
@@ -266,7 +277,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
   @Override
   public void generate() {
     boolean _and = false;
-    if (!this.generateJsHighlighting) {
+    boolean _get = this.generateJsHighlighting.get();
+    if (!_get) {
       _and = false;
     } else {
       IXtextProjectConfig _projectConfig = this.getProjectConfig();
@@ -282,9 +294,9 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
       boolean _isNullOrEmpty = StringExtensions.isNullOrEmpty(this.highlightingModuleName);
       if (_isNullOrEmpty) {
         String _switchResult = null;
-        final WebIntegrationFragment.Framework framework = this.framework;
-        if (framework != null) {
-          switch (framework) {
+        WebIntegrationFragment.Framework _get_1 = this.framework.get();
+        if (_get_1 != null) {
+          switch (_get_1) {
             case ORION:
               _switchResult = (("xtext-resources/generated/" + langId) + "-syntax");
               break;
@@ -313,7 +325,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
       this.generateJsHighlighting(langId);
     }
     boolean _and_1 = false;
-    if (!this.generateServlet) {
+    boolean _get_2 = this.generateServlet.get();
+    if (!_get_2) {
       _and_1 = false;
     } else {
       IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
@@ -326,7 +339,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
       this.generateServlet();
     }
     boolean _and_2 = false;
-    if (!this.generateJettyLauncher) {
+    boolean _get_3 = this.generateJettyLauncher.get();
+    if (!_get_3) {
       _and_2 = false;
     } else {
       IXtextProjectConfig _projectConfig_2 = this.getProjectConfig();
@@ -339,7 +353,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
       this.generateServerLauncher();
     }
     boolean _and_3 = false;
-    if (!this.generateHtmlExample) {
+    boolean _get_4 = this.generateHtmlExample.get();
+    if (!_get_4) {
       _and_3 = false;
     } else {
       IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();
@@ -353,7 +368,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
       this.generateStyleSheet();
     }
     boolean _and_4 = false;
-    if (!this.generateWebXml) {
+    boolean _get_5 = this.generateWebXml.get();
+    if (!_get_5) {
       _and_4 = false;
     } else {
       IXtextProjectConfig _projectConfig_4 = this.getProjectConfig();
@@ -435,9 +451,9 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
     Collections.<String>sort(nonWordKeywords);
     final TextFileAccess jsFile = this.fileAccessFactory.createTextFile();
     jsFile.setPath(this.highlightingPath);
-    final WebIntegrationFragment.Framework framework = this.framework;
-    if (framework != null) {
-      switch (framework) {
+    WebIntegrationFragment.Framework _get = this.framework.get();
+    if (_get != null) {
+      switch (_get) {
         case ORION:
           final Collection<String> patterns = this.createOrionPatterns(langId, allKeywords);
           boolean _isEmpty = wordKeywords.isEmpty();
@@ -1381,7 +1397,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
       patterns.put("start", _builder_9.toString());
     }
     boolean _and_12 = false;
-    boolean _equals = Objects.equal(this.framework, WebIntegrationFragment.Framework.CODEMIRROR);
+    WebIntegrationFragment.Framework _get = this.framework.get();
+    boolean _equals = Objects.equal(_get, WebIntegrationFragment.Framework.CODEMIRROR);
     if (!_equals) {
       _and_12 = false;
     } else {
@@ -1394,7 +1411,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
       patterns.put("meta", _builder_10.toString());
     }
     boolean _and_13 = false;
-    boolean _equals_1 = Objects.equal(this.framework, WebIntegrationFragment.Framework.CODEMIRROR);
+    WebIntegrationFragment.Framework _get_1 = this.framework.get();
+    boolean _equals_1 = Objects.equal(_get_1, WebIntegrationFragment.Framework.CODEMIRROR);
     if (!_equals_1) {
       _and_13 = false;
     } else {
@@ -1435,7 +1453,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
         _builder.append("<title>Example Web Editor</title>");
         _builder.newLine();
         {
-          boolean _equals = Objects.equal(WebIntegrationFragment.this.framework, WebIntegrationFragment.Framework.ORION);
+          WebIntegrationFragment.Framework _get = WebIntegrationFragment.this.framework.get();
+          boolean _equals = Objects.equal(_get, WebIntegrationFragment.Framework.ORION);
           if (_equals) {
             _builder.append("\t");
             _builder.append("<link rel=\"stylesheet\" type=\"text/css\" href=\"orion/code_edit/built-codeEdit.css\"/>");
@@ -1447,7 +1466,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
             _builder.append("/xtext-orion.css\"/>");
             _builder.newLineIfNotEmpty();
           } else {
-            boolean _equals_1 = Objects.equal(WebIntegrationFragment.this.framework, WebIntegrationFragment.Framework.ACE);
+            WebIntegrationFragment.Framework _get_1 = WebIntegrationFragment.this.framework.get();
+            boolean _equals_1 = Objects.equal(_get_1, WebIntegrationFragment.Framework.ACE);
             if (_equals_1) {
               _builder.append("\t");
               _builder.append("<link rel=\"stylesheet\" type=\"text/css\" href=\"xtext/");
@@ -1456,7 +1476,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
               _builder.append("/xtext-ace.css\"/>");
               _builder.newLineIfNotEmpty();
             } else {
-              boolean _equals_2 = Objects.equal(WebIntegrationFragment.this.framework, WebIntegrationFragment.Framework.CODEMIRROR);
+              WebIntegrationFragment.Framework _get_2 = WebIntegrationFragment.this.framework.get();
+              boolean _equals_2 = Objects.equal(_get_2, WebIntegrationFragment.Framework.CODEMIRROR);
               if (_equals_2) {
                 _builder.append("\t");
                 _builder.append("<link rel=\"stylesheet\" type=\"text/css\" href=\"webjars/codemirror/");
@@ -1502,7 +1523,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
         _builder.append("baseUrl = baseUrl.slice(0, fileIndex);");
         _builder.newLine();
         {
-          boolean _equals_3 = Objects.equal(WebIntegrationFragment.this.framework, WebIntegrationFragment.Framework.ORION);
+          WebIntegrationFragment.Framework _get_3 = WebIntegrationFragment.this.framework.get();
+          boolean _equals_3 = Objects.equal(_get_3, WebIntegrationFragment.Framework.ORION);
           if (_equals_3) {
             _builder.append("\t\t");
             _builder.append("require.config({");
@@ -1560,7 +1582,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
             _builder.append("\t\t\t");
             _builder.append("syntaxDefinition: \"");
             String _xifexpression = null;
-            if (WebIntegrationFragment.this.generateJsHighlighting) {
+            boolean _get_4 = WebIntegrationFragment.this.generateJsHighlighting.get();
+            if (_get_4) {
               _xifexpression = WebIntegrationFragment.this.highlightingModuleName;
             } else {
               _xifexpression = "none";
@@ -1580,7 +1603,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
             _builder.append("});");
             _builder.newLine();
           } else {
-            boolean _equals_4 = Objects.equal(WebIntegrationFragment.this.framework, WebIntegrationFragment.Framework.ACE);
+            WebIntegrationFragment.Framework _get_5 = WebIntegrationFragment.this.framework.get();
+            boolean _equals_4 = Objects.equal(_get_5, WebIntegrationFragment.Framework.ACE);
             if (_equals_4) {
               _builder.append("\t\t");
               _builder.append("require.config({");
@@ -1640,7 +1664,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
               _builder.append("\t\t\t");
               _builder.append("syntaxDefinition: \"");
               String _xifexpression_1 = null;
-              if (WebIntegrationFragment.this.generateJsHighlighting) {
+              boolean _get_6 = WebIntegrationFragment.this.generateJsHighlighting.get();
+              if (_get_6) {
                 _xifexpression_1 = WebIntegrationFragment.this.highlightingModuleName;
               } else {
                 _xifexpression_1 = "none";
@@ -1660,7 +1685,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
               _builder.append("});");
               _builder.newLine();
             } else {
-              boolean _equals_5 = Objects.equal(WebIntegrationFragment.this.framework, WebIntegrationFragment.Framework.CODEMIRROR);
+              WebIntegrationFragment.Framework _get_7 = WebIntegrationFragment.this.framework.get();
+              boolean _equals_5 = Objects.equal(_get_7, WebIntegrationFragment.Framework.CODEMIRROR);
               if (_equals_5) {
                 _builder.append("\t\t");
                 _builder.append("require.config({");
@@ -1718,7 +1744,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
                 _builder.append("\t\t");
                 _builder.append("require([");
                 {
-                  if (WebIntegrationFragment.this.generateJsHighlighting) {
+                  boolean _get_8 = WebIntegrationFragment.this.generateJsHighlighting.get();
+                  if (_get_8) {
                     _builder.append("\"");
                     _builder.append(WebIntegrationFragment.this.highlightingModuleName, "\t\t");
                     _builder.append("\", ");
@@ -1726,7 +1753,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
                 }
                 _builder.append("\"xtext/xtext-codemirror\"], function(");
                 {
-                  if (WebIntegrationFragment.this.generateJsHighlighting) {
+                  boolean _get_9 = WebIntegrationFragment.this.generateJsHighlighting.get();
+                  if (_get_9) {
                     _builder.append("mode, ");
                   }
                 }
@@ -1740,7 +1768,9 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
                 _builder.append("\t\t");
                 _builder.append("baseUrl: baseUrl");
                 {
-                  if ((!WebIntegrationFragment.this.generateJsHighlighting)) {
+                  boolean _get_10 = WebIntegrationFragment.this.generateJsHighlighting.get();
+                  boolean _not = (!_get_10);
+                  if (_not) {
                     _builder.append(",");
                     _builder.newLineIfNotEmpty();
                     _builder.append("\t\t");
@@ -1969,7 +1999,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
         _builder.append("}");
         _builder.newLine();
         {
-          boolean _equals = Objects.equal(WebIntegrationFragment.this.framework, WebIntegrationFragment.Framework.ORION);
+          WebIntegrationFragment.Framework _get = WebIntegrationFragment.this.framework.get();
+          boolean _equals = Objects.equal(_get, WebIntegrationFragment.Framework.ORION);
           if (_equals) {
             _builder.newLine();
             _builder.append("/************* Examples for custom icons *************/");
@@ -2339,7 +2370,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
         _builder.append("</description>");
         _builder.newLine();
         {
-          if (WebIntegrationFragment.this.generateServlet) {
+          boolean _get = WebIntegrationFragment.this.generateServlet.get();
+          if (_get) {
             _builder.append("\t");
             _builder.newLine();
             _builder.append("\t");
@@ -2459,7 +2491,8 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
           }
         }
         {
-          if (WebIntegrationFragment.this.generateHtmlExample) {
+          boolean _get_1 = WebIntegrationFragment.this.generateHtmlExample.get();
+          if (_get_1) {
             _builder.append("\t");
             _builder.newLine();
             _builder.append("\t");
@@ -2494,6 +2527,36 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
     IWebProjectConfig _web_1 = _projectConfig_1.getWeb();
     IXtextGeneratorFileSystemAccess _assets_1 = _web_1.getAssets();
     xmlFile.writeTo(_assets_1);
+  }
+  
+  @Pure
+  public GeneratorOption<WebIntegrationFragment.Framework> getFramework() {
+    return this.framework;
+  }
+  
+  @Pure
+  public BooleanGeneratorOption getGenerateJsHighlighting() {
+    return this.generateJsHighlighting;
+  }
+  
+  @Pure
+  public BooleanGeneratorOption getGenerateServlet() {
+    return this.generateServlet;
+  }
+  
+  @Pure
+  public BooleanGeneratorOption getGenerateJettyLauncher() {
+    return this.generateJettyLauncher;
+  }
+  
+  @Pure
+  public BooleanGeneratorOption getGenerateWebXml() {
+    return this.generateWebXml;
+  }
+  
+  @Pure
+  public BooleanGeneratorOption getGenerateHtmlExample() {
+    return this.generateHtmlExample;
   }
   
   public void setRequireJsVersion(final String requireJsVersion) {


### PR DESCRIPTION
Solved problem: when using the StandardLanguage and overriding a fragment with its corresponding setter, the default options of the fragment were used instead of the default options of the StandardLanguage. Now it can detect whether explicit values have been set by the user, and apply its own default if not.