### PR TITLE
Bug 482845 - [compiler] NPE in ScopeStack when building malformed Xtend

### DIFF
--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/FeatureCallCompiler.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/FeatureCallCompiler.java
@@ -909,7 +909,7 @@ public class FeatureCallCompiler extends LiteralsCompiler {
 			return;
 		}
 		JvmIdentifiableElement feature = call.getFeature();
-		String name;
+		String name = null;
 		if (feature instanceof JvmConstructor) {
 			JvmDeclaredType constructorContainer = ((JvmConstructor) feature).getDeclaringType();
 			JvmIdentifiableElement logicalContainer = contextProvider.getNearestLogicalContainer(call);
@@ -918,7 +918,7 @@ public class FeatureCallCompiler extends LiteralsCompiler {
 				name = "this";
 			else
 				name = "super";
-		} else {
+		} else if(feature != null) {
 			if (b.hasName(feature)) {
 				name = b.getName(feature);
 			} else {

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerErrorHandlingTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerErrorHandlingTest.xtend
@@ -366,8 +366,26 @@ class XtendCompilerErrorHandlingTest extends AbstractXtendTestCase {
 		''')
 	}
 	
-	def assertCompilesTo(CharSequence input, CharSequence expected) {
-		val file = file(input.toString(), false)
+	@Test
+	def void testBug482845() {
+		'''
+			class C {
+				val foo = String.
+			}
+		'''.assertCompilesTo('''
+			@SuppressWarnings("all")
+			public class C {
+			  private final Object foo = String.class./* name is null */;
+			}
+		''', false)
+	}
+	
+	def assertCompilesTo(CharSequence input, CharSequence expected) { 
+		assertCompilesTo(input, expected, true)	
+	}
+	
+	def assertCompilesTo(CharSequence input, CharSequence expected, boolean shouldBeSyntacticallyValid) {
+		val file = file(input.toString(), false, shouldBeSyntacticallyValid)
 		val resource = file.eResource
 		try {
 			// we need to attach the data here explicitly since #generateType is called directly

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerErrorHandlingTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerErrorHandlingTest.java
@@ -632,10 +632,37 @@ public class XtendCompilerErrorHandlingTest extends AbstractXtendTestCase {
     this.assertCompilesTo(_builder, _builder_1);
   }
   
+  @Test
+  public void testBug482845() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class C {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("val foo = String.");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("private final Object foo = String.class./* name is null */;");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1, false);
+  }
+  
   public void assertCompilesTo(final CharSequence input, final CharSequence expected) {
+    this.assertCompilesTo(input, expected, true);
+  }
+  
+  public void assertCompilesTo(final CharSequence input, final CharSequence expected, final boolean shouldBeSyntacticallyValid) {
     try {
       String _string = input.toString();
-      final XtendFile file = this.file(_string, false);
+      final XtendFile file = this.file(_string, false, shouldBeSyntacticallyValid);
       final Resource resource = file.eResource();
       try {
         this.issueProviderFactory.attachData(resource);


### PR DESCRIPTION
Signed-off-by: Dennis Huebner <dennis.huebner@itemis.de>