### PR TITLE
[409003] ImportedNamespaceAwareLocalScopeProvider public getQualifiedNameConverter()

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/scoping/impl/ImportedNamespaceAwareLocalScopeProvider.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/scoping/impl/ImportedNamespaceAwareLocalScopeProvider.java
@@ -79,6 +79,13 @@ public class ImportedNamespaceAwareLocalScopeProvider extends AbstractGlobalScop
 		return qualifiedNameProvider;
 	}
 
+	/**
+	 * @since 2.10
+	 */
+	public IQualifiedNameConverter getQualifiedNameConverter() {
+		return qualifiedNameConverter;
+	}
+
 	@Override
 	public IScope getScope(EObject context, EReference reference) {
 		if (context == null)


### PR DESCRIPTION
https://bugs.eclipse.org/bugs/show_bug.cgi?id=409003

Signed-off-by: Michael Vorburger <mike@vorburger.ch>