### PR TITLE
Add Support for WriteTraceFiles to BatchCompiler-Main

### DIFF
--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/batch/Main.java
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/batch/Main.java
@@ -56,6 +56,8 @@ public class Main {
 				compiler.setGeneratedAnnotationComment(arguments.next().trim());
 			} else if ("-useCurrentClassLoader".equals(argument)) {
 				compiler.setUseCurrentClassLoaderAsParent(true);
+			} else if ("-writeTraceFiles".equals(argument)) {
+				compiler.setWriteTraceFiles(true);
 			} else {
 				List<String> existingDirs = new ArrayList<String>(compiler.getSourcePathDirectories());
 				existingDirs.add(argument);
@@ -82,6 +84,7 @@ public class Main {
 		out.println("-includeDateInGeneratedAnnnotation  If -generateGeneratedAnnotation is used, add the current date/time.");
 		out.println("-generateAnnotationComment <string> If -generateGeneratedAnnotation is used, add a comment.");
 		out.println("-useCurrentClassLoader              Use current classloader as parent classloader");
+		out.println("-writeTraceFiles                    Write Trace-Files");
 	}
 
 }


### PR DESCRIPTION
https://bugs.eclipse.org/bugs/show_bug.cgi?id=486491 Add Support for WriteTraceFiles to BatchCompiler-Main

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>