### PR TITLE
[483080] proposal of fix for bug 483080 in xtext builder

### DIFF
--- a/plugins/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/builderState/MarkerUpdaterImpl.java
+++ b/plugins/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/builderState/MarkerUpdaterImpl.java
@@ -65,12 +65,17 @@ public class MarkerUpdaterImpl implements IMarkerUpdater {
 		IMarkerContributor markerContributor = getMarkerContributor(uri);
 		CheckMode normalAndFastMode = CheckMode.NORMAL_AND_FAST;
 
-		for (Pair<IStorage, IProject> pair : mapper.getStorages(uri)) {
+		for (Pair<IStorage, IProject> pair : mapper.getStorages(uri, false)) {
 			if (monitor.isCanceled()) {
 				throw new OperationCanceledException();
 			}
 			if (pair.getFirst() instanceof IFile) {
 				IFile file = (IFile) pair.getFirst();
+				
+				// if (file.isLinked(IResource.CHECK_ANCESTORS)) {
+				//		continue;
+				// }
+				
 				if (delta.getNew() != null) {
 					if (resourceSet == null)
 						throw new IllegalArgumentException("resourceSet may not be null for changed resources.");

--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/IStorage2UriMapper.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/IStorage2UriMapper.java
@@ -32,6 +32,19 @@ public interface IStorage2UriMapper {
 	 * @return IStorages corresponding to the given URI. Never <code>null</code>. 
 	 */
 	Iterable<Pair<IStorage, IProject>> getStorages(URI uri);
+	
+	/**
+	 * Find the storages that can be mapped to the given URI. It will typically 
+	 * be only one {@link IStorage} associated with one {@link IProject} but 
+	 * in the case that the same external class folder or jar is referenced in 
+	 * multiple projects multiple {@link IStorage}s are returned.
+	 * @param uri the {@link URI}. May not be <code>null</code>.
+	 * @param includeArchivesAndExternals if <code>true</code> the resources within whole classpath will be provided,
+	 * 			otherwise only resources being contained/linked in workspace projects are considered  
+	 * @return IStorages corresponding to the given URI. Never <code>null</code>.
+	 * @since 2.9 
+	 */
+	Iterable<Pair<IStorage, IProject>> getStorages(URI uri, boolean includeArchivesAndExternals);
 
 	/**
 	 * Returns the URI for the given {@link IStorage} or <code>null</code> if no valid URI exists.

--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/Storage2UriMapperImpl.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/Storage2UriMapperImpl.java
@@ -199,24 +199,40 @@ public class Storage2UriMapperImpl implements IStorage2UriMapperExtension {
 
 	@Override
 	public Iterable<Pair<IStorage, IProject>> getStorages(URI uri) {
+		return getStorages(uri, true);
+	}
+
+	/**
+	 * @since 2.9
+	 */
+	@Override
+	public Iterable<Pair<IStorage, IProject>> getStorages(URI uri, boolean includeArchivesAndExternals) {
 		if (!uri.isPlatformResource()) {
 			// support storage lookup by absolute file URI as it is possibly resolved by importURI references
 			if (uri.isFile()) {
 				IPath path = new Path(uri.toFileString());
 				if (path.isAbsolute()) {
 					IFile file = getWorkspaceRoot().getFileForLocation(path);
-					return getStorages(uri, file);
+					return getStorages(uri, file, includeArchivesAndExternals);
 				}
 			}
-			return contribution.getStorages(uri);
+			if (includeArchivesAndExternals) {
+				return contribution.getStorages(uri);
+			} else {
+				return Collections.emptyList(); 
+			}
 		}
 		IFile file = getWorkspaceRoot().getFile(new Path(uri.toPlatformString(true)));
-		return getStorages(uri, file);
+		return getStorages(uri, file, includeArchivesAndExternals);
 	}
 
-	private Iterable<Pair<IStorage, IProject>> getStorages(/* @NonNull */ URI uri, IFile file) {
+	private Iterable<Pair<IStorage, IProject>> getStorages(/* @NonNull */ URI uri, IFile file, boolean includeArchivesAndExternals) {
 		if (file == null || !file.isAccessible()) {
-			return contribution.getStorages(uri);
+			if (includeArchivesAndExternals) {
+				return contribution.getStorages(uri);
+			} else {
+				return Collections.emptyList();
+			}
 		}
 		return Collections.singleton(Tuples.<IStorage,IProject>create(file, file.getProject()));
 	}


### PR DESCRIPTION
I identified an issue with external referenced resources being available as plain files, not jar entries for example. The issue occurs if those files will receive markers by the 'MarkerUpdaterImpl', like TODO markers. My proposal is to exclude those resources from the marker processing.
To that end I introduced an additional method in 'IStorage2UriMapper' allowing to query only non-external resources. Let me know you thoughts on that.

I did not streamline the changes yet in order to simplify review.

Signed-off-by: Christian Schneider <christian.schneider@itemis.de>