### PR TITLE
[formatter#480737] improve FormatterFragment.

### DIFF
--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.java
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.java
@@ -11,6 +11,7 @@ import com.google.common.base.Objects;
 import java.util.Arrays;
 import java.util.List;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.common.types.JvmFormalParameter;
 import org.eclipse.xtext.common.types.JvmGenericArrayTypeReference;
 import org.eclipse.xtext.common.types.JvmParameterizedTypeReference;
@@ -417,6 +418,9 @@ public class DomainmodelFormatter extends XbaseFormatter {
       return;
     } else if (entity instanceof XImportSection) {
       _format((XImportSection)entity, document);
+      return;
+    } else if (entity instanceof EObject) {
+      _format((EObject)entity, document);
       return;
     } else if (entity == null) {
       _format((Void)null, document);

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.java
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.example.homeautomation.formatting2;
 import com.google.common.base.Objects;
 import java.util.Arrays;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.common.types.JvmFormalParameter;
 import org.eclipse.xtext.common.types.JvmGenericArrayTypeReference;
 import org.eclipse.xtext.common.types.JvmParameterizedTypeReference;
@@ -621,6 +622,9 @@ public class RuleEngineFormatter extends XbaseFormatter {
       return;
     } else if (device instanceof XImportSection) {
       _format((XImportSection)device, document);
+      return;
+    } else if (device instanceof EObject) {
+      _format((EObject)device, document);
       return;
     } else if (device == null) {
       _format((Void)null, document);

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
@@ -965,6 +965,9 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     } else if (anonymousClass instanceof XImportSection) {
       _format((XImportSection)anonymousClass, format);
       return;
+    } else if (anonymousClass instanceof EObject) {
+      _format((EObject)anonymousClass, format);
+      return;
     } else if (anonymousClass == null) {
       _format((Void)null, format);
       return;

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/annotations/formatting2/XbaseWithAnnotationsFormatter.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/annotations/formatting2/XbaseWithAnnotationsFormatter.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.xbase.annotations.formatting2;
 import com.google.common.base.Objects;
 import java.util.Arrays;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.common.types.JvmFormalParameter;
 import org.eclipse.xtext.common.types.JvmGenericArrayTypeReference;
 import org.eclipse.xtext.common.types.JvmParameterizedTypeReference;
@@ -248,6 +249,9 @@ public class XbaseWithAnnotationsFormatter extends XbaseFormatter {
       return;
     } else if (ann instanceof XImportSection) {
       _format((XImportSection)ann, document);
+      return;
+    } else if (ann instanceof EObject) {
+      _format((EObject)ann, document);
       return;
     } else if (ann == null) {
       _format((Void)null, document);

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
@@ -2379,6 +2379,9 @@ public class XbaseFormatter extends XtypeFormatter {
     } else if (expr instanceof XImportSection) {
       _format((XImportSection)expr, format);
       return;
+    } else if (expr instanceof EObject) {
+      _format((EObject)expr, format);
+      return;
     } else if (expr == null) {
       _format((Void)null, format);
       return;

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XtypeFormatter.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XtypeFormatter.java
@@ -11,6 +11,7 @@ import com.google.common.base.Objects;
 import java.util.Arrays;
 import java.util.List;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.common.types.JvmParameterizedTypeReference;
 import org.eclipse.xtext.common.types.JvmTypeConstraint;
 import org.eclipse.xtext.common.types.JvmTypeParameter;
@@ -276,6 +277,9 @@ public class XtypeFormatter extends AbstractFormatter2 {
       return;
     } else if (ref instanceof XImportSection) {
       _format((XImportSection)ref, document);
+      return;
+    } else if (ref instanceof EObject) {
+      _format((EObject)ref, document);
       return;
     } else if (ref == null) {
       _format((Void)null, document);

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.xtend
@@ -36,8 +36,9 @@ import org.eclipse.xtext.xtext.generator.util.GenModelUtil2
 import static extension org.eclipse.xtext.GrammarUtil.*
 import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
 import static extension org.eclipse.xtext.xtext.generator.util.GrammarUtil2.*
+import org.eclipse.xtext.util.internal.Log
 
-class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
+@Log class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
 	
 	@Inject FileAccessFactory fileAccessFactory
 	
@@ -66,25 +67,35 @@ class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
 	}
 
 	protected def doGenerateStubFile() {
-		val xtendFile = fileAccessFactory.createXtendFile(grammar.formatter2Stub)
-		xtendFile.resourceSet = language.resourceSet
-		
-		val type2ref = LinkedHashMultimap.<EClass, EReference>create
-		getLocallyAssignedContainmentReferences(language.grammar, type2ref)
-		val inheritedTypes = LinkedHashMultimap.<EClass, EReference>create
-		getInheritedContainmentReferences(language.grammar, inheritedTypes, newHashSet)
-		
-		xtendFile.content = '''
-			class «grammar.formatter2Stub.simpleName» extends «stubSuperClass» {
-				
-				@«Inject» extension «grammar.grammarAccess»
-				«FOR type : type2ref.keySet»
+		if(!isGenerateStub)
+			return;
+			
+		if(isGenerateXtendStub) {
+			val xtendFile = fileAccessFactory.createXtendFile(grammar.formatter2Stub)
+			xtendFile.resourceSet = language.resourceSet
+			
+			val type2ref = LinkedHashMultimap.<EClass, EReference>create
+			getLocallyAssignedContainmentReferences(language.grammar, type2ref)
+			val inheritedTypes = LinkedHashMultimap.<EClass, EReference>create
+			getInheritedContainmentReferences(language.grammar, inheritedTypes, newHashSet)
+			val types = type2ref.keySet
+			
+			xtendFile.content = '''
+				class «grammar.formatter2Stub.simpleName» extends «stubSuperClass» {
+					
+					@«Inject» extension «grammar.grammarAccess»
+					«FOR type : types.take(2)»
 
-					«type.generateFormatMethod(type2ref.get(type), inheritedTypes.containsKey(type))»
-				«ENDFOR»	
-			}
-		'''
-		xtendFile.writeTo(projectConfig.runtime.src)
+						«type.generateFormatMethod(type2ref.get(type), inheritedTypes.containsKey(type))»
+					«ENDFOR»	
+					
+					// TODO: implement for «types.drop(2).map[name].join(", ")»
+				}
+			'''
+			xtendFile.writeTo(projectConfig.runtime.src) 
+		} else {
+			LOG.error(this.class.name +  " has been configured to generate a Java stub, but that's not yet supported. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=481563")	
+		}
 	}
 	
 	protected def StringConcatenationClient generateFormatMethod(EClass clazz, Collection<EReference> containmentRefs, boolean isOverriding) '''
@@ -93,10 +104,10 @@ class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
 			«FOR ref:containmentRefs»
 				«IF ref.isMany»
 					for («ref.EReferenceType» «ref.toVarName» : «clazz.toVarName».«ref.getGetAccessor()»()) {
-						format(«ref.toVarName», document);
+						«ref.toVarName».format;
 					}
 				«ELSE»
-					format(«clazz.toVarName».«ref.getGetAccessor()»(), document);
+					«clazz.toVarName».«ref.getGetAccessor()».format;
 				«ENDIF»
 			«ENDFOR»
 		}

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/formatting/Formatter2Fragment2.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.log4j.Logger;
 import org.eclipse.emf.codegen.ecore.genmodel.GenFeature;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
@@ -35,8 +36,11 @@ import org.eclipse.xtext.formatting2.FormatterPreferences;
 import org.eclipse.xtext.formatting2.IFormattableDocument;
 import org.eclipse.xtext.formatting2.IFormatter2;
 import org.eclipse.xtext.preferences.IPreferenceValuesProvider;
+import org.eclipse.xtext.util.internal.Log;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
@@ -52,6 +56,7 @@ import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 import org.eclipse.xtext.xtext.generator.util.GenModelUtil2;
 import org.eclipse.xtext.xtext.generator.util.GrammarUtil2;
 
+@Log
 @SuppressWarnings("all")
 public class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
   @Inject
@@ -116,65 +121,94 @@ public class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
   }
   
   protected void doGenerateStubFile() {
-    Grammar _grammar = this.getGrammar();
-    TypeReference _formatter2Stub = this.getFormatter2Stub(_grammar);
-    final XtendFileAccess xtendFile = this.fileAccessFactory.createXtendFile(_formatter2Stub);
-    IXtextGeneratorLanguage _language = this.getLanguage();
-    ResourceSet _resourceSet = _language.getResourceSet();
-    xtendFile.setResourceSet(_resourceSet);
-    final LinkedHashMultimap<EClass, EReference> type2ref = LinkedHashMultimap.<EClass, EReference>create();
-    IXtextGeneratorLanguage _language_1 = this.getLanguage();
-    Grammar _grammar_1 = _language_1.getGrammar();
-    this.getLocallyAssignedContainmentReferences(_grammar_1, type2ref);
-    final LinkedHashMultimap<EClass, EReference> inheritedTypes = LinkedHashMultimap.<EClass, EReference>create();
-    IXtextGeneratorLanguage _language_2 = this.getLanguage();
-    Grammar _grammar_2 = _language_2.getGrammar();
-    HashSet<Grammar> _newHashSet = CollectionLiterals.<Grammar>newHashSet();
-    this.getInheritedContainmentReferences(_grammar_2, inheritedTypes, _newHashSet);
-    StringConcatenationClient _client = new StringConcatenationClient() {
-      @Override
-      protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-        _builder.append("class ");
-        Grammar _grammar = Formatter2Fragment2.this.getGrammar();
-        TypeReference _formatter2Stub = Formatter2Fragment2.this.getFormatter2Stub(_grammar);
-        String _simpleName = _formatter2Stub.getSimpleName();
-        _builder.append(_simpleName, "");
-        _builder.append(" extends ");
-        TypeReference _stubSuperClass = Formatter2Fragment2.this.getStubSuperClass();
-        _builder.append(_stubSuperClass, "");
-        _builder.append(" {");
-        _builder.newLineIfNotEmpty();
-        _builder.append("\t");
-        _builder.newLine();
-        _builder.append("\t");
-        _builder.append("@");
-        _builder.append(Inject.class, "\t");
-        _builder.append(" extension ");
-        Grammar _grammar_1 = Formatter2Fragment2.this.getGrammar();
-        TypeReference _grammarAccess = Formatter2Fragment2.this._grammarAccessExtensions.getGrammarAccess(_grammar_1);
-        _builder.append(_grammarAccess, "\t");
-        _builder.newLineIfNotEmpty();
-        {
-          Set<EClass> _keySet = type2ref.keySet();
-          for(final EClass type : _keySet) {
-            _builder.newLine();
-            _builder.append("\t");
-            Set<EReference> _get = type2ref.get(type);
-            boolean _containsKey = inheritedTypes.containsKey(type);
-            StringConcatenationClient _generateFormatMethod = Formatter2Fragment2.this.generateFormatMethod(type, _get, _containsKey);
-            _builder.append(_generateFormatMethod, "\t");
-            _builder.newLineIfNotEmpty();
+    boolean _isGenerateStub = this.isGenerateStub();
+    boolean _not = (!_isGenerateStub);
+    if (_not) {
+      return;
+    }
+    boolean _isGenerateXtendStub = this.isGenerateXtendStub();
+    if (_isGenerateXtendStub) {
+      Grammar _grammar = this.getGrammar();
+      TypeReference _formatter2Stub = this.getFormatter2Stub(_grammar);
+      final XtendFileAccess xtendFile = this.fileAccessFactory.createXtendFile(_formatter2Stub);
+      IXtextGeneratorLanguage _language = this.getLanguage();
+      ResourceSet _resourceSet = _language.getResourceSet();
+      xtendFile.setResourceSet(_resourceSet);
+      final LinkedHashMultimap<EClass, EReference> type2ref = LinkedHashMultimap.<EClass, EReference>create();
+      IXtextGeneratorLanguage _language_1 = this.getLanguage();
+      Grammar _grammar_1 = _language_1.getGrammar();
+      this.getLocallyAssignedContainmentReferences(_grammar_1, type2ref);
+      final LinkedHashMultimap<EClass, EReference> inheritedTypes = LinkedHashMultimap.<EClass, EReference>create();
+      IXtextGeneratorLanguage _language_2 = this.getLanguage();
+      Grammar _grammar_2 = _language_2.getGrammar();
+      HashSet<Grammar> _newHashSet = CollectionLiterals.<Grammar>newHashSet();
+      this.getInheritedContainmentReferences(_grammar_2, inheritedTypes, _newHashSet);
+      final Set<EClass> types = type2ref.keySet();
+      StringConcatenationClient _client = new StringConcatenationClient() {
+        @Override
+        protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
+          _builder.append("class ");
+          Grammar _grammar = Formatter2Fragment2.this.getGrammar();
+          TypeReference _formatter2Stub = Formatter2Fragment2.this.getFormatter2Stub(_grammar);
+          String _simpleName = _formatter2Stub.getSimpleName();
+          _builder.append(_simpleName, "");
+          _builder.append(" extends ");
+          TypeReference _stubSuperClass = Formatter2Fragment2.this.getStubSuperClass();
+          _builder.append(_stubSuperClass, "");
+          _builder.append(" {");
+          _builder.newLineIfNotEmpty();
+          _builder.append("\t");
+          _builder.newLine();
+          _builder.append("\t");
+          _builder.append("@");
+          _builder.append(Inject.class, "\t");
+          _builder.append(" extension ");
+          Grammar _grammar_1 = Formatter2Fragment2.this.getGrammar();
+          TypeReference _grammarAccess = Formatter2Fragment2.this._grammarAccessExtensions.getGrammarAccess(_grammar_1);
+          _builder.append(_grammarAccess, "\t");
+          _builder.newLineIfNotEmpty();
+          {
+            Iterable<EClass> _take = IterableExtensions.<EClass>take(types, 2);
+            for(final EClass type : _take) {
+              _builder.newLine();
+              _builder.append("\t");
+              Set<EReference> _get = type2ref.get(type);
+              boolean _containsKey = inheritedTypes.containsKey(type);
+              StringConcatenationClient _generateFormatMethod = Formatter2Fragment2.this.generateFormatMethod(type, _get, _containsKey);
+              _builder.append(_generateFormatMethod, "\t");
+              _builder.newLineIfNotEmpty();
+            }
           }
+          _builder.append("\t");
+          _builder.newLine();
+          _builder.append("\t");
+          _builder.append("// TODO: implement for ");
+          Iterable<EClass> _drop = IterableExtensions.<EClass>drop(types, 2);
+          final Function1<EClass, String> _function = new Function1<EClass, String>() {
+            @Override
+            public String apply(final EClass it) {
+              return it.getName();
+            }
+          };
+          Iterable<String> _map = IterableExtensions.<EClass, String>map(_drop, _function);
+          String _join = IterableExtensions.join(_map, ", ");
+          _builder.append(_join, "\t");
+          _builder.newLineIfNotEmpty();
+          _builder.append("}");
+          _builder.newLine();
         }
-        _builder.append("}");
-        _builder.newLine();
-      }
-    };
-    xtendFile.setContent(_client);
-    IXtextProjectConfig _projectConfig = this.getProjectConfig();
-    IRuntimeProjectConfig _runtime = _projectConfig.getRuntime();
-    IXtextGeneratorFileSystemAccess _src = _runtime.getSrc();
-    xtendFile.writeTo(_src);
+      };
+      xtendFile.setContent(_client);
+      IXtextProjectConfig _projectConfig = this.getProjectConfig();
+      IRuntimeProjectConfig _runtime = _projectConfig.getRuntime();
+      IXtextGeneratorFileSystemAccess _src = _runtime.getSrc();
+      xtendFile.writeTo(_src);
+    } else {
+      Class<? extends Formatter2Fragment2> _class = this.getClass();
+      String _name = _class.getName();
+      String _plus = (_name + " has been configured to generate a Java stub, but that\'s not yet supported. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=481563");
+      Formatter2Fragment2.LOG.error(_plus);
+    }
   }
   
   protected StringConcatenationClient generateFormatMethod(final EClass clazz, final Collection<EReference> containmentRefs, final boolean isOverriding) {
@@ -222,23 +256,21 @@ public class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
                 _builder.newLineIfNotEmpty();
                 _builder.append("\t");
                 _builder.append("\t");
-                _builder.append("format(");
                 String _varName_3 = Formatter2Fragment2.this.toVarName(ref);
                 _builder.append(_varName_3, "\t\t");
-                _builder.append(", document);");
+                _builder.append(".format;");
                 _builder.newLineIfNotEmpty();
                 _builder.append("\t");
                 _builder.append("}");
                 _builder.newLine();
               } else {
                 _builder.append("\t");
-                _builder.append("format(");
                 String _varName_4 = Formatter2Fragment2.this.toVarName(clazz);
                 _builder.append(_varName_4, "\t");
                 _builder.append(".");
                 String _getAccessor_1 = Formatter2Fragment2.this.getGetAccessor(ref);
                 _builder.append(_getAccessor_1, "\t");
-                _builder.append("(), document);");
+                _builder.append(".format;");
                 _builder.newLineIfNotEmpty();
               }
             }
@@ -346,4 +378,6 @@ public class Formatter2Fragment2 extends AbstractStubGeneratingFragment {
     GenFeature _genFeature = GenModelUtil2.getGenFeature(feature, _resourceSet);
     return _genFeature.getGetAccessor();
   }
+  
+  private final static Logger LOG = Logger.getLogger(Formatter2Fragment2.class);
 }

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/AbstractFormatter2.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/AbstractFormatter2.java
@@ -178,6 +178,14 @@ public abstract class AbstractFormatter2 implements IFormatter2 {
 	}
 
 	/**
+	 * Fall-back for types that are not handled by a subclasse's dispatch method.
+	 */
+	protected void _format(EObject obj, IFormattableDocument document) {
+		for (EObject child : obj.eContents())
+			document.format(child);
+	}
+
+	/**
 	 * Fall-back for subclasses that accidently try to dispatch over null values.
 	 */
 	protected void _format(Void obj, IFormattableDocument document) {

--- a/tests/org.eclipse.xtext.testlanguages/xtend-gen/org/eclipse/xtext/testlanguages/backtracking/formatting2/BeeLangTestLanguageFormatter.java
+++ b/tests/org.eclipse.xtext.testlanguages/xtend-gen/org/eclipse/xtext/testlanguages/backtracking/formatting2/BeeLangTestLanguageFormatter.java
@@ -6,6 +6,7 @@ package org.eclipse.xtext.testlanguages.backtracking.formatting2;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.formatting2.AbstractFormatter2;
 import org.eclipse.xtext.formatting2.IFormattableDocument;
 import org.eclipse.xtext.resource.XtextResource;
@@ -341,6 +342,9 @@ public class BeeLangTestLanguageFormatter extends AbstractFormatter2 {
       return;
     } else if (callNamedFunction instanceof Unit) {
       _format((Unit)callNamedFunction, document);
+      return;
+    } else if (callNamedFunction instanceof EObject) {
+      _format((EObject)callNamedFunction, document);
       return;
     } else if (callNamedFunction == null) {
       _format((Void)null, document);

--- a/tests/org.eclipse.xtext.testlanguages/xtend-gen/org/eclipse/xtext/testlanguages/noJdt/formatting2/NoJdtTestLanguageFormatter.java
+++ b/tests/org.eclipse.xtext.testlanguages/xtend-gen/org/eclipse/xtext/testlanguages/noJdt/formatting2/NoJdtTestLanguageFormatter.java
@@ -6,6 +6,7 @@ package org.eclipse.xtext.testlanguages.noJdt.formatting2;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.formatting2.AbstractFormatter2;
 import org.eclipse.xtext.formatting2.IFormattableDocument;
 import org.eclipse.xtext.resource.XtextResource;
@@ -33,6 +34,9 @@ public class NoJdtTestLanguageFormatter extends AbstractFormatter2 {
       return;
     } else if (model instanceof Model) {
       _format((Model)model, document);
+      return;
+    } else if (model instanceof EObject) {
+      _format((EObject)model, document);
       return;
     } else if (model == null) {
       _format((Void)null, document);

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/GenericFormatterTester.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/GenericFormatterTester.xtend
@@ -52,7 +52,7 @@ class GenericFormatterTestRequest extends FormatterTestRequest {
  */
 @Accessors
 abstract class GenericFormatter<T extends EObject> extends AbstractFormatter2 {
-	def dispatch format(EObject obj, IFormattableDocument document) {
+	override dispatch format(EObject obj, IFormattableDocument document) {
 		format(obj as T, request.textRegionAccess.extensions, document)
 	}
 

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/FormatterSerializerIntegrationTest.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/FormatterSerializerIntegrationTest.java
@@ -91,6 +91,9 @@ public class FormatterSerializerIntegrationTest {
       } else if (model instanceof IDList) {
         _format((IDList)model, document);
         return;
+      } else if (model instanceof EObject) {
+        _format((EObject)model, document);
+        return;
       } else if (model == null) {
         _format((Void)null, document);
         return;

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/GenericFormatter.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/GenericFormatter.java
@@ -23,6 +23,7 @@ import org.eclipse.xtext.resource.XtextResource;
 @Accessors
 @SuppressWarnings("all")
 public abstract class GenericFormatter<T extends EObject> extends AbstractFormatter2 {
+  @Override
   protected void _format(final EObject obj, final IFormattableDocument document) {
     FormatterRequest _request = this.getRequest();
     ITextRegionAccess _textRegionAccess = _request.getTextRegionAccess();

--- a/web/org.eclipse.xtext.web.example.statemachine/xtend-gen/org/eclipse/xtext/web/example/statemachine/formatting2/StatemachineFormatter.java
+++ b/web/org.eclipse.xtext.web.example.statemachine/xtend-gen/org/eclipse/xtext/web/example/statemachine/formatting2/StatemachineFormatter.java
@@ -9,6 +9,7 @@ package org.eclipse.xtext.web.example.statemachine.formatting2;
 
 import java.util.Arrays;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.formatting2.AbstractFormatter2;
 import org.eclipse.xtext.formatting2.IFormattableDocument;
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatter;
@@ -138,6 +139,9 @@ public class StatemachineFormatter extends AbstractFormatter2 {
       return;
     } else if (command instanceof Transition) {
       _format((Transition)command, document);
+      return;
+    } else if (command instanceof EObject) {
+      _format((EObject)command, document);
       return;
     } else if (command == null) {
       _format((Void)null, document);


### PR DESCRIPTION
This incorporates two changes:
- for the generate-once stub, the formatter will only generate 
  methods for the first two EClasses. Generating more will most
  likely create code that breaks the next time the grammar is changed.
- have a generic _format(EObject) method in AbstractFormatter2 that 
  does nothing but invoke the formatter-dispatch-method for all
  direct children of the EObject.
  
see https://bugs.eclipse.org/bugs/show_bug.cgi?id=480737

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@itemis.de>