### PR TITLE
[grammar comparison] enhanced grammar comparator to ignore comments

### DIFF
--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/parser/AntlrGrammarComparatorTest.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/parser/AntlrGrammarComparatorTest.xtend
@@ -7,10 +7,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.generator.parser
 
-import org.eclipse.xtext.generator.parser.antlr.AntlrGrammarComparator
 import org.junit.Test
-
-import static org.junit.Assert.*
 
 /**
  * Contributes unit tests for {@link AntlrGrammarComparator}.
@@ -19,14 +16,8 @@ import static org.junit.Assert.*
  */
 class AntlrGrammarComparatorTest {
 
-	AntlrGrammarComparator comparator = new AntlrGrammarComparator
+	private extension AntlrGrammarComparatorTestHelper = new AntlrGrammarComparatorTestHelper();
 
-	TestErrorHandler errorHandler = new TestErrorHandler
-	
-	private def compare(CharSequence grammar, CharSequence grammarReference) {
-		comparator.compareGrammars(grammar, grammarReference, errorHandler);
-	}
-	
 	/**
 	 * The pattern of "\"" is not expected to occur in ANTLR grammar,
 	 *  so I use it for testing the unmatched token check.
@@ -324,28 +315,157 @@ class AntlrGrammarComparatorTest {
 		
 		testee.compare(expected)		
 	}
-
-
-
-	private static class TestErrorHandler implements AntlrGrammarComparator.IErrorHandler {
+	
+	@Test
+	def void sLCommentIgnoring01() {
+		val testee = '''
+			A: 'A'
+			
+			// rule B
+			B: 'B'
+		'''
 		
-		override handleMismatch(String match, String matchReference, AntlrGrammarComparator.ErrorContext context) {
-			fail('''
-				Inputs differs at token «match» (line «context.testedGrammar.lineNumber»), expected token «
-					matchReference» (line «context.referenceGrammar.lineNumber» ).
-			''')
-		}
+		val expected = '''
+			A: 'A'
+			
+			B: 'B'
+		'''
 		
-		override handleInvalidGeneratedGrammarFile(AntlrGrammarComparator.ErrorContext context) {
-			fail('''
-				Noticed an unmatched character sequence in 'testee' in/before line «context.testedGrammar.lineNumber».
-			''')
-		}
+		testee.compare(expected)
+	}
+	
+	@Test
+	def void sLCommentIgnoring01b() {
+		val testee = '''
+			A: 'A'
+			
+			B: 'B'
+		'''
 		
-		override handleInvalidReferenceGrammarFile(AntlrGrammarComparator.ErrorContext context) {
-			fail('''
-				Noticed an unmatched character sequence in 'expected' in/before line «context.referenceGrammar.lineNumber».
-			''')
-		}
+		val expected = '''
+			A: 'A'
+			
+			// rule B
+			B: 'B'
+		'''
+		
+		testee.compare(expected)
+	}
+	
+	@Test
+	def void mismatchWithSLComment01() {
+		val testee = '''
+			A: 'A'
+			
+			B: 'B'
+		'''
+		
+		val expected = '''
+			A: 'A'
+			
+			// rule B
+			B: 'C'
+		'''
+		
+		testee.compareAndExpectMismatchInLines(expected, 3, 4)
+	}
+	
+	@Test(expected = AssertionError)
+	def void mismatchWithSLComment01b() {
+		val testee = '''
+			A: 'A'
+			
+			B: 'B'
+		'''
+		
+		val expected = '''
+			A: 'A'
+			
+			// rule B
+			B: 'C'
+		'''
+		// expected to fail because of wrong 'lineNoTestee'
+		testee.compareAndExpectMismatchInLines(expected, 4, 4)
+	}
+	
+	@Test
+	def void mLCommentIgnoring01() {
+		val testee = '''
+			A: 'A'
+			
+			/*
+			 * rule B
+			 */
+			B: 'B'
+		'''
+		
+		val expected = '''
+			A: 'A'
+			
+			B: 'B'
+		'''
+		
+		testee.compare(expected)
+	}
+	
+	@Test
+	def void mLCommentIgnoring01b() {
+		val testee = '''
+			A: 'A'
+			
+			B: 'B'
+		'''
+		
+		val expected = '''
+			A: 'A'
+			
+			/*
+			 * rule B
+			 */
+			B: 'B'
+		'''
+		
+		testee.compare(expected)
+	}
+	
+	@Test
+	def void mismatchWithMLComment01() {
+		val testee = '''
+			A: 'A'
+			
+			B: 'B'
+		'''
+		
+		val expected = '''
+			A: 'A'
+			
+			/*
+			 * rule B
+			 */
+			B: 'C'
+		'''
+		
+		testee.compareAndExpectMismatchInLines(expected, 3, 6)
+	}
+	
+	@Test(expected = AssertionError)
+	def void mismatchWithMLComment01b() {
+		val testee = '''
+			A: 'A'
+			
+			B: 'B'
+		'''
+		
+		val expected = '''
+			A: 'A'
+			
+			/*
+			 * rule B
+			 */
+			B: 'C'
+		'''
+		
+		// expected to fail because of wrong 'lineNoExpected'
+		testee.compareAndExpectMismatchInLines(expected, 3, 5)
 	}
 }

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/parser/AntlrGrammarComparatorTestHelper.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/parser/AntlrGrammarComparatorTestHelper.xtend
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.generator.parser
+
+import org.eclipse.xtext.generator.parser.antlr.AntlrGrammarComparator
+
+/**
+ * @author Christian Schneider - Initial contribution and API
+ */
+class AntlrGrammarComparatorTestHelper {
+
+	private val AntlrGrammarComparator comparator = new AntlrGrammarComparator
+	private val TestErrorHandler errorHandler = new TestErrorHandler
+
+	def compare(CharSequence grammar, CharSequence grammarReference) {
+		comparator.compareGrammars(grammar, grammarReference, errorHandler);
+	}
+
+	/**
+	 * This method delegates to 'compare(..., ...)' and expects a {@link ComparisonError} reporting a mismatch
+	 * in the given line numbers. If so the error is dropped. If the error reports different line numbers
+	 * the error is re-thrown indicating a failure in the test. If no error occurs in 'compare(..., ...)'
+	 * this test is supposed to fail. 
+	 */
+	def compareAndExpectMismatchInLines(String testee, String expected, int lineNoTestee, int lineNoExpected) {
+		try {			
+			testee.compare(expected)
+		} catch (ComparisonError e) {
+			if (lineNoTestee == e.lineNoTestee && lineNoExpected == e.lineNoExpected) {
+				return
+			} else {
+				throw e;				
+			}
+		}
+		
+		fail('''Expected mismatch in lines «lineNoTestee»/«lineNoExpected».''')
+	}
+
+	private def static fail(String msg) {
+		throw new ComparisonError(msg);
+	}
+
+	private def static fail(int lineNoTestee, int lineNoExpected, String msg) {
+		throw new ComparisonError(lineNoTestee, lineNoExpected, msg);
+	}
+
+	static class ComparisonError extends AssertionError {
+		
+		private val int lineNoTestee 
+		private val int lineNoExpected
+		
+		new(String msg) {
+			super(msg)
+			this.lineNoTestee = -1
+			this.lineNoExpected = -1
+		}
+		
+		new(int lineNoTestee, int lineNoExpected, String msg) {
+			super(msg)
+			this.lineNoTestee = lineNoTestee
+			this.lineNoExpected = lineNoExpected
+		}
+	}
+
+	private static class TestErrorHandler implements AntlrGrammarComparator.IErrorHandler {
+		
+		override handleMismatch(String match, String matchReference, AntlrGrammarComparator.ErrorContext context) {
+			fail(context.testedGrammar.lineNumber, context.referenceGrammar.lineNumber, '''
+				Inputs differs at token «match» (line «context.testedGrammar.lineNumber»), expected token «
+					matchReference» (line «context.referenceGrammar.lineNumber»).
+			''')
+		}
+		
+		override handleInvalidGeneratedGrammarFile(AntlrGrammarComparator.ErrorContext context) {
+			fail('''
+				Noticed an unmatched character sequence in 'testee' in/before line «context.testedGrammar.lineNumber».
+			''')
+		}
+		
+		override handleInvalidReferenceGrammarFile(AntlrGrammarComparator.ErrorContext context) {
+			fail('''
+				Noticed an unmatched character sequence in 'expected' in/before line «context.referenceGrammar.lineNumber».
+			''')
+		}
+	}
+}

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/generator/parser/AntlrGrammarComparatorTest.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/generator/parser/AntlrGrammarComparatorTest.java
@@ -8,8 +8,8 @@
 package org.eclipse.xtext.generator.parser;
 
 import org.eclipse.xtend2.lib.StringConcatenation;
-import org.eclipse.xtext.generator.parser.antlr.AntlrGrammarComparator;
-import org.junit.Assert;
+import org.eclipse.xtext.generator.parser.AntlrGrammarComparatorTestHelper;
+import org.eclipse.xtext.xbase.lib.Extension;
 import org.junit.Test;
 
 /**
@@ -19,59 +19,8 @@ import org.junit.Test;
  */
 @SuppressWarnings("all")
 public class AntlrGrammarComparatorTest {
-  private static class TestErrorHandler implements AntlrGrammarComparator.IErrorHandler {
-    @Override
-    public void handleMismatch(final String match, final String matchReference, final AntlrGrammarComparator.ErrorContext context) {
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("Inputs differs at token ");
-      _builder.append(match, "");
-      _builder.append(" (line ");
-      AntlrGrammarComparator.MatchState _testedGrammar = context.getTestedGrammar();
-      int _lineNumber = _testedGrammar.getLineNumber();
-      _builder.append(_lineNumber, "");
-      _builder.append("), expected token ");
-      _builder.append(matchReference, "");
-      _builder.append(" (line ");
-      AntlrGrammarComparator.MatchState _referenceGrammar = context.getReferenceGrammar();
-      int _lineNumber_1 = _referenceGrammar.getLineNumber();
-      _builder.append(_lineNumber_1, "");
-      _builder.append(" ).");
-      _builder.newLineIfNotEmpty();
-      Assert.fail(_builder.toString());
-    }
-    
-    @Override
-    public void handleInvalidGeneratedGrammarFile(final AntlrGrammarComparator.ErrorContext context) {
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("Noticed an unmatched character sequence in \'testee\' in/before line ");
-      AntlrGrammarComparator.MatchState _testedGrammar = context.getTestedGrammar();
-      int _lineNumber = _testedGrammar.getLineNumber();
-      _builder.append(_lineNumber, "");
-      _builder.append(".");
-      _builder.newLineIfNotEmpty();
-      Assert.fail(_builder.toString());
-    }
-    
-    @Override
-    public void handleInvalidReferenceGrammarFile(final AntlrGrammarComparator.ErrorContext context) {
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("Noticed an unmatched character sequence in \'expected\' in/before line ");
-      AntlrGrammarComparator.MatchState _referenceGrammar = context.getReferenceGrammar();
-      int _lineNumber = _referenceGrammar.getLineNumber();
-      _builder.append(_lineNumber, "");
-      _builder.append(".");
-      _builder.newLineIfNotEmpty();
-      Assert.fail(_builder.toString());
-    }
-  }
-  
-  private AntlrGrammarComparator comparator = new AntlrGrammarComparator();
-  
-  private AntlrGrammarComparatorTest.TestErrorHandler errorHandler = new AntlrGrammarComparatorTest.TestErrorHandler();
-  
-  private AntlrGrammarComparator.ErrorContext compare(final CharSequence grammar, final CharSequence grammarReference) {
-    return this.comparator.compareGrammars(grammar, grammarReference, this.errorHandler);
-  }
+  @Extension
+  private AntlrGrammarComparatorTestHelper _antlrGrammarComparatorTestHelper = new AntlrGrammarComparatorTestHelper();
   
   /**
    * The pattern of "\"" is not expected to occur in ANTLR grammar,
@@ -83,7 +32,7 @@ public class AntlrGrammarComparatorTest {
     _builder.append("\"\\\"\"a");
     _builder.newLine();
     final String testee = _builder.toString();
-    this.compare(testee, testee);
+    this._antlrGrammarComparatorTestHelper.compare(testee, testee);
   }
   
   @Test
@@ -96,7 +45,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("hans");
     _builder_1.newLine();
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test
@@ -107,7 +56,7 @@ public class AntlrGrammarComparatorTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("hans");
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test
@@ -120,7 +69,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("hans hugo");
     _builder_1.newLine();
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test
@@ -131,7 +80,7 @@ public class AntlrGrammarComparatorTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("hans hugo");
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test(expected = AssertionError.class)
@@ -144,7 +93,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("hugo hans");
     _builder_1.newLine();
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test(expected = AssertionError.class)
@@ -155,7 +104,7 @@ public class AntlrGrammarComparatorTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("hugo hans");
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test(expected = AssertionError.class)
@@ -168,7 +117,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("hans hugo");
     _builder_1.newLine();
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test(expected = AssertionError.class)
@@ -179,7 +128,7 @@ public class AntlrGrammarComparatorTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("hans hugo");
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test(expected = AssertionError.class)
@@ -192,7 +141,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("hans");
     _builder_1.newLine();
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test(expected = AssertionError.class)
@@ -203,7 +152,7 @@ public class AntlrGrammarComparatorTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("hans");
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test(expected = AssertionError.class)
@@ -214,7 +163,7 @@ public class AntlrGrammarComparatorTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("hans hugo");
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test(expected = AssertionError.class)
@@ -225,7 +174,7 @@ public class AntlrGrammarComparatorTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("hans hu");
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test
@@ -238,7 +187,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("RULE_IN_RICH_STRING ?");
     _builder_1.newLine();
     final String testee = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test
@@ -251,7 +200,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("RULE_IN_RICH_STRING *");
     _builder_1.newLine();
     final String testee = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test
@@ -264,7 +213,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("RULE_IN_RICH_STRING +");
     _builder_1.newLine();
     final String testee = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test
@@ -294,7 +243,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("}");
     _builder_1.newLine();
     final String testee = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test
@@ -322,7 +271,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("(\'abstract\' | \'annotation\' | \'class\' | \'(\' | RULE_ID | RULE_HEX )");
     _builder_1.newLine();
     final String testee = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test
@@ -331,7 +280,7 @@ public class AntlrGrammarComparatorTest {
     _builder.append("RULE_RICH_TEXT : \'\\\'\\\'\\\'\' RULE_IN_RICH_STRING* (\'\\\'\\\'\\\'\'|(\'\\\'\' \'\\\'\'?)? EOF);");
     _builder.newLine();
     final String testee = _builder.toString();
-    this.compare(testee, testee);
+    this._antlrGrammarComparatorTestHelper.compare(testee, testee);
   }
   
   @Test
@@ -352,7 +301,7 @@ public class AntlrGrammarComparatorTest {
     _builder.append("RULE_COMMENT_RICH_TEXT_END : \'\\u00AB\\u00AB\' ~((\'\\n\'|\'\\r\'))* (\'\\r\'? \'\\n\' RULE_IN_RICH_STRING* (\'\\\'\\\'\\\'\'|(\'\\\'\' \'\\\'\'?)? EOF)|EOF);");
     _builder.newLine();
     final String testee = _builder.toString();
-    this.compare(testee, testee);
+    this._antlrGrammarComparatorTestHelper.compare(testee, testee);
   }
   
   @Test(expected = AssertionError.class)
@@ -365,7 +314,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("hans ( hugo )");
     _builder_1.newLine();
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test(expected = AssertionError.class)
@@ -378,7 +327,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("hans ( hugo )");
     _builder_1.newLine();
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test(expected = AssertionError.class)
@@ -391,7 +340,7 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("{ \'(\' \')\' }");
     _builder_1.newLine();
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
   }
   
   @Test(expected = AssertionError.class)
@@ -404,6 +353,198 @@ public class AntlrGrammarComparatorTest {
     _builder_1.append("{ \'(\' \'(\' \')\' }");
     _builder_1.newLine();
     final String expected = _builder_1.toString();
-    this.compare(testee, expected);
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
+  }
+  
+  @Test
+  public void sLCommentIgnoring01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("A: \'A\'");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("// rule B");
+    _builder.newLine();
+    _builder.append("B: \'B\'");
+    _builder.newLine();
+    final String testee = _builder.toString();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("A: \'A\'");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("B: \'B\'");
+    _builder_1.newLine();
+    final String expected = _builder_1.toString();
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
+  }
+  
+  @Test
+  public void sLCommentIgnoring01b() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("A: \'A\'");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("B: \'B\'");
+    _builder.newLine();
+    final String testee = _builder.toString();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("A: \'A\'");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("// rule B");
+    _builder_1.newLine();
+    _builder_1.append("B: \'B\'");
+    _builder_1.newLine();
+    final String expected = _builder_1.toString();
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
+  }
+  
+  @Test
+  public void mismatchWithSLComment01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("A: \'A\'");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("B: \'B\'");
+    _builder.newLine();
+    final String testee = _builder.toString();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("A: \'A\'");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("// rule B");
+    _builder_1.newLine();
+    _builder_1.append("B: \'C\'");
+    _builder_1.newLine();
+    final String expected = _builder_1.toString();
+    this._antlrGrammarComparatorTestHelper.compareAndExpectMismatchInLines(testee, expected, 3, 4);
+  }
+  
+  @Test(expected = AssertionError.class)
+  public void mismatchWithSLComment01b() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("A: \'A\'");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("B: \'B\'");
+    _builder.newLine();
+    final String testee = _builder.toString();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("A: \'A\'");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("// rule B");
+    _builder_1.newLine();
+    _builder_1.append("B: \'C\'");
+    _builder_1.newLine();
+    final String expected = _builder_1.toString();
+    this._antlrGrammarComparatorTestHelper.compareAndExpectMismatchInLines(testee, expected, 4, 4);
+  }
+  
+  @Test
+  public void mLCommentIgnoring01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("A: \'A\'");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("/*");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* rule B");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("B: \'B\'");
+    _builder.newLine();
+    final String testee = _builder.toString();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("A: \'A\'");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("B: \'B\'");
+    _builder_1.newLine();
+    final String expected = _builder_1.toString();
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
+  }
+  
+  @Test
+  public void mLCommentIgnoring01b() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("A: \'A\'");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("B: \'B\'");
+    _builder.newLine();
+    final String testee = _builder.toString();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("A: \'A\'");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("/*");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* rule B");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    _builder_1.append("B: \'B\'");
+    _builder_1.newLine();
+    final String expected = _builder_1.toString();
+    this._antlrGrammarComparatorTestHelper.compare(testee, expected);
+  }
+  
+  @Test
+  public void mismatchWithMLComment01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("A: \'A\'");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("B: \'B\'");
+    _builder.newLine();
+    final String testee = _builder.toString();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("A: \'A\'");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("/*");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* rule B");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    _builder_1.append("B: \'C\'");
+    _builder_1.newLine();
+    final String expected = _builder_1.toString();
+    this._antlrGrammarComparatorTestHelper.compareAndExpectMismatchInLines(testee, expected, 3, 6);
+  }
+  
+  @Test(expected = AssertionError.class)
+  public void mismatchWithMLComment01b() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("A: \'A\'");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("B: \'B\'");
+    _builder.newLine();
+    final String testee = _builder.toString();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("A: \'A\'");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("/*");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* rule B");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    _builder_1.append("B: \'C\'");
+    _builder_1.newLine();
+    final String expected = _builder_1.toString();
+    this._antlrGrammarComparatorTestHelper.compareAndExpectMismatchInLines(testee, expected, 3, 5);
   }
 }

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/generator/parser/AntlrGrammarComparatorTestHelper.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/generator/parser/AntlrGrammarComparatorTestHelper.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.generator.parser;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.generator.parser.antlr.AntlrGrammarComparator;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+
+/**
+ * @author Christian Schneider - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class AntlrGrammarComparatorTestHelper {
+  public static class ComparisonError extends AssertionError {
+    private final int lineNoTestee;
+    
+    private final int lineNoExpected;
+    
+    public ComparisonError(final String msg) {
+      super(msg);
+      this.lineNoTestee = (-1);
+      this.lineNoExpected = (-1);
+    }
+    
+    public ComparisonError(final int lineNoTestee, final int lineNoExpected, final String msg) {
+      super(msg);
+      this.lineNoTestee = lineNoTestee;
+      this.lineNoExpected = lineNoExpected;
+    }
+  }
+  
+  private static class TestErrorHandler implements AntlrGrammarComparator.IErrorHandler {
+    @Override
+    public void handleMismatch(final String match, final String matchReference, final AntlrGrammarComparator.ErrorContext context) {
+      AntlrGrammarComparator.MatchState _testedGrammar = context.getTestedGrammar();
+      int _lineNumber = _testedGrammar.getLineNumber();
+      AntlrGrammarComparator.MatchState _referenceGrammar = context.getReferenceGrammar();
+      int _lineNumber_1 = _referenceGrammar.getLineNumber();
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("Inputs differs at token ");
+      _builder.append(match, "");
+      _builder.append(" (line ");
+      AntlrGrammarComparator.MatchState _testedGrammar_1 = context.getTestedGrammar();
+      int _lineNumber_2 = _testedGrammar_1.getLineNumber();
+      _builder.append(_lineNumber_2, "");
+      _builder.append("), expected token ");
+      _builder.append(matchReference, "");
+      _builder.append(" (line ");
+      AntlrGrammarComparator.MatchState _referenceGrammar_1 = context.getReferenceGrammar();
+      int _lineNumber_3 = _referenceGrammar_1.getLineNumber();
+      _builder.append(_lineNumber_3, "");
+      _builder.append(").");
+      _builder.newLineIfNotEmpty();
+      AntlrGrammarComparatorTestHelper.fail(_lineNumber, _lineNumber_1, _builder.toString());
+    }
+    
+    @Override
+    public void handleInvalidGeneratedGrammarFile(final AntlrGrammarComparator.ErrorContext context) {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("Noticed an unmatched character sequence in \'testee\' in/before line ");
+      AntlrGrammarComparator.MatchState _testedGrammar = context.getTestedGrammar();
+      int _lineNumber = _testedGrammar.getLineNumber();
+      _builder.append(_lineNumber, "");
+      _builder.append(".");
+      _builder.newLineIfNotEmpty();
+      AntlrGrammarComparatorTestHelper.fail(_builder.toString());
+    }
+    
+    @Override
+    public void handleInvalidReferenceGrammarFile(final AntlrGrammarComparator.ErrorContext context) {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("Noticed an unmatched character sequence in \'expected\' in/before line ");
+      AntlrGrammarComparator.MatchState _referenceGrammar = context.getReferenceGrammar();
+      int _lineNumber = _referenceGrammar.getLineNumber();
+      _builder.append(_lineNumber, "");
+      _builder.append(".");
+      _builder.newLineIfNotEmpty();
+      AntlrGrammarComparatorTestHelper.fail(_builder.toString());
+    }
+  }
+  
+  private final AntlrGrammarComparator comparator = new AntlrGrammarComparator();
+  
+  private final AntlrGrammarComparatorTestHelper.TestErrorHandler errorHandler = new AntlrGrammarComparatorTestHelper.TestErrorHandler();
+  
+  public AntlrGrammarComparator.ErrorContext compare(final CharSequence grammar, final CharSequence grammarReference) {
+    return this.comparator.compareGrammars(grammar, grammarReference, this.errorHandler);
+  }
+  
+  /**
+   * This method delegates to 'compare(..., ...)' and expects a {@link ComparisonError} reporting a mismatch
+   * in the given line numbers. If so the error is dropped. If the error reports different line numbers
+   * the error is re-thrown indicating a failure in the test. If no error occurs in 'compare(..., ...)'
+   * this test is supposed to fail.
+   */
+  public void compareAndExpectMismatchInLines(final String testee, final String expected, final int lineNoTestee, final int lineNoExpected) {
+    try {
+      this.compare(testee, expected);
+    } catch (final Throwable _t) {
+      if (_t instanceof AntlrGrammarComparatorTestHelper.ComparisonError) {
+        final AntlrGrammarComparatorTestHelper.ComparisonError e = (AntlrGrammarComparatorTestHelper.ComparisonError)_t;
+        if (((lineNoTestee == e.lineNoTestee) && (lineNoExpected == e.lineNoExpected))) {
+          return;
+        } else {
+          throw e;
+        }
+      } else {
+        throw Exceptions.sneakyThrow(_t);
+      }
+    }
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Expected mismatch in lines ");
+    _builder.append(lineNoTestee, "");
+    _builder.append("/");
+    _builder.append(lineNoExpected, "");
+    _builder.append(".");
+    AntlrGrammarComparatorTestHelper.fail(_builder.toString());
+  }
+  
+  private static void fail(final String msg) {
+    throw new AntlrGrammarComparatorTestHelper.ComparisonError(msg);
+  }
+  
+  private static void fail(final int lineNoTestee, final int lineNoExpected, final String msg) {
+    throw new AntlrGrammarComparatorTestHelper.ComparisonError(lineNoTestee, lineNoExpected, msg);
+  }
+}


### PR DESCRIPTION
* comparator now ignores single & multi line comments (still counts line numbers),
* added corresponding tests
* moved test helper methods & classes into new helper class
