### PR TITLE
Update community.html

### DIFF
--- a/xtext-website/community.html
+++ b/xtext-website/community.html
@@ -186,12 +186,12 @@ title: Community
   	            <td>Language</td>
   	            <td>Larry Moore</td>
   	       </tr>
-  	       <tr>
-  	          <td><a href="http://marketplace.eclipse.org/content/graphviz-dot-zest-dot4zest">DOT for Zest</a></td>
-  	          <td>A Graphviz-compatible DSL for the Eclipse Visualization Toolkit</td>
+  	      <tr>
+  	          <td><a href="https://wiki.eclipse.org/GEF/GEF4/DOT">GEF4 DOT</a></td>
+  	          <td>Graphviz DOT language editor</td>
   	          <td>EPL</td>
   	          <td>Language, Framework</td>
-  	          <td>Fabian Steeg, Michael Clay</td>
+  	          <td>Fabian Steeg, Michael Clay, et al.</td>
   	        </tr>
   	        <tr>
   	          <td><a href="https://github.com/dslmeinte/Xtext2-DSLs">dslmeinte's example DSLs</a></td>


### PR DESCRIPTION
Fix broken link and update description of GEF4 DOT (formerly known as DOT for Zest).
Signed-off-by: Alexander Nyßen <alexander.nyssen@itemis.de>