### PR TITLE
add scope to maven dependency example

### DIFF
--- a/xtend-website/download.md
+++ b/xtend-website/download.md
@@ -81,6 +81,7 @@ If you already have a project, you need to add the Xtend library:
   <groupId>org.eclipse.xtend</groupId>
   <artifactId>org.eclipse.xtend.lib</artifactId>
   <version>2.9.0</version>
+  <scope>provided</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
since xtend does not need to be a transitive dependency at runtime, it's a good idea to mark it provided ...