### PR TITLE
Fix for #482665

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextReplacerContext.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/internal/TextReplacerContext.java
@@ -183,7 +183,7 @@ public class TextReplacerContext implements ITextReplacerContext {
 		if (regions.isEmpty())
 			return true;
 		for (org.eclipse.xtext.util.ITextRegion region : regions)
-			if (region.getOffset() <= repl.getOffset() && region.getOffset() + region.getLength() > repl.getEndOffset())
+			if (region.getOffset() <= repl.getOffset() && region.getOffset() + region.getLength() >= repl.getEndOffset())
 				return true;
 		return false;
 	}

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendFileFormatterTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendFileFormatterTest.xtend
@@ -59,7 +59,8 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 			package foo
 			
 			class bar {
-			}''', '''   package  foo  class  bar  {  }''')	
+			}
+			''', '''   package  foo  class  bar  {  }''')	
 	}
 	
 	@Test def formatClass2() {

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.xtend
@@ -210,7 +210,8 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 		abstract package class XtendTest {
 			static final def void foo() {
 			}
-		}''', '''  abstract  package  class  XtendTest  {  static  final  def  void  foo  (  )  {  }  }''')
+		}
+		''', '''  abstract  package  class  XtendTest  {  static  final  def  void  foo  (  )  {  }  }''')
 	}
 	
 	@Test def bug462628() {
@@ -227,5 +228,18 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 				}
 			'''
 		]
+	}
+	
+	@Test def testBug482665() {
+		assertFormatted('''
+			class Foo {
+				def void someMethod() {
+				}
+			}
+		''','''
+			class Foo { 
+				def void someMethod() {
+				}
+		}''')
 	}
 }

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendFileFormatterTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendFileFormatterTest.java
@@ -104,6 +104,7 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.append("class bar {");
     _builder.newLine();
     _builder.append("}");
+    _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("   ");
     _builder_1.append("package  foo  class  bar  {  }");

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.java
@@ -391,6 +391,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.append("}");
     _builder.newLine();
     _builder.append("}");
+    _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("  ");
     _builder_1.append("abstract  package  class  XtendTest  {  static  final  def  void  foo  (  )  {  }  }");
@@ -430,5 +431,32 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
       }
     };
     this.tester.assertFormatted(_function);
+  }
+  
+  @Test
+  public void testBug482665() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def void someMethod() {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("\t");
+    _builder_1.append("class Foo { ");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("def void someMethod() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    this.assertFormatted(_builder, _builder_1);
   }
 }


### PR DESCRIPTION
Modified the bigger than check to bigger than or equal on
isInRequestedRange as it would otherwise skip the last whitespace region
in a document.

Link to original bug : 
https://bugs.eclipse.org/bugs/show_bug.cgi?id=482665