### PR TITLE
Make the org.eclipse.xtext.xbase.lib.Pair class serializable

### DIFF
--- a/plugins/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/Pair.java
+++ b/plugins/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/Pair.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.lib;
 
+import java.io.Serializable;
+
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Objects;
 
@@ -20,8 +22,9 @@ import com.google.common.base.Objects;
  *            the value-type of the pair.
  * @author Sebastian Zarnekow - Initial contribution and API
  */
-@GwtCompatible public final class Pair<K, V> {
+@GwtCompatible public final class Pair<K, V> implements Serializable {
 
+	private static final long serialVersionUID = 736548906251305939L;
 	private final K k;
 	private final V v;
 	


### PR DESCRIPTION
This PR simply makes the class org.eclipse.xtext.xbase.lib.Pair implements Serializable.

Signed-off-by: Miguel Jiménez <migueljimenezachinte@gmail.com>