### PR TITLE
Bug 488635: Removed leading '/' in resource path

### DIFF
--- a/web/org.eclipse.xtext.web.servlet/src/main/java/org/eclipse/xtext/web/servlet/XtextResourcesServlet.xtend
+++ b/web/org.eclipse.xtext.web.servlet/src/main/java/org/eclipse/xtext/web/servlet/XtextResourcesServlet.xtend
@@ -35,7 +35,7 @@ class XtextResourcesServlet extends HttpServlet {
 	}
 
 	override doGet(HttpServletRequest request, HttpServletResponse response) {
-		val resourceURI = '/META-INF/resources' + request.servletPath + request.pathInfo
+		val resourceURI = 'META-INF/resources' + request.servletPath + request.pathInfo
 		val inputStream = getResourceAsStream(resourceURI)
 		if (inputStream !== null) {
 			val tokens = resourceURI.split('/')
@@ -46,7 +46,7 @@ class XtextResourcesServlet extends HttpServlet {
 				response.setDateHeader('Expires', System.currentTimeMillis + DEFAULT_EXPIRE_TIME_MS)
 				response.addHeader('Cache-Control', 'private, max-age=' + DEFAULT_EXPIRE_TIME_S)
 			}
-			val mimeType = request.servletContext.getMimeType(fileName)
+			val mimeType = servletContext.getMimeType(fileName)
 			response.setContentType(mimeType ?: 'application/octet-stream')
 			ByteStreams.copy(inputStream, response.outputStream)
 		} else {

--- a/web/org.eclipse.xtext.web.servlet/src/main/xtend-gen/org/eclipse/xtext/web/servlet/XtextResourcesServlet.java
+++ b/web/org.eclipse.xtext.web.servlet/src/main/xtend-gen/org/eclipse/xtext/web/servlet/XtextResourcesServlet.java
@@ -44,7 +44,7 @@ public class XtextResourcesServlet extends HttpServlet {
   public void doGet(final HttpServletRequest request, final HttpServletResponse response) {
     try {
       String _servletPath = request.getServletPath();
-      String _plus = ("/META-INF/resources" + _servletPath);
+      String _plus = ("META-INF/resources" + _servletPath);
       String _pathInfo = request.getPathInfo();
       final String resourceURI = (_plus + _pathInfo);
       final InputStream inputStream = this.getResourceAsStream(resourceURI);
@@ -69,7 +69,7 @@ public class XtextResourcesServlet extends HttpServlet {
           response.setDateHeader("Expires", _plus_1);
           response.addHeader("Cache-Control", ("private, max-age=" + Long.valueOf(XtextResourcesServlet.DEFAULT_EXPIRE_TIME_S)));
         }
-        ServletContext _servletContext = request.getServletContext();
+        ServletContext _servletContext = this.getServletContext();
         final String mimeType = _servletContext.getMimeType(fileName);
         String _elvis = null;
         if (mimeType != null) {


### PR DESCRIPTION
Also avoided usage of Servlet 3.0 API method `ServletRequest.getServletContext()`.