### PR TITLE
[488463] [xtext.ui] introduced hook method 'getImage(IEObjectDescription)'

### DIFF
--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/AbstractContentProposalProvider.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/AbstractContentProposalProvider.java
@@ -223,6 +223,19 @@ public abstract class AbstractContentProposalProvider implements IContentProposa
 	/**
 	 * Returns the image for the label of the given element.
 	 * 
+	 * @param description
+	 *            the {@link IEObjectDescription} for which to provide the label image
+	 * @return the image used to label the element, or <code>null</code> if there is no image for the given object
+	 * 
+	 * @since 2.9 .2
+	 */
+	protected Image getImage(IEObjectDescription description) {
+		return getImage(description.getEObjectOrProxy());
+	}
+
+	/**
+	 * Returns the image for the label of the given element.
+	 * 
 	 * @param eObject
 	 *            the element for which to provide the label image
 	 * @return the image used to label the element, or <code>null</code> if there is no image for the given object

--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/AbstractJavaBasedContentProposalProvider.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/AbstractJavaBasedContentProposalProvider.java
@@ -107,7 +107,7 @@ public abstract class AbstractJavaBasedContentProposalProvider extends AbstractC
 			}
 			EObject objectOrProxy = candidate.getEObjectOrProxy();
 			StyledString displayString = getStyledDisplayString(candidate);
-			Image image = getImage(objectOrProxy);
+			Image image = getImage(candidate);
 			result = createCompletionProposal(proposal, displayString, image, contentAssistContext);
 			if (result instanceof ConfigurableCompletionProposal) {
 				((ConfigurableCompletionProposal) result).setProposalContextResource(contentAssistContext.getResource());


### PR DESCRIPTION
... in AbstractContentProposalProvider; switched to that method in AbstractJavaBasedContentProposalProvider.DefaultProposalCreator, fixes bug [488463]

Signed-off-by: Christian Schneider <christian.schneider@typefox.io>