### PR TITLE
Bug 485263: Allow javax.inject.Provider in provideX() methods of reflective modules

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/service/ProviderModule.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/service/ProviderModule.java
@@ -13,7 +13,6 @@ import java.lang.reflect.Type;
 
 import org.eclipse.xtext.util.ReflectionUtil;
 
-import com.google.inject.Provider;
 import com.google.inject.binder.LinkedBindingBuilder;
 
 public class ProviderModule extends MethodBasedModule {
@@ -26,20 +25,26 @@ public class ProviderModule extends MethodBasedModule {
 	@Override
 	protected void bindToInstance(LinkedBindingBuilder<Object> bind, Object instance) {
 		if (instance != null) // provider may not be null
-			bind.toProvider((Provider<? extends Object>) instance);
+			bind.toProvider((com.google.inject.Provider<? extends Object>) instance);
 	}
 	
 	@SuppressWarnings("unchecked")
 	@Override
 	protected void bindToClass(LinkedBindingBuilder<Object> bind, Class<?> value) {
-		bind.toProvider((Class<? extends Provider<?>>)value);
+		bind.toProvider((Class<? extends javax.inject.Provider<?>>) value);
 	}
 
 	@Override
 	public Type getKeyType() {
 		Type keyType = super.getKeyType();
-		if (!(isInstanceOf(keyType, Provider.class)))
-			throw new IllegalStateException("The method "+getMethod().getName()+" is expected to return a Class<? extends Provider<Something>> or directly Provider<Something>.");
+		if (!isInstanceOf(keyType, com.google.inject.Provider.class)) {
+			if (isInstanceOf(keyType, javax.inject.Provider.class)) {
+				if (!isClassBinding())
+					throw new IllegalStateException("The method "+getMethod().getName()+" returns javax.inject.Provider, but this kind of binding is allowed only for com.google.inject.Provider.");
+			} else {
+				throw new IllegalStateException("The method "+getMethod().getName()+" is expected to return a Class<? extends Provider<Something>> or directly Provider<Something>.");
+			}
+		}
 		return getFirstTypeParameter((ParameterizedType) keyType);
 	}
 


### PR DESCRIPTION
https://bugs.eclipse.org/bugs/show_bug.cgi?id=485263