### PR TITLE
Bug 484465: Improved serializer performance

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/analysis/GrammarConstraintProvider.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/serializer/analysis/GrammarConstraintProvider.java
@@ -85,10 +85,14 @@ public class GrammarConstraintProvider implements IGrammarConstraintProvider {
 
 		protected void collectBounds(ISemState state, int[] current, Set<ISemState> visited, int[] min, int[] max) {
 			int featureID = state.getFeatureID();
+			int previousValue = -1;
+			boolean newVisit = false;
 			if (featureID >= 0) {
 				if (current[featureID] == IGrammarConstraintProvider.MAX)
 					return;
-				if (visited.add(state))
+				previousValue = current[featureID];
+				newVisit = visited.add(state);
+				if (newVisit)
 					current[featureID]++;
 				else
 					current[featureID] = IGrammarConstraintProvider.MAX;
@@ -99,8 +103,13 @@ public class GrammarConstraintProvider implements IGrammarConstraintProvider {
 				}
 				return;
 			}
-			for (ISemState follower : state.getFollowers())
-				collectBounds(follower, current.clone(), Sets.newHashSet(visited), min, max);
+			for (ISemState follower : state.getFollowers()) {
+				collectBounds(follower, current, visited, min, max);
+			}
+			if (previousValue >= 0)
+				current[featureID] = previousValue;
+			if (newVisit)
+				visited.remove(state);
 		}
 
 		@Override


### PR DESCRIPTION
In one specific example with partial serialization via `XtextDocument.modify(..)` the average time for applying the modification was reduced from 80.7 seconds (before this change) to 5.8 seconds (after this change). Cloning the array and hash set seems to keep the GC quite busy in some cases.