### PR TITLE
[web] Added API for template proposals

### DIFF
--- a/plugins/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/AbstractIdeTemplateProposalProvider.xtend
+++ b/plugins/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/AbstractIdeTemplateProposalProvider.xtend
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ide.editor.contentassist
+
+import com.google.inject.Inject
+import org.eclipse.xtend.lib.annotations.Data
+import org.eclipse.xtend2.lib.StringConcatenation
+import org.eclipse.xtend2.lib.StringConcatenationClient
+import org.eclipse.xtext.util.TextRegion
+
+/**
+ * Base class for adding template proposals from an {@link IdeContentProposalProvider} implementation.
+ * Use {@link #variable(String)} and {@link #cursor()} to generate edit positions and an exit position
+ * into the proposal, e.g.
+ * <pre>
+ * val StringConcatenationClient template = '''
+ *     state «variable('name')»
+ *         «cursor»
+ *     end
+ * '''
+ * acceptProposal('state', 'Create a new state', template, context, acceptor)
+ * </pre>
+ * 
+ * @since 2.10
+ */
+abstract class AbstractIdeTemplateProposalProvider {
+	
+	@Inject IdeContentProposalPriorities proposalPriorities
+	
+	/** Placeholder for a variable (edit position) in a template. */
+	@Data
+	protected static class Variable {
+		String name
+	}
+	
+	protected def Variable variable(String name) {
+		new Variable(name)
+	}
+	
+	/** Placeholder for the cursor (exit position) in a template. */
+	protected static class Cursor {
+	}
+	
+	protected def Cursor cursor() {
+		new Cursor
+	}
+	
+	protected def void acceptProposal(String name, String description, StringConcatenationClient template,
+			ContentAssistContext context, IIdeContentProposalAcceptor acceptor) {
+		acceptProposal(name, description, template, context, acceptor, true)
+	}
+	
+	protected def void acceptProposal(String name, String description, StringConcatenationClient template,
+			ContentAssistContext context, IIdeContentProposalAcceptor acceptor, boolean adaptIndentation) {
+		val entry = createProposal(template, context, adaptIndentation)
+		if (canAcceptProposal(entry, context)) {
+			entry.label = name
+			entry.description = description
+			acceptor.accept(entry, proposalPriorities.getDefaultPriority(entry))
+		}
+	}
+	
+	protected def boolean canAcceptProposal(ContentAssistEntry entry, ContentAssistContext context) {
+		entry.proposal.startsWith(context.prefix)
+	}
+	
+	protected def ContentAssistEntry createProposal(StringConcatenationClient template,
+			ContentAssistContext context, boolean adaptIndentation) {
+		val entry = new ContentAssistEntry
+		entry.prefix = context.prefix
+		val stringConcat = new TemplateStringConcatenation(context, entry, lineDelimiter)
+		val indentation = if (adaptIndentation) context.indentation else null
+		if (indentation === null)
+			stringConcat.append(template)
+		else
+			stringConcat.append(template, indentation)
+		entry.proposal = stringConcat.toString
+		return entry
+	}
+	
+	protected def String getLineDelimiter() {
+		StringConcatenation.DEFAULT_LINE_DELIMITER
+	}
+	
+	protected def String getIndentation(ContentAssistContext context) {
+		val text = context.rootNode?.text
+		if (text !== null && text.length >= context.offset) {
+			var lineStart = context.replaceRegion.offset
+			var indentEnd = lineStart
+			while (lineStart > 0 && text.charAt(lineStart - 1) != '\n'.charAt(0)) {
+				lineStart--
+				if (!Character.isWhitespace(text.charAt(lineStart)))
+					indentEnd = lineStart
+			}
+			return text.substring(lineStart, indentEnd)
+		}
+	}
+	
+	private static class TemplateStringConcatenation extends StringConcatenation {
+		
+		val ContentAssistContext context
+		val ContentAssistEntry entry
+		
+		new(ContentAssistContext context, ContentAssistEntry entry, String lineDelimiter) {
+			super(lineDelimiter)
+			this.context = context
+			this.entry = entry
+		}
+		
+		override protected getStringRepresentation(Object object) {
+			if (object instanceof Variable) {
+				val varName = object.name
+				val offset = context.replaceRegion.offset + currentOffset
+				entry.editPositions.add(new TextRegion(offset, varName.length))
+				return varName
+			} else if (object instanceof Cursor) {
+				val offset = context.replaceRegion.offset + currentOffset
+				entry.setEscapePosition(offset)
+				return null
+			} else {
+				return object.toString
+			}
+		}
+		
+		protected def int getCurrentOffset() {
+			var result = 0
+			for (segment : content) {
+				result += segment.length
+			}
+			return result
+		}
+		
+		override newLineIfNotEmpty() {
+			newLine()
+		}
+		
+	}
+	
+}

--- a/plugins/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/editor/contentassist/AbstractIdeTemplateProposalProvider.java
+++ b/plugins/org.eclipse.xtext.ide/xtend-gen/org/eclipse/xtext/ide/editor/contentassist/AbstractIdeTemplateProposalProvider.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ide.editor.contentassist;
+
+import com.google.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.xtend.lib.annotations.Data;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtend2.lib.StringConcatenationClient;
+import org.eclipse.xtext.ide.editor.contentassist.ContentAssistContext;
+import org.eclipse.xtext.ide.editor.contentassist.ContentAssistEntry;
+import org.eclipse.xtext.ide.editor.contentassist.IIdeContentProposalAcceptor;
+import org.eclipse.xtext.ide.editor.contentassist.IdeContentProposalPriorities;
+import org.eclipse.xtext.nodemodel.ICompositeNode;
+import org.eclipse.xtext.util.ITextRegion;
+import org.eclipse.xtext.util.TextRegion;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Base class for adding template proposals from an {@link IdeContentProposalProvider} implementation.
+ * Use {@link #variable(String)} and {@link #cursor()} to generate edit positions and an exit position
+ * into the proposal, e.g.
+ * <pre>
+ * val StringConcatenationClient template = '''
+ *     state «variable('name')»
+ *         «cursor»
+ *     end
+ * '''
+ * acceptProposal('state', 'Create a new state', template, context, acceptor)
+ * </pre>
+ * 
+ * @since 2.10
+ */
+@SuppressWarnings("all")
+public abstract class AbstractIdeTemplateProposalProvider {
+  /**
+   * Placeholder for a variable (edit position) in a template.
+   */
+  @Data
+  protected static class Variable {
+    private final String name;
+    
+    public Variable(final String name) {
+      super();
+      this.name = name;
+    }
+    
+    @Override
+    @Pure
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((this.name== null) ? 0 : this.name.hashCode());
+      return result;
+    }
+    
+    @Override
+    @Pure
+    public boolean equals(final Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+        return false;
+      AbstractIdeTemplateProposalProvider.Variable other = (AbstractIdeTemplateProposalProvider.Variable) obj;
+      if (this.name == null) {
+        if (other.name != null)
+          return false;
+      } else if (!this.name.equals(other.name))
+        return false;
+      return true;
+    }
+    
+    @Override
+    @Pure
+    public String toString() {
+      ToStringBuilder b = new ToStringBuilder(this);
+      b.add("name", this.name);
+      return b.toString();
+    }
+    
+    @Pure
+    public String getName() {
+      return this.name;
+    }
+  }
+  
+  /**
+   * Placeholder for the cursor (exit position) in a template.
+   */
+  protected static class Cursor {
+  }
+  
+  private static class TemplateStringConcatenation extends StringConcatenation {
+    private final ContentAssistContext context;
+    
+    private final ContentAssistEntry entry;
+    
+    public TemplateStringConcatenation(final ContentAssistContext context, final ContentAssistEntry entry, final String lineDelimiter) {
+      super(lineDelimiter);
+      this.context = context;
+      this.entry = entry;
+    }
+    
+    @Override
+    protected String getStringRepresentation(final Object object) {
+      if ((object instanceof AbstractIdeTemplateProposalProvider.Variable)) {
+        final String varName = ((AbstractIdeTemplateProposalProvider.Variable)object).name;
+        ITextRegion _replaceRegion = this.context.getReplaceRegion();
+        int _offset = _replaceRegion.getOffset();
+        int _currentOffset = this.getCurrentOffset();
+        final int offset = (_offset + _currentOffset);
+        ArrayList<TextRegion> _editPositions = this.entry.getEditPositions();
+        int _length = varName.length();
+        TextRegion _textRegion = new TextRegion(offset, _length);
+        _editPositions.add(_textRegion);
+        return varName;
+      } else {
+        if ((object instanceof AbstractIdeTemplateProposalProvider.Cursor)) {
+          ITextRegion _replaceRegion_1 = this.context.getReplaceRegion();
+          int _offset_1 = _replaceRegion_1.getOffset();
+          int _currentOffset_1 = this.getCurrentOffset();
+          final int offset_1 = (_offset_1 + _currentOffset_1);
+          this.entry.setEscapePosition(Integer.valueOf(offset_1));
+          return null;
+        } else {
+          return object.toString();
+        }
+      }
+    }
+    
+    protected int getCurrentOffset() {
+      int result = 0;
+      List<String> _content = this.getContent();
+      for (final String segment : _content) {
+        int _result = result;
+        int _length = segment.length();
+        result = (_result + _length);
+      }
+      return result;
+    }
+    
+    @Override
+    public void newLineIfNotEmpty() {
+      this.newLine();
+    }
+  }
+  
+  @Inject
+  private IdeContentProposalPriorities proposalPriorities;
+  
+  protected AbstractIdeTemplateProposalProvider.Variable variable(final String name) {
+    return new AbstractIdeTemplateProposalProvider.Variable(name);
+  }
+  
+  protected AbstractIdeTemplateProposalProvider.Cursor cursor() {
+    return new AbstractIdeTemplateProposalProvider.Cursor();
+  }
+  
+  protected void acceptProposal(final String name, final String description, final StringConcatenationClient template, final ContentAssistContext context, final IIdeContentProposalAcceptor acceptor) {
+    this.acceptProposal(name, description, template, context, acceptor, true);
+  }
+  
+  protected void acceptProposal(final String name, final String description, final StringConcatenationClient template, final ContentAssistContext context, final IIdeContentProposalAcceptor acceptor, final boolean adaptIndentation) {
+    final ContentAssistEntry entry = this.createProposal(template, context, adaptIndentation);
+    boolean _canAcceptProposal = this.canAcceptProposal(entry, context);
+    if (_canAcceptProposal) {
+      entry.setLabel(name);
+      entry.setDescription(description);
+      int _defaultPriority = this.proposalPriorities.getDefaultPriority(entry);
+      acceptor.accept(entry, _defaultPriority);
+    }
+  }
+  
+  protected boolean canAcceptProposal(final ContentAssistEntry entry, final ContentAssistContext context) {
+    String _proposal = entry.getProposal();
+    String _prefix = context.getPrefix();
+    return _proposal.startsWith(_prefix);
+  }
+  
+  protected ContentAssistEntry createProposal(final StringConcatenationClient template, final ContentAssistContext context, final boolean adaptIndentation) {
+    final ContentAssistEntry entry = new ContentAssistEntry();
+    String _prefix = context.getPrefix();
+    entry.setPrefix(_prefix);
+    String _lineDelimiter = this.getLineDelimiter();
+    final AbstractIdeTemplateProposalProvider.TemplateStringConcatenation stringConcat = new AbstractIdeTemplateProposalProvider.TemplateStringConcatenation(context, entry, _lineDelimiter);
+    String _xifexpression = null;
+    if (adaptIndentation) {
+      _xifexpression = this.getIndentation(context);
+    } else {
+      _xifexpression = null;
+    }
+    final String indentation = _xifexpression;
+    if ((indentation == null)) {
+      stringConcat.append(template);
+    } else {
+      stringConcat.append(template, indentation);
+    }
+    String _string = stringConcat.toString();
+    entry.setProposal(_string);
+    return entry;
+  }
+  
+  protected String getLineDelimiter() {
+    return StringConcatenation.DEFAULT_LINE_DELIMITER;
+  }
+  
+  protected String getIndentation(final ContentAssistContext context) {
+    ICompositeNode _rootNode = context.getRootNode();
+    String _text = null;
+    if (_rootNode!=null) {
+      _text=_rootNode.getText();
+    }
+    final String text = _text;
+    boolean _and = false;
+    if (!(text != null)) {
+      _and = false;
+    } else {
+      int _length = text.length();
+      int _offset = context.getOffset();
+      boolean _greaterEqualsThan = (_length >= _offset);
+      _and = _greaterEqualsThan;
+    }
+    if (_and) {
+      ITextRegion _replaceRegion = context.getReplaceRegion();
+      int lineStart = _replaceRegion.getOffset();
+      int indentEnd = lineStart;
+      while (((lineStart > 0) && (text.charAt((lineStart - 1)) != "\n".charAt(0)))) {
+        {
+          lineStart--;
+          char _charAt = text.charAt(lineStart);
+          boolean _isWhitespace = Character.isWhitespace(_charAt);
+          boolean _not = (!_isWhitespace);
+          if (_not) {
+            indentEnd = lineStart;
+          }
+        }
+      }
+      return text.substring(lineStart, indentEnd);
+    }
+    return null;
+  }
+}

--- a/web/org.eclipse.xtext.web.example.statemachine.ide/src/org/eclipse/xtext/web/example/statemachine/ide/StatemachineTemplateProposalProvider.xtend
+++ b/web/org.eclipse.xtext.web.example.statemachine.ide/src/org/eclipse/xtext/web/example/statemachine/ide/StatemachineTemplateProposalProvider.xtend
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.web.example.statemachine.ide
+
+import org.eclipse.xtext.ide.editor.contentassist.AbstractIdeTemplateProposalProvider
+import org.eclipse.xtext.ide.editor.contentassist.ContentAssistContext
+import org.eclipse.xtext.ide.editor.contentassist.IIdeContentProposalAcceptor
+import org.eclipse.xtend2.lib.StringConcatenationClient
+
+class StatemachineTemplateProposalProvider extends AbstractIdeTemplateProposalProvider {
+	
+	def void createStateProposal(ContentAssistContext context, IIdeContentProposalAcceptor acceptor) {
+		val StringConcatenationClient template = '''
+			state «variable('name')»
+				«cursor»
+			end
+		'''
+		acceptProposal('state', 'Create a new state', template, context, acceptor)
+	}
+	
+}

--- a/web/org.eclipse.xtext.web.example.statemachine.ide/src/org/eclipse/xtext/web/example/statemachine/ide/StatemachineWebContentProposalProvider.xtend
+++ b/web/org.eclipse.xtext.web.example.statemachine.ide/src/org/eclipse/xtext/web/example/statemachine/ide/StatemachineWebContentProposalProvider.xtend
@@ -9,6 +9,7 @@ package org.eclipse.xtext.web.example.statemachine.ide
 
 import com.google.inject.Inject
 import org.eclipse.xtext.Assignment
+import org.eclipse.xtext.Keyword
 import org.eclipse.xtext.RuleCall
 import org.eclipse.xtext.ide.editor.contentassist.ContentAssistContext
 import org.eclipse.xtext.ide.editor.contentassist.ContentAssistEntry
@@ -22,11 +23,13 @@ class StatemachineWebContentProposalProvider extends IdeContentProposalProvider 
 	
 	@Inject extension StatemachineGrammarAccess
 	
+	@Inject StatemachineTemplateProposalProvider templateProvider
+	
 	override dispatch createProposals(RuleCall ruleCall, ContentAssistContext context,
 			IIdeContentProposalAcceptor acceptor) {
-		switch (ruleCall.rule) {
+		switch ruleCall.rule {
 			
-			case getBOOLEANRule: {
+			case BOOLEANRule: {
 				if ('true'.startsWith(context.prefix)) {
 					val trueEntry = new ContentAssistEntry => [
 						prefix = context.prefix
@@ -42,6 +45,9 @@ class StatemachineWebContentProposalProvider extends IdeContentProposalProvider 
 					acceptor.accept(falseEntry, proposalPriorities.getDefaultPriority(falseEntry))
 				}
 			}
+			case stateRule: {
+				templateProvider.createStateProposal(context, acceptor)
+			}
 			
 			default:
 				super._createProposals(ruleCall, context, acceptor)	
@@ -50,7 +56,7 @@ class StatemachineWebContentProposalProvider extends IdeContentProposalProvider 
 	
 	override dispatch createProposals(Assignment assignment, ContentAssistContext context,
 			IIdeContentProposalAcceptor acceptor) {
-		switch (assignment) {
+		switch assignment {
 			case eventAccess.signalAssignment_0: {
 				val scope = scopeProvider.getScope(context.currentModel, EVENT__SIGNAL)
 				for (description : scope.allElements.filter[getEClass == INPUT_SIGNAL]) {
@@ -84,6 +90,15 @@ class StatemachineWebContentProposalProvider extends IdeContentProposalProvider 
 			
 			default:
 				super._createProposals(assignment, context, acceptor)
+		}
+	}
+	
+	override protected filterKeyword(Keyword keyword, ContentAssistContext context) {
+		switch keyword {
+			case stateAccess.stateKeyword_0:
+				false
+			default:
+				super.filterKeyword(keyword, context)
 		}
 	}
 	

--- a/web/org.eclipse.xtext.web.example.statemachine.ide/xtend-gen/org/eclipse/xtext/web/example/statemachine/ide/StatemachineTemplateProposalProvider.java
+++ b/web/org.eclipse.xtext.web.example.statemachine.ide/xtend-gen/org/eclipse/xtext/web/example/statemachine/ide/StatemachineTemplateProposalProvider.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.web.example.statemachine.ide;
+
+import org.eclipse.xtend2.lib.StringConcatenationClient;
+import org.eclipse.xtext.ide.editor.contentassist.AbstractIdeTemplateProposalProvider;
+import org.eclipse.xtext.ide.editor.contentassist.ContentAssistContext;
+import org.eclipse.xtext.ide.editor.contentassist.IIdeContentProposalAcceptor;
+
+@SuppressWarnings("all")
+public class StatemachineTemplateProposalProvider extends AbstractIdeTemplateProposalProvider {
+  public void createStateProposal(final ContentAssistContext context, final IIdeContentProposalAcceptor acceptor) {
+    StringConcatenationClient _client = new StringConcatenationClient() {
+      @Override
+      protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
+        _builder.append("state ");
+        AbstractIdeTemplateProposalProvider.Variable _variable = StatemachineTemplateProposalProvider.this.variable("name");
+        _builder.append(_variable, "");
+        _builder.newLineIfNotEmpty();
+        _builder.append("\t");
+        AbstractIdeTemplateProposalProvider.Cursor _cursor = StatemachineTemplateProposalProvider.this.cursor();
+        _builder.append(_cursor, "\t");
+        _builder.newLineIfNotEmpty();
+        _builder.append("end");
+        _builder.newLine();
+      }
+    };
+    final StringConcatenationClient template = _client;
+    this.acceptProposal("state", "Create a new state", template, context, acceptor);
+  }
+}

--- a/web/org.eclipse.xtext.web.example.statemachine.ide/xtend-gen/org/eclipse/xtext/web/example/statemachine/ide/StatemachineWebContentProposalProvider.java
+++ b/web/org.eclipse.xtext.web.example.statemachine.ide/xtend-gen/org/eclipse/xtext/web/example/statemachine/ide/StatemachineWebContentProposalProvider.java
@@ -17,6 +17,7 @@ import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.Assignment;
 import org.eclipse.xtext.CrossReference;
 import org.eclipse.xtext.Keyword;
+import org.eclipse.xtext.ParserRule;
 import org.eclipse.xtext.RuleCall;
 import org.eclipse.xtext.TerminalRule;
 import org.eclipse.xtext.ide.editor.contentassist.ContentAssistContext;
@@ -28,6 +29,7 @@ import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.scoping.IScope;
 import org.eclipse.xtext.scoping.IScopeProvider;
+import org.eclipse.xtext.web.example.statemachine.ide.StatemachineTemplateProposalProvider;
 import org.eclipse.xtext.web.example.statemachine.services.StatemachineGrammarAccess;
 import org.eclipse.xtext.web.example.statemachine.statemachine.StatemachinePackage;
 import org.eclipse.xtext.xbase.lib.Extension;
@@ -41,6 +43,9 @@ public class StatemachineWebContentProposalProvider extends IdeContentProposalPr
   @Inject
   @Extension
   private StatemachineGrammarAccess _statemachineGrammarAccess;
+  
+  @Inject
+  private StatemachineTemplateProposalProvider templateProvider;
   
   @Override
   protected void _createProposals(final RuleCall ruleCall, final ContentAssistContext context, final IIdeContentProposalAcceptor acceptor) {
@@ -84,6 +89,13 @@ public class StatemachineWebContentProposalProvider extends IdeContentProposalPr
           int _defaultPriority_1 = _proposalPriorities_1.getDefaultPriority(falseEntry);
           acceptor.accept(falseEntry, _defaultPriority_1);
         }
+      }
+    }
+    if (!_matched) {
+      ParserRule _stateRule = this._statemachineGrammarAccess.getStateRule();
+      if (Objects.equal(_rule, _stateRule)) {
+        _matched=true;
+        this.templateProvider.createStateProposal(context, acceptor);
       }
     }
     if (!_matched) {
@@ -193,6 +205,24 @@ public class StatemachineWebContentProposalProvider extends IdeContentProposalPr
     if (!_matched) {
       super._createProposals(assignment, context, acceptor);
     }
+  }
+  
+  @Override
+  protected boolean filterKeyword(final Keyword keyword, final ContentAssistContext context) {
+    boolean _switchResult = false;
+    boolean _matched = false;
+    if (!_matched) {
+      StatemachineGrammarAccess.StateElements _stateAccess = this._statemachineGrammarAccess.getStateAccess();
+      Keyword _stateKeyword_0 = _stateAccess.getStateKeyword_0();
+      if (Objects.equal(keyword, _stateKeyword_0)) {
+        _matched=true;
+        _switchResult = false;
+      }
+    }
+    if (!_matched) {
+      _switchResult = super.filterKeyword(keyword, context);
+    }
+    return _switchResult;
   }
   
   public void createProposals(final AbstractElement assignment, final ContentAssistContext context, final IIdeContentProposalAcceptor acceptor) {

--- a/web/org.eclipse.xtext.web/src/test/java/org/eclipse/xtext/web/server/test/ContentAssistTest.xtend
+++ b/web/org.eclipse.xtext.web/src/test/java/org/eclipse/xtext/web/server/test/ContentAssistTest.xtend
@@ -37,25 +37,25 @@ class ContentAssistTest extends AbstractWebServerTest {
 	}
 	
 	@Test def testKeywords() {
-		''.assertContentAssistResult('''
+		'state foo | end'.assertContentAssistResult('''
 			ContentAssistResult [
 			  stateId = "-80000000"
 			  entries = ArrayList (
 			    ContentAssistEntry [
 			      prefix = ""
-			      proposal = "input"
+			      proposal = "end"
 			      textReplacements = ArrayList ()
 			      editPositions = ArrayList ()
 			    ],
 			    ContentAssistEntry [
 			      prefix = ""
-			      proposal = "output"
+			      proposal = "if"
 			      textReplacements = ArrayList ()
 			      editPositions = ArrayList ()
 			    ],
 			    ContentAssistEntry [
 			      prefix = ""
-			      proposal = "state"
+			      proposal = "set"
 			      textReplacements = ArrayList ()
 			      editPositions = ArrayList ()
 			    ]
@@ -64,15 +64,58 @@ class ContentAssistTest extends AbstractWebServerTest {
 	}
 	
 	@Test def testKeywordWithPrefix() {
-		'sta|'.assertContentAssistResult('''
+		'inp|'.assertContentAssistResult('''
 			ContentAssistResult [
 			  stateId = "-80000000"
 			  entries = ArrayList (
 			    ContentAssistEntry [
-			      prefix = "sta"
-			      proposal = "state"
+			      prefix = "inp"
+			      proposal = "input"
 			      textReplacements = ArrayList ()
 			      editPositions = ArrayList ()
+			    ]
+			  )
+			]''')
+	}
+	
+	@Test def testTemplate() {
+		'state foo end |'.assertContentAssistResult('''
+			ContentAssistResult [
+			  stateId = "-80000000"
+			  entries = ArrayList (
+			    ContentAssistEntry [
+			      prefix = ""
+			      proposal = "state name\n	\nend\n"
+			      label = "state"
+			      description = "Create a new state"
+			      escapePosition = 26
+			      textReplacements = ArrayList ()
+			      editPositions = ArrayList (
+			        [20:4]
+			      )
+			    ]
+			  )
+			]''')
+	}
+	
+	@Test def testIndentedTemplate() {
+		'''
+			state foo end
+				|
+		'''.assertContentAssistResult('''
+			ContentAssistResult [
+			  stateId = "-80000000"
+			  entries = ArrayList (
+			    ContentAssistEntry [
+			      prefix = ""
+			      proposal = "state name\n		\n	end\n"
+			      label = "state"
+			      description = "Create a new state"
+			      escapePosition = 28
+			      textReplacements = ArrayList ()
+			      editPositions = ArrayList (
+			        [21:4]
+			      )
 			    ]
 			  )
 			]''')

--- a/web/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/ContentAssistTest.java
+++ b/web/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/ContentAssistTest.java
@@ -75,7 +75,7 @@ public class ContentAssistTest extends AbstractWebServerTest {
     _builder.append("prefix = \"\"");
     _builder.newLine();
     _builder.append("      ");
-    _builder.append("proposal = \"input\"");
+    _builder.append("proposal = \"end\"");
     _builder.newLine();
     _builder.append("      ");
     _builder.append("textReplacements = ArrayList ()");
@@ -93,7 +93,7 @@ public class ContentAssistTest extends AbstractWebServerTest {
     _builder.append("prefix = \"\"");
     _builder.newLine();
     _builder.append("      ");
-    _builder.append("proposal = \"output\"");
+    _builder.append("proposal = \"if\"");
     _builder.newLine();
     _builder.append("      ");
     _builder.append("textReplacements = ArrayList ()");
@@ -111,7 +111,7 @@ public class ContentAssistTest extends AbstractWebServerTest {
     _builder.append("prefix = \"\"");
     _builder.newLine();
     _builder.append("      ");
-    _builder.append("proposal = \"state\"");
+    _builder.append("proposal = \"set\"");
     _builder.newLine();
     _builder.append("      ");
     _builder.append("textReplacements = ArrayList ()");
@@ -126,7 +126,7 @@ public class ContentAssistTest extends AbstractWebServerTest {
     _builder.append(")");
     _builder.newLine();
     _builder.append("]");
-    this.assertContentAssistResult("", _builder);
+    this.assertContentAssistResult("state foo | end", _builder);
   }
   
   @Test
@@ -144,10 +144,10 @@ public class ContentAssistTest extends AbstractWebServerTest {
     _builder.append("ContentAssistEntry [");
     _builder.newLine();
     _builder.append("      ");
-    _builder.append("prefix = \"sta\"");
+    _builder.append("prefix = \"inp\"");
     _builder.newLine();
     _builder.append("      ");
-    _builder.append("proposal = \"state\"");
+    _builder.append("proposal = \"input\"");
     _builder.newLine();
     _builder.append("      ");
     _builder.append("textReplacements = ArrayList ()");
@@ -162,7 +162,115 @@ public class ContentAssistTest extends AbstractWebServerTest {
     _builder.append(")");
     _builder.newLine();
     _builder.append("]");
-    this.assertContentAssistResult("sta|", _builder);
+    this.assertContentAssistResult("inp|", _builder);
+  }
+  
+  @Test
+  public void testTemplate() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("ContentAssistResult [");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("stateId = \"-80000000\"");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("entries = ArrayList (");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("ContentAssistEntry [");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("prefix = \"\"");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("proposal = \"state name\\n\t\\nend\\n\"");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("label = \"state\"");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("description = \"Create a new state\"");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("escapePosition = 26");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("textReplacements = ArrayList ()");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("editPositions = ArrayList (");
+    _builder.newLine();
+    _builder.append("        ");
+    _builder.append("[20:4]");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append(")");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("]");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append(")");
+    _builder.newLine();
+    _builder.append("]");
+    this.assertContentAssistResult("state foo end |", _builder);
+  }
+  
+  @Test
+  public void testIndentedTemplate() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("state foo end");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("|");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("ContentAssistResult [");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("stateId = \"-80000000\"");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("entries = ArrayList (");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("ContentAssistEntry [");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("prefix = \"\"");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("proposal = \"state name\\n\t\t\\n\tend\\n\"");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("label = \"state\"");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("description = \"Create a new state\"");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("escapePosition = 28");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("textReplacements = ArrayList ()");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("editPositions = ArrayList (");
+    _builder_1.newLine();
+    _builder_1.append("        ");
+    _builder_1.append("[21:4]");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append(")");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("]");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append(")");
+    _builder_1.newLine();
+    _builder_1.append("]");
+    this.assertContentAssistResult(_builder, _builder_1);
   }
   
   @Test


### PR DESCRIPTION
Example:
```xtend
class StatemachineTemplateProposalProvider extends AbstractIdeTemplateProposalProvider {
	
	def void createStateProposal(ContentAssistContext context, IIdeContentProposalAcceptor acceptor) {
		val StringConcatenationClient template = '''
			state «variable('name')»
				«cursor»
			end
		'''
		acceptProposal('state', 'Create a new state', template, context, acceptor)
	}
	
}
```