### PR TITLE
Bug 486454: TokenRegionProvider computes a wrong region

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/parser/impl/TokenRegionProvider.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/parser/impl/TokenRegionProvider.java
@@ -37,29 +37,20 @@ public class TokenRegionProvider {
 		lexer.setCharStream(new ANTLRStringStream(text));
 		int currentStart = 0;
 		int currentEnd = 0;
-		CommonToken currentToken = (CommonToken) lexer.nextToken();
-		int regionStartOffset = region.getOffset();
-		int regionEnd = regionStartOffset + region.getLength();
-		while (currentToken != Token.EOF_TOKEN) {
-			currentStart = currentToken.getStartIndex();
-			currentEnd = currentToken.getStopIndex() + 1;
-			if (currentToken.getStopIndex() >= regionStartOffset) 
-				break;
-			currentToken = (CommonToken) lexer.nextToken();
+		CommonToken nextToken = (CommonToken) lexer.nextToken();
+		int regionStart = region.getOffset();
+		int regionEnd = regionStart + region.getLength();
+		while (nextToken != Token.EOF_TOKEN && currentEnd <= regionStart) {
+			currentStart = nextToken.getStartIndex();
+			currentEnd = nextToken.getStopIndex() + 1;
+			nextToken = (CommonToken) lexer.nextToken();
 		}
-		if (region.getLength() == 0 && regionStartOffset == currentToken.getStopIndex() + 1) {
-			currentEnd = currentStart;
-		} else {
-			// currentToken is first token overlapping with the region or EOF
-			while (currentToken != Token.EOF_TOKEN) {
-				currentEnd = currentToken.getStopIndex() + 1;
-				if (currentEnd >= regionEnd) {
-					break;
-				}
-				currentToken = (CommonToken) lexer.nextToken();
-			}
+		// nextToken is either EOF or the first token that follows the start of the given region
+		while (nextToken != Token.EOF_TOKEN && currentEnd < regionEnd) {
+			currentEnd = nextToken.getStopIndex() + 1;
+			nextToken = (CommonToken) lexer.nextToken();
 		}
-		if (currentStart != regionStartOffset || currentEnd != regionEnd) 
+		if (currentStart != regionStart || currentEnd != regionEnd) 
 			return new TextRegion(currentStart, currentEnd - currentStart);
 		else 
 			return region;

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/PartialParserTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/PartialParserTest.java
@@ -401,5 +401,13 @@ public class PartialParserTest extends AbstractPartialParserTest {
 		assertTrue(resource.getErrors().toString(), resource.getErrors().isEmpty());
 		assertEquals(model, serialize(resource.getContents().get(0)));
 	}
+	
+	@Test public void testBug486454() throws Exception {
+		with(SimpleExpressionsTestLanguageStandaloneSetup.class);
+		String model = "tim";
+		XtextResource resource = getResourceFromString(model);
+		resource.update(1, 2, "");
+		assertEquals("t", resource.getParseResult().getRootNode().getText());
+	}
 
 }

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/TokenRegionProviderTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/TokenRegionProviderTest.java
@@ -91,6 +91,14 @@ public class TokenRegionProviderTest extends AbstractXtextTests {
 		assertEquals(3, tokenRegion.getLength());
 	}
 	
+	@Test 
+	public void testBug486454() throws Exception {
+		String model = "t";
+		ITextRegion tokenRegion = tokenRegionProvider.getTokenRegion(model, new TextRegion(1, 0));
+		assertEquals(0, tokenRegion.getOffset());
+		assertEquals(1, tokenRegion.getLength());
+	}
+	
 	protected CommonToken findTokenStartingAt(final int offset, List<CommonToken> tokens) {
 		return find(tokens, new Predicate<CommonToken>() {
 			@Override


### PR DESCRIPTION
The problem is in `TokenRegionProvider#getTokenRegion(String, ITextRegion)`: line 51 sets `currentEnd` to `currentStart`, resulting in a region length of zero, which does not cover the whole input region in that particular case.

I tried to simplify the code, please review.