### PR TITLE
Fixed Xtend compiler tests

### DIFF
--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
@@ -4904,6 +4904,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 		'''.assertCompilesTo('''
 			package org.xtext.example.mydsl;
 			
+			import java.io.Serializable;
 			import java.util.Collections;
 			import java.util.Map;
 			import java.util.Set;
@@ -4924,7 +4925,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			      1, 2);
 			    final Map<Object, Object> map = Collections.<Object, Object>unmodifiableMap(CollectionLiterals.<Object, Object>newHashMap(pair, _pair, _mappedTo, Bug412642_2.staticPair, this.pairField, _methodStaticPair, _plus));
 			    Pair<String, Integer> _mappedTo_1 = Pair.<String, Integer>of("Banana", Integer.valueOf(2));
-			    final Set<?> set = Collections.<Object>unmodifiableSet(CollectionLiterals.<Object>newHashSet(Integer.valueOf((1 * 2)), _mappedTo_1));
+			    final Set<? extends Serializable> set = Collections.<Serializable>unmodifiableSet(CollectionLiterals.<Serializable>newHashSet(Integer.valueOf((1 * 2)), _mappedTo_1));
 			  }
 			  
 			  public Pair<Object, Object> operator_plus(final int operant, final int operand2) {
@@ -4974,6 +4975,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 		'''.assertCompilesTo('''
 			package org.xtext.example.mydsl;
 			
+			import java.io.Serializable;
 			import java.util.Collections;
 			import java.util.Map;
 			import java.util.Set;
@@ -4994,7 +4996,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			      1, 2);
 			    final Map<Object, Object> map = Collections.<Object, Object>unmodifiableMap(CollectionLiterals.<Object, Object>newHashMap(pair, _pair, _mappedTo, Bug412642_2.staticPair, this.pairField, _methodStaticPair, _plus));
 			    Pair<String, Integer> _mappedTo_1 = Pair.<String, Integer>of("Banana", Integer.valueOf(2));
-			    final Set<?> set = Collections.<Object>unmodifiableSet(CollectionLiterals.<Object>newHashSet(Integer.valueOf((1 * 2)), _mappedTo_1));
+			    final Set<? extends Serializable> set = Collections.<Serializable>unmodifiableSet(CollectionLiterals.<Serializable>newHashSet(Integer.valueOf((1 * 2)), _mappedTo_1));
 			  }
 			  
 			  public Pair<Object, Object> operator_plus(final int operant, final int operand2) {

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
@@ -10812,6 +10812,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("package org.xtext.example.mydsl;");
     _builder_1.newLine();
     _builder_1.newLine();
+    _builder_1.append("import java.io.Serializable;");
+    _builder_1.newLine();
     _builder_1.append("import java.util.Collections;");
     _builder_1.newLine();
     _builder_1.append("import java.util.Map;");
@@ -10862,7 +10864,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("Pair<String, Integer> _mappedTo_1 = Pair.<String, Integer>of(\"Banana\", Integer.valueOf(2));");
     _builder_1.newLine();
     _builder_1.append("    ");
-    _builder_1.append("final Set<?> set = Collections.<Object>unmodifiableSet(CollectionLiterals.<Object>newHashSet(Integer.valueOf((1 * 2)), _mappedTo_1));");
+    _builder_1.append("final Set<? extends Serializable> set = Collections.<Serializable>unmodifiableSet(CollectionLiterals.<Serializable>newHashSet(Integer.valueOf((1 * 2)), _mappedTo_1));");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("}");
@@ -10978,6 +10980,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("package org.xtext.example.mydsl;");
     _builder_1.newLine();
     _builder_1.newLine();
+    _builder_1.append("import java.io.Serializable;");
+    _builder_1.newLine();
     _builder_1.append("import java.util.Collections;");
     _builder_1.newLine();
     _builder_1.append("import java.util.Map;");
@@ -11028,7 +11032,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("Pair<String, Integer> _mappedTo_1 = Pair.<String, Integer>of(\"Banana\", Integer.valueOf(2));");
     _builder_1.newLine();
     _builder_1.append("    ");
-    _builder_1.append("final Set<?> set = Collections.<Object>unmodifiableSet(CollectionLiterals.<Object>newHashSet(Integer.valueOf((1 * 2)), _mappedTo_1));");
+    _builder_1.append("final Set<? extends Serializable> set = Collections.<Serializable>unmodifiableSet(CollectionLiterals.<Serializable>newHashSet(Integer.valueOf((1 * 2)), _mappedTo_1));");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("}");


### PR DESCRIPTION
With PR #827 xbase.lib.Pair has been made Serializable (change 78096c12), which breaks two Xtend compiler tests. I updated the expectations.