### PR TITLE
Bug 483162 - [generator] o.e.x.x.generator.model.TypeReference has not the right pattern to match package and class name

### DIFF
--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TypeReference.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TypeReference.xtend
@@ -18,6 +18,7 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend.lib.annotations.EqualsHashCode
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage
 import org.eclipse.xtext.xtext.generator.util.GenModelUtil2
+import org.eclipse.emf.codegen.util.CodeGenUtil
 
 @Accessors
 @EqualsHashCode
@@ -26,7 +27,7 @@ class TypeReference {
 	static def TypeReference typeRef(String name, TypeReference... arguments) {
 		new TypeReference(name, arguments)
 	}
-	
+
 	/**
 	 * @deprecated this method is available for backwards compatibility reasons
 	 */
@@ -34,24 +35,21 @@ class TypeReference {
 	static def TypeReference guessTypeRef(String name, TypeReference... arguments) {
 		new TypeReference(name, arguments, false)
 	}
-	
+
 	static def TypeReference typeRef(Class<?> clazz, TypeReference... arguments) {
 		new TypeReference(clazz, arguments)
 	}
-	
+
 	static def TypeReference typeRef(EClass clazz, IXtextGeneratorLanguage language) {
 		new TypeReference(clazz, language.resourceSet)
 	}
-	
-	static val PACKAGE_MATCHER = Pattern.compile('([a-zA-Z_$][a-zA-Z0-9_$]*(\\.[a-zA-Z_$][a-zA-Z0-9_$]*)*)?')
-	static val CLASS_MATCHER = Pattern.compile('[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*')
-	
+
 	val String packageName
-	
+
 	val List<String> simpleNames
-	
+
 	val List<TypeReference> typeArguments
-	
+
 	new(String qualifiedName) {
 		this(qualifiedName, null as List<TypeReference>)
 	}
@@ -59,29 +57,29 @@ class TypeReference {
 	new(String qualifiedName, List<TypeReference> arguments) {
 		this(qualifiedName, arguments, true)
 	}
-	
+
 	private new(String qualifiedName, List<TypeReference> arguments, boolean strict) {
 		this(getPackageName(qualifiedName, strict), getClassName(qualifiedName, strict), arguments)
 	}
-	
+
 	new(String packageName, String className) {
 		this(packageName, className, null)
 	}
-	
+
 	new(String packageName, String className, List<TypeReference> arguments) {
-		if (packageName === null || !PACKAGE_MATCHER.matcher(packageName).matches)
+		if (packageName === null || !isValidIdentifier(packageName, true))
 			throw new IllegalArgumentException('Invalid package name: ' + packageName)
-		if (className === null || !CLASS_MATCHER.matcher(className).matches)
+		if (className === null ||  !isValidIdentifier(className, false))
 			throw new IllegalArgumentException('Invalid class name: ' + className)
 		this.packageName = packageName
 		this.simpleNames = className.split('\\.')
 		this.typeArguments = arguments ?: Collections.emptyList
 	}
-	
+
 	new(Class<?> clazz) {
 		this(clazz, null)
 	}
-	
+
 	new(Class<?> clazz, List<TypeReference> arguments) {
 		if (clazz.primitive)
 			throw new IllegalArgumentException('Type is primitive: ' + clazz.name)
@@ -98,37 +96,38 @@ class TypeReference {
 			c = c.declaringClass
 		} while (c !== null)
 	}
-	
+
 	new(EClass clazz, ResourceSet resourceSet) {
 		this(getQualifiedName(clazz, resourceSet))
 	}
-	
+
 	new(EPackage epackage, ResourceSet resourceSet) {
 		this(getQualifiedName(epackage, resourceSet))
 	}
-	
+
 	private static def getPackageName(String qualifiedName, boolean strict) {
 		val segments = Splitter.on('.').split(qualifiedName).toList
 		if (segments.size == 1)
 			return ""
 		if (strict) {
-			val packageSegments = segments.subList(0, segments.length -1)
+			val packageSegments = segments.subList(0, segments.length - 1)
 			if (!packageSegments.filter[Character.isUpperCase(charAt(0))].isEmpty)
-				throw new IllegalArgumentException("Cannot determine the package name of '" + qualifiedName + "'. Please use the TypeReference(packageName, className) constructor")
+				throw new IllegalArgumentException("Cannot determine the package name of '" + qualifiedName +
+					"'. Please use the TypeReference(packageName, className) constructor")
 			return packageSegments.join(".")
 		} else {
-			var packageSegments = segments.subList(0, segments.length -1)
-			while(!packageSegments.isEmpty) {
+			var packageSegments = segments.subList(0, segments.length - 1)
+			while (!packageSegments.isEmpty) {
 				if (Character.isUpperCase(packageSegments.last.charAt(0))) {
-					packageSegments = packageSegments.subList(0, packageSegments.length -1)
+					packageSegments = packageSegments.subList(0, packageSegments.length - 1)
 				} else {
-					return packageSegments.join(".") 
+					return packageSegments.join(".")
 				}
 			}
 			return ""
 		}
 	}
-	
+
 	private static def getClassName(String qualifiedName, boolean strict) {
 		val packageName = qualifiedName.getPackageName(strict)
 		if (packageName.isEmpty)
@@ -136,40 +135,60 @@ class TypeReference {
 		else
 			qualifiedName.substring(packageName.length + 1, qualifiedName.length)
 	}
-	
+
 	private static def getQualifiedName(EClass clazz, ResourceSet resourceSet) {
 		if (clazz.EPackage.nsURI == 'http://www.eclipse.org/2008/Xtext')
 			'org.eclipse.xtext.' + clazz.name
 		else
 			GenModelUtil2.getGenClass(clazz, resourceSet).qualifiedInterfaceName
 	}
-	
+
 	private static def getQualifiedName(EPackage epackage, ResourceSet resourceSet) {
 		GenModelUtil2.getGenPackage(epackage, resourceSet).qualifiedPackageInterfaceName
 	}
-	
+
+	private static def isValidIdentifier(String name, boolean allowEmpty) {
+		if (name.empty)
+			return allowEmpty;
+		val segments = name.split(Pattern.quote("."), -1);
+		return segments.forall[s|s.isValidSegment]
+	}
+
+	private static def isValidSegment(String name) {
+		if (name.isNullOrEmpty || CodeGenUtil::isJavaReservedWord(name))
+			return false
+		if (!Character.isJavaIdentifierStart(name.charAt(0)))
+			return false
+		for (i : 1 ..< name.length) {
+			if (!Character.isJavaIdentifierPart(name.charAt(i))) {
+				return false;
+			}
+		}
+		return true
+	}
+
 	override toString() {
 		name + typeArguments.join('<', ', ', '>', [toString])
 	}
-	
+
 	def String getName() {
 		packageName + '.' + simpleNames.join('.')
 	}
-	
+
 	def String getSimpleName() {
 		simpleNames.last
 	}
-	
+
 	def String getPath() {
 		return packageName.replace('.', '/') + '/' + simpleNames.head
 	}
-	
+
 	def String getJavaPath() {
 		path + ".java"
 	}
-	
+
 	def String getXtendPath() {
 		path + ".xtend"
 	}
-	
+
 }

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TypeReference.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TypeReference.xtend
@@ -43,7 +43,7 @@ class TypeReference {
 		new TypeReference(clazz, language.resourceSet)
 	}
 	
-	static val PACKAGE_MATCHER = Pattern.compile('([a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*)?')
+	static val PACKAGE_MATCHER = Pattern.compile('([a-zA-Z_$][a-zA-Z0-9_$]*(\\.[a-zA-Z_$][a-zA-Z0-9_$]*)*)?')
 	static val CLASS_MATCHER = Pattern.compile('[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*')
 	
 	val String packageName

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/TypeReferenceTest.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/TypeReferenceTest.xtend
@@ -86,4 +86,117 @@ class TypeReferenceTest {
 		val ref = "org.example.MyType".typeRef
 		assertEquals("org/example/MyType.xtend", ref.xtendPath)
 	}
+
+	@Test(expected = IllegalArgumentException)
+	def void tesIllegalPackageNameWithEmptySegment() {
+		new TypeReference("org..example", "MyType")
+	}
+	
+	@Test(expected = IllegalArgumentException)
+	def void tesIllegalPackageNameWithUnderscore() {
+		"org.7z.MyType".typeRef
+	}
+	
+	@Test
+	def void testPackageNameWithUnderscoreAtStart() {
+		val ref = "org._7z.MyType".typeRef
+		assertEquals("MyType", ref.simpleName)
+		assertEquals("org._7z", ref.packageName)
+	}
+
+	@Test
+	def void testPackageNameWithUnderscoreAtEnd() {
+		val ref = "org.z_.MyType".typeRef
+		assertEquals("MyType", ref.simpleName)
+		assertEquals("org.z_", ref.packageName)
+	}
+
+	@Test
+	def void testPackageNameWithUnderscoreInTheMiddle() {
+		val ref = "org.z_x.example.MyType".typeRef
+		assertEquals("MyType", ref.simpleName)
+		assertEquals("org.z_x.example", ref.packageName)
+	}
+
+	@Test(expected = IllegalArgumentException)
+	def void tesIllegalPackageNameWithJavaKeyword() {
+		"org.null.example.MyType".typeRef
+	}
+
+	@Test
+	def void testPackageNameWithDollar() {
+		val ref = "org.$$$.example.MyType".typeRef
+		assertEquals("MyType", ref.simpleName)
+		assertEquals("org.$$$.example", ref.packageName)
+	}
+	
+	@Test(expected = IllegalArgumentException)
+	def void tesIllegalPackageNameWithIllegalChar() {
+		"org.exa*mple.MyType".typeRef
+	}
+
+	@Test
+	def void testNamesInUnicode() {
+		val ref = "\u0440\u0444.\u043F\u0440\u0438\u043C\u0435\u0440.\u0422\u0435\u0441\u0442\u043E\u0432\u044B\u0439\u041A\u043B\u0430\u0441\u0441".typeRef
+		assertEquals("\u0422\u0435\u0441\u0442\u043E\u0432\u044B\u0439\u041A\u043B\u0430\u0441\u0441", ref.simpleName)
+		assertEquals("\u0440\u0444.\u043F\u0440\u0438\u043C\u0435\u0440", ref.packageName)
+	}
+	
+	@Test
+	def void testClassNameWithUnderscoreInTheMiddle() {
+		val ref = "org.example.My_Type".typeRef
+		assertEquals("My_Type", ref.simpleName)
+		assertEquals("org.example", ref.packageName)
+	}
+
+	@Test
+	def void testClassNameWithUnderscoreAtTheStart() {
+		val ref = "org.example._MyType".typeRef
+		assertEquals("_MyType", ref.simpleName)
+		assertEquals("org.example", ref.packageName)
+	}
+
+	@Test
+	def void testClassNameWithUnderscoreAtTheEnd() {
+		val ref = "org.example.MyType_".typeRef
+		assertEquals("MyType_", ref.simpleName)
+		assertEquals("org.example", ref.packageName)
+	}
+
+	@Test
+	def void testClassNameWithDollar() {
+		val ref = "org.example.$My$Type$".typeRef
+		assertEquals("$My$Type$", ref.simpleName)
+		assertEquals("org.example", ref.packageName)
+	}
+
+	@Test(expected = IllegalArgumentException)
+	def void tesIllegalClassNameWithIllegalChar() {
+		"org.example.My&Type".typeRef
+	}
+
+	@Test(expected = IllegalArgumentException)
+	def void testIllegalNames() {
+		new TypeReference(".", ".")
+	}
+
+	@Test(expected = IllegalArgumentException)
+	def void tesIllegalClassName() {
+		new TypeReference("org.example", ".")
+	}
+
+	@Test(expected = IllegalArgumentException)
+	def void tesIllegalClassEmptyName() {
+		new TypeReference("org.example", "")
+	}
+	
+	@Test(expected = IllegalArgumentException)
+	def void tesIllegalClassName2() {
+		new TypeReference("org.example", "ABC.")
+	}
+
+	@Test(expected = IllegalArgumentException)
+	def void tesIllegalClassName3() {
+		new TypeReference("org.example", ".ABC")
+	}
 }


### PR DESCRIPTION
Changed package name validation pattern. Now it allows '_' and '$' in
package name. 

Signed-off-by: George Suaridze <suag@1c.ru>