### PR TITLE
Add warning for keywords containing spaces

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextConfigurableIssueCodes.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextConfigurableIssueCodes.java
@@ -33,6 +33,7 @@ public class XtextConfigurableIssueCodes extends ConfigurableIssueCodesProvider 
 	public static final String INVALID_ACTION_USAGE = ISSUE_CODE_PREFIX + "InvalidActionUsage";
 	public static final String EMPTY_ENUM_LITERAL = ISSUE_CODE_PREFIX + "EmptyEnumLiteral";
 	public static final String EMPTY_KEYWORD = ISSUE_CODE_PREFIX + "EmptyKeyword";
+	public static final String SPACES_IN_KEYWORD = ISSUE_CODE_PREFIX + "SpacesInKeyword";
 	public static final String INVALID_HIDDEN_TOKEN = ISSUE_CODE_PREFIX + "InvalidHiddenToken";
 	public static final String INVALID_HIDDEN_TOKEN_FRAGMENT = ISSUE_CODE_PREFIX + "InvalidHiddenTokenFragment";
 	public static final String INVALID_PACKAGE_REFERENCE_INHERITED = ISSUE_CODE_PREFIX + "InvalidPackageReference.inherited";
@@ -60,6 +61,7 @@ public class XtextConfigurableIssueCodes extends ConfigurableIssueCodesProvider 
 		acceptor.accept(create(INVALID_ACTION_USAGE, SeverityConverter.SEVERITY_ERROR));
 		acceptor.accept(create(EMPTY_ENUM_LITERAL, SeverityConverter.SEVERITY_ERROR));
 		acceptor.accept(create(EMPTY_KEYWORD, SeverityConverter.SEVERITY_ERROR));
+		acceptor.accept(create(SPACES_IN_KEYWORD, SeverityConverter.SEVERITY_WARNING));
 		acceptor.accept(create(INVALID_HIDDEN_TOKEN, SeverityConverter.SEVERITY_ERROR));
 		acceptor.accept(create(INVALID_HIDDEN_TOKEN_FRAGMENT, SeverityConverter.SEVERITY_ERROR));
 		acceptor.accept(create(INVALID_PACKAGE_REFERENCE_INHERITED, SeverityConverter.SEVERITY_ERROR));

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextValidator.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextValidator.java
@@ -1077,6 +1077,18 @@ public class XtextValidator extends AbstractDeclarativeValidator {
 	}
 	
 	@Check
+	public void checkKeywordNoSpaces(final Keyword keyword) {
+		if (keyword.getValue() != null && !(keyword.eContainer() instanceof EnumLiteralDeclaration)) {
+			if (keyword.getValue().contains(" ") || keyword.getValue().contains("\t")) {
+				addIssue("A keyword should non contain spaces.", 
+						keyword, 
+						null,
+						SPACES_IN_KEYWORD);
+			}
+		}
+	}
+	
+	@Check
 	public void checkKeywordHidesTerminalRule(final Keyword keyword) {
 		if (keywordHidesTerminalInspector == null)
 			keywordHidesTerminalInspector = new KeywordInspector(this);

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextValidationTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextValidationTest.java
@@ -1842,6 +1842,33 @@ public class XtextValidationTest extends AbstractValidationMessageAcceptingTestC
 		messageAcceptor.validate();
 	}
 	
+	@Test public void testKeywordWithSpaces() throws Exception {
+		String grammarAsText =
+				"grammar test with org.eclipse.xtext.common.Terminals\n" +
+				"generate test 'http://test'\n" +
+				"A: foo='a b c'; B: bar='x\ty';";
+		
+		Grammar grammar = (Grammar) getModel(grammarAsText);
+		XtextValidator validator = get(XtextValidator.class);
+		ValidatingMessageAcceptor messageAcceptor = new ValidatingMessageAcceptor(null, false, true);
+		Assignment valueAssignment = (Assignment) grammar.getRules().get(0).getAlternatives();
+		Assignment valueAssignment2 = (Assignment) grammar.getRules().get(1).getAlternatives();
+		messageAcceptor.expectedContext(
+				valueAssignment.getTerminal()
+		);
+		configureValidator(validator, messageAcceptor, valueAssignment);
+		validator.checkKeywordNoSpaces((Keyword) valueAssignment.getTerminal());
+		messageAcceptor.validate();
+		
+		messageAcceptor = new ValidatingMessageAcceptor(null, false, true);
+		messageAcceptor.expectedContext(
+				valueAssignment2.getTerminal()
+		);
+		configureValidator(validator, messageAcceptor, valueAssignment2);
+		validator.checkKeywordNoSpaces((Keyword) valueAssignment2.getTerminal());
+		messageAcceptor.validate();
+	}
+	
 	public class ValidatingMessageAcceptor extends AbstractValidationMessageAcceptor {
 
 		private final Set<EObject> contexts;


### PR DESCRIPTION
Fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=488458
Add warning for keywords containing spaces
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>