### PR TITLE
Updated IntelliJ plugin download link

### DIFF
--- a/xtext-website/download.html
+++ b/xtext-website/download.html
@@ -57,7 +57,7 @@ title: Download
 			    </p>
 				<h3>Plug-In Repositories</h3>
 				<p>Choose one of the following repository URLs for IDEA :</p>
-				<p><a href="http://download.eclipse.org/modeling/tmf/xtext/idea/2.9.0/updatePlugins.xml" class="has-popover btn btn-primary btn-medium">Releases (right click &amp; copy)</a></p>
+				<p><a href="http://download.eclipse.org/modeling/tmf/xtext/idea/2.9.1/updatePlugins.xml" class="has-popover btn btn-primary btn-medium">Releases (right click &amp; copy)</a></p>
 				<!--p><a href="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/milestones/" class="has-popover btn btn-primary btn-medium">Milestones (right click &amp; copy)</a></p-->
 				<p><a href="https://hudson.eclipse.org/xtext/job/xtext-intellij/lastSuccessfulBuild/artifact/git-repo/intellij/build/ideaRepository/updatePlugins.xml" class="has-popover btn btn-primary btn-medium">Nightly Builds (right click &amp; copy)</a>
 				</p>


### PR DESCRIPTION
The `Release` button for the IntelliJ plugin on the download site still targeted version `2.9.0`. Updated the link to version `2.9.1` to prevent other users running into the issues described [here](https://www.eclipse.org/forums/index.php/m/1720259/#msg_1720259).