### PR TITLE
Fix for Bug 486584

### DIFF
--- a/plugins/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/SharedContributionWithJDT.java
+++ b/plugins/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/SharedContributionWithJDT.java
@@ -26,6 +26,7 @@ import org.eclipse.xtext.ui.resource.JarEntryLocator;
 import org.eclipse.xtext.ui.resource.JavaProjectResourceSetInitializer;
 import org.eclipse.xtext.ui.resource.Storage2UriMapperJavaImpl;
 import org.eclipse.xtext.ui.shared.contribution.IEagerContribution;
+import org.eclipse.xtext.ui.util.JavaProjectClasspathChangeAnalyzer;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -49,6 +50,7 @@ public class SharedContributionWithJDT implements Module {
 		public void configure(Binder binder) {
 			binder.bind(JarEntryLocator.class);
 			
+			binder.bind(JavaProjectClasspathChangeAnalyzer.class);
 			binder.bind(ProjectClasspathChangeListener.class);
 			
 			binder.bind(JavaProjectsStateHelper.class);

--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JavaProjectClasspathChangeAnalyzer.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JavaProjectClasspathChangeAnalyzer.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ui.util;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaElementDelta;
+import org.eclipse.jdt.core.IJavaModel;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+
+import com.google.common.collect.Sets;
+
+/**
+ * Analyzes a given {@link IJavaElementDelta} for relevant classpath changes
+ * 
+ * @author Christian Dietrich - Initial contribution and API
+ * @since 2.10
+ */
+public class JavaProjectClasspathChangeAnalyzer {
+	
+	/**
+	 * retrieves all Java Projects whose classpath was effected by the given delta
+	 * 
+	 * @param delta the delta to analyze
+	 * @return a Set of the affected Java Projects
+	 */
+	public Set<IJavaProject> getJavaProjectsWithClasspathChange(IJavaElementDelta delta) {
+		IJavaElement element = delta.getElement();
+		if (element instanceof IPackageFragmentRoot) {
+			if (isRelevantPackageFragmentRootChange(delta)) {
+				IPackageFragmentRoot root = (IPackageFragmentRoot) element;
+				return Collections.singleton(root.getJavaProject());
+			}
+		} else if (element instanceof IJavaModel) {
+			return getJavaProjectsWithClasspathChange(delta.getAffectedChildren());
+		} else if (element instanceof IJavaProject) {
+			if (isClasspathChangeOnProject(delta)) {
+				// filter out IJavaElementDelta.F_SOURCEATTACHED | IJavaElementDelta.F_SOURCEDETACHED only
+				if (isAttachmentChangeOnly(delta)) {
+					return  Collections.emptySet();
+				}
+				return Collections.singleton((IJavaProject) element);
+			}
+			return getJavaProjectsWithClasspathChange(delta.getAffectedChildren());
+		}
+		return Collections.emptySet();
+	}
+
+	/**
+	 * Determines if the change i a classpath change on a project
+	 * 
+	 * @param delta the IJavaElementDelta to analyze. the deltas element must be an instance of IProject
+	 */
+	public boolean isClasspathChangeOnProject(IJavaElementDelta delta) {
+		assert (delta.getElement() instanceof IJavaProject);
+		return (delta.getFlags() & IJavaElementDelta.F_CLASSPATH_CHANGED) != 0
+				|| (delta.getFlags() & IJavaElementDelta.F_RESOLVED_CLASSPATH_CHANGED) != 0;
+	}
+
+	/**
+	 * Determines if a given change is a attachment change only
+	 */
+	public boolean isAttachmentChangeOnly(IJavaElementDelta delta) {
+		// there must be at least one child delta
+		if (delta.getAffectedChildren().length == 0) {
+			return false;
+		}
+		// all child deltas have to be attachment changes only
+		for (IJavaElementDelta child : delta.getAffectedChildren()) {
+			if (!isAttachmentChangeFlagOnly(child)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	/**
+	 * determines if the delta is a relevant change on a IPackageFragmentRoot
+	 * 
+	 * @param delta the IJavaElementDelta to analyze. the deltas element must be an instance of IPackageFragmentRoot
+	 */
+	public boolean isRelevantPackageFragmentRootChange(IJavaElementDelta delta) {
+		IJavaElement element = delta.getElement();
+		assert (element instanceof IPackageFragmentRoot);
+		return delta.getKind() == IJavaElementDelta.REMOVED
+			|| delta.getKind() == IJavaElementDelta.ADDED
+			|| (delta.getFlags() & IJavaElementDelta.F_REORDER) != 0
+			|| (delta.getFlags() & IJavaElementDelta.F_REMOVED_FROM_CLASSPATH) != 0
+			|| (delta.getFlags() & IJavaElementDelta.F_ADDED_TO_CLASSPATH) != 0
+			|| (((IPackageFragmentRoot) element).isExternal() && (delta.getFlags() & // external folders change
+					(IJavaElementDelta.F_CONTENT)) == delta.getFlags());
+	}
+
+	private boolean isAttachmentChangeFlagOnly(IJavaElementDelta child) {
+		// change is sourceattached or sourcedetached or sourceattached and sourcedetached at the same time
+		return child.getFlags() == IJavaElementDelta.F_SOURCEATTACHED
+				 || child.getFlags() == IJavaElementDelta.F_SOURCEDETACHED
+				|| child.getFlags() == IJavaElementDelta.F_SOURCEDETACHED + IJavaElementDelta.F_SOURCEATTACHED;
+	}
+
+	private Set<IJavaProject> getJavaProjectsWithClasspathChange(IJavaElementDelta[] affectedChildren) {
+		LinkedHashSet<IJavaProject> set = Sets.newLinkedHashSet();
+		for (IJavaElementDelta delta : affectedChildren) {
+			set.addAll(getJavaProjectsWithClasspathChange(delta));
+		}
+		return set;
+	}
+
+}

--- a/tests/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/Bug486584Test.java
+++ b/tests/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/Bug486584Test.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.builder.impl;
+
+import static org.eclipse.xtext.builder.impl.BuilderUtil.*;
+import static org.eclipse.xtext.junit4.ui.util.IResourcesSetupUtil.*;
+import static org.eclipse.xtext.junit4.ui.util.JavaProjectSetupUtil.*;
+
+import java.io.InputStream;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.xtext.ui.XtextProjectHelper;
+import org.eclipse.xtext.util.StringInputStream;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Christian Dietrich - Initial contribution and API
+ */
+public class Bug486584Test extends AbstractBuilderTest {
+	
+	private static final String PROJECT_NAME = "foo";
+	private static final String XTEND_EXAMPLE_JAR = "XtendExample.jar";
+	private static final String SRC_FOLDER = "src";
+	
+	@Override
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		getBuilderState().addListener(this);
+	}
+	
+	@Test
+	public void testFullBuildWhenClasspathChanged() throws CoreException {
+		IJavaProject project = setupProject();
+		assertFalse(getEvents().isEmpty());
+		getEvents().clear();
+		
+		IFile libaryFile = copyAndGetXtendExampleJar(project);
+		IClasspathEntry libraryEntry = JavaCore.newLibraryEntry(libaryFile.getFullPath(), null, null);
+		addToClasspath(project, libraryEntry);
+		waitForBuild();
+		assertFalse(getEvents().isEmpty());
+		
+	}
+	
+	@Test
+	public void testNoFullBuildIfAttachmentChangeOnly() throws CoreException {
+		IJavaProject project = setupProject();
+		assertFalse(getEvents().isEmpty());
+		getEvents().clear();
+		IFile libaryFile = copyAndGetXtendExampleJar(project);
+		IClasspathEntry libraryEntry = JavaCore.newLibraryEntry(libaryFile.getFullPath(), null, null);
+		addToClasspath(project, libraryEntry);
+		waitForBuild();
+		assertFalse(getEvents().isEmpty());
+		getEvents().clear();
+		
+		IClasspathEntry[] classpath = project.getRawClasspath();
+		for (int i = 0; i < classpath.length; ++i) {
+			IPath entryPath = classpath[i].getPath();
+			if (libraryEntry.getPath().equals(entryPath)) {
+				IClasspathEntry[] newClasspath = new IClasspathEntry[classpath.length];
+				System.arraycopy(classpath, 0, newClasspath, 0, classpath.length);
+				
+				classpath[i] = JavaCore.newLibraryEntry(libaryFile.getFullPath(), libaryFile.getFullPath(), null);
+				project.setRawClasspath(classpath, null);
+
+			}
+		}
+		waitForBuild();
+		assertTrue(getEvents().isEmpty());
+	}
+	
+	private IFile copyAndGetXtendExampleJar(IJavaProject javaProject) throws CoreException {
+		IFile file = javaProject.getProject().getFile(XTEND_EXAMPLE_JAR);
+		InputStream inputStream = Bug486584Test.class.getResourceAsStream(XTEND_EXAMPLE_JAR);
+		file.create(inputStream, IResource.FORCE, null);
+		return file;
+	}
+	
+	private IJavaProject setupProject() throws CoreException {
+		IJavaProject project = createJavaProject(PROJECT_NAME);
+		addNature(project.getProject(), XtextProjectHelper.NATURE_ID);
+		addBuilder(project.getProject(), XtextProjectHelper.BUILDER_ID);
+		IFolder folder = project.getProject().getFolder(SRC_FOLDER);
+		addFile(folder, "source", "namespace bar { object B }");
+		ResourcesPlugin.getWorkspace().build(
+				IncrementalProjectBuilder.AUTO_BUILD, monitor());
+		return project;
+	}
+
+	private void addFile(IFolder folder, String fileName, String content) throws CoreException {
+		IFile file = folder.getFile(fileName + F_EXT);
+		file.create(new StringInputStream(content), true, monitor());
+		waitForBuild();
+	}
+}

--- a/tests/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.xtend
+++ b/tests/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.xtend
@@ -25,6 +25,7 @@ import org.junit.Test
 
 import static org.eclipse.xtext.junit4.ui.util.IResourcesSetupUtil.*
 import static org.eclipse.xtext.junit4.ui.util.JavaProjectSetupUtil.*
+import org.eclipse.xtext.ui.util.JavaProjectClasspathChangeAnalyzer
 
 /**
  * @author Anton Kosyakov - Initial contribution and API
@@ -57,6 +58,7 @@ class Storage2UriMapperJavaImplTest extends Assert {
 			}
 			locator = new JarEntryLocator()
 			workspace = ResourcesPlugin.workspace
+			javaProjectClasspathChangeAnalyzer = new JavaProjectClasspathChangeAnalyzer
 		]
 	}
 

--- a/tests/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.java
+++ b/tests/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.java
@@ -27,6 +27,7 @@ import org.eclipse.xtext.junit4.ui.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.ui.resource.JarEntryLocator;
 import org.eclipse.xtext.ui.resource.Storage2UriMapperJavaImpl;
 import org.eclipse.xtext.ui.resource.UriValidator;
+import org.eclipse.xtext.ui.util.JavaProjectClasspathChangeAnalyzer;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
@@ -86,6 +87,8 @@ public class Storage2UriMapperJavaImplTest extends Assert {
         it.setLocator(_jarEntryLocator);
         IWorkspace _workspace = ResourcesPlugin.getWorkspace();
         it.setWorkspace(_workspace);
+        JavaProjectClasspathChangeAnalyzer _javaProjectClasspathChangeAnalyzer = new JavaProjectClasspathChangeAnalyzer();
+        it.setJavaProjectClasspathChangeAnalyzer(_javaProjectClasspathChangeAnalyzer);
       }
     };
     return ObjectExtensions.<Storage2UriMapperJavaImpl>operator_doubleArrow(_storage2UriMapperJavaImpl, _function);


### PR DESCRIPTION
Do not trigger FullBuild if ClasspathChange is a SourceAttachmentChange only. Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=486584

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>