### PR TITLE
488966: provide an AbstractOutlineTest

### DIFF
--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/ContentAssistTest.xtend
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/ContentAssistTest.xtend
@@ -7,11 +7,11 @@ import org.eclipse.xtext.xbase.junit.ui.AbstractContentAssistTest
 import org.junit.runner.RunWith
 import org.junit.Test
 
-@RunWith(typeof(XtextRunner))
-@InjectWith(typeof(DomainmodelUiInjectorProvider))
 /**
  * @author Jan Koehnlein - copied and adapted form Xtend
  */
+@RunWith(typeof(XtextRunner))
+@InjectWith(typeof(DomainmodelUiInjectorProvider))
 class ContentAssistTest extends AbstractContentAssistTest {
 	
 	@Test def void testImportCompletion() {

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/OutlineTest.xtend
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/OutlineTest.xtend
@@ -1,0 +1,58 @@
+package org.eclipse.xtext.example.domainmodel.tests
+
+import org.eclipse.xtext.example.domainmodel.DomainmodelUiInjectorProvider
+import org.eclipse.xtext.example.domainmodel.ui.internal.DomainmodelActivator
+import org.eclipse.xtext.junit4.InjectWith
+import org.eclipse.xtext.junit4.XtextRunner
+import org.eclipse.xtext.junit4.ui.AbstractOutlineTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author Lorenzo Bettini - Initial contribution and API
+ */
+@RunWith(typeof(XtextRunner))
+@InjectWith(typeof(DomainmodelUiInjectorProvider))
+class OutlineTest extends AbstractOutlineTest {
+
+	override protected getEditorId() {
+		DomainmodelActivator.ORG_ECLIPSE_XTEXT_EXAMPLE_DOMAINMODEL_DOMAINMODEL
+	}
+
+	@Test def void testOutline() {
+		'''
+			entity Foo {
+				name : String
+				op doStuff(String x) : String {
+					return x + ' ' + this.name
+				}
+			}
+		'''.assertAllLabels(
+			'''
+				Foo
+				  name : String
+				  doStuff(String) : String
+			'''
+		)
+	}
+
+	@Test def void testOutlineWithPackage() {
+		'''
+			package mypackage {
+				entity Foo {
+					name : String
+					op doStuff(String x) : String {
+						return x + ' ' + this.name
+					}
+				}
+			}
+		'''.assertAllLabels(
+			'''
+				mypackage
+				  Foo
+				    name : String
+				    doStuff(String) : String
+			'''
+		)
+	}
+}

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/ContentAssistTest.java
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/ContentAssistTest.java
@@ -9,6 +9,9 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+/**
+ * @author Jan Koehnlein - copied and adapted form Xtend
+ */
 @RunWith(XtextRunner.class)
 @InjectWith(DomainmodelUiInjectorProvider.class)
 @SuppressWarnings("all")

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/OutlineTest.java
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/OutlineTest.java
@@ -1,0 +1,103 @@
+package org.eclipse.xtext.example.domainmodel.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.domainmodel.DomainmodelUiInjectorProvider;
+import org.eclipse.xtext.example.domainmodel.ui.internal.DomainmodelActivator;
+import org.eclipse.xtext.junit4.InjectWith;
+import org.eclipse.xtext.junit4.XtextRunner;
+import org.eclipse.xtext.junit4.ui.AbstractOutlineTest;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Lorenzo Bettini - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(DomainmodelUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class OutlineTest extends AbstractOutlineTest {
+  @Override
+  protected String getEditorId() {
+    return DomainmodelActivator.ORG_ECLIPSE_XTEXT_EXAMPLE_DOMAINMODEL_DOMAINMODEL;
+  }
+  
+  @Test
+  public void testOutline() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("entity Foo {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("name : String");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("op doStuff(String x) : String {");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("return x + \' \' + this.name");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("Foo");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("name : String");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("doStuff(String) : String");
+      _builder_1.newLine();
+      this.assertAllLabels(_builder, _builder_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testOutlineWithPackage() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("package mypackage {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("entity Foo {");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("name : String");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("op doStuff(String x) : String {");
+      _builder.newLine();
+      _builder.append("\t\t\t");
+      _builder.append("return x + \' \' + this.name");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("}");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("mypackage");
+      _builder_1.newLine();
+      _builder_1.append("  ");
+      _builder_1.append("Foo");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("name : String");
+      _builder_1.newLine();
+      _builder_1.append("    ");
+      _builder_1.append("doStuff(String) : String");
+      _builder_1.newLine();
+      this.assertAllLabels(_builder, _builder_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+}

--- a/plugins/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractOutlineTest.java
+++ b/plugins/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractOutlineTest.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.junit4.ui;
+
+import static org.eclipse.xtext.junit4.ui.util.IResourcesSetupUtil.addNature;
+import static org.eclipse.xtext.junit4.ui.util.JavaProjectSetupUtil.createJavaProject;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.xtext.junit4.ui.AbstractEditorTest;
+import org.eclipse.xtext.junit4.ui.util.IResourcesSetupUtil;
+import org.eclipse.xtext.resource.FileExtensionProvider;
+import org.eclipse.xtext.ui.XtextProjectHelper;
+import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.outline.IOutlineNode;
+import org.eclipse.xtext.ui.editor.outline.IOutlineTreeProvider;
+
+import com.google.inject.Inject;
+
+/**
+ * A utility class for testing the outline's tree of Xtext languages.
+ * 
+ * Example:
+ * <pre>
+ * &#64;RunWith(XtextRunner)
+ * &#64;InjectWith(MyLanguageUiInjectorProvider) 
+ * class OutlineTest extends AbstractOutlineTest {
+ * 
+ *	override protected getEditorId() {
+ *		MyDslActivator.ORG_XTEXT_EXAMPLE_MYDSL
+ *	}
+ *	
+ *	&#64;Test def void myTest() {
+ *	  '''
+ *	  	// DSL code
+ *	  	Foo bla {
+ *	  		Bar b
+ *	  		Bar c
+ *	  	}
+ *	  '''.assertAllLabels('''
+ *	  	bla
+ *	  	  b
+ *	  	  c
+ *	  '''
+ *	}
+ *  }
+ * </pre>
+ * 
+ * @author Jan Koehnlein - Initial contribution and API
+ * @author Lorenzo Bettini - Adapted to be used for any DSL
+ * 
+ * @since 2.10
+ */
+public abstract class AbstractOutlineTest extends AbstractEditorTest {
+
+	protected static int TAB_INDENT = 2;
+
+	protected static String TEST_PROJECT = "test";
+
+	protected IFile file;
+	protected XtextEditor editor;
+	protected IXtextDocument document;
+
+	public String fileExtension;
+	
+	@Inject
+	protected IOutlineTreeProvider treeProvider;
+
+	@Inject
+	public void setFileExtensionProvider(FileExtensionProvider extensionProvider) {
+		fileExtension = extensionProvider.getPrimaryFileExtension();
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		createjavaProject(TEST_PROJECT);
+	}
+
+	protected IJavaProject createjavaProject(String projectName) throws CoreException {
+		IJavaProject javaProject = createJavaProject(projectName);
+		addNature(javaProject.getProject(), XtextProjectHelper.NATURE_ID);
+		return javaProject;
+	}
+
+	@Override
+	public void tearDown() throws Exception {
+		super.tearDown();
+		editor.close(false);
+	}
+
+	protected IOutlineNode getOutlineTree(CharSequence modelAsText)
+			throws Exception {
+		file = IResourcesSetupUtil.createFile(TEST_PROJECT + "/test."
+				+ fileExtension, modelAsText.toString());
+		editor = openEditor(file);
+		document = editor.getDocument();
+		return treeProvider.createRoot(document);
+	}
+
+	/**
+	 * The root node of the outline of the passed program
+	 * is expanded and a string representation of the tree is
+	 * built where children are indented of TAB_INDENT number of tabs; this
+	 * string representation is then compared with the expected representation.
+	 * 
+	 * @param modelAsText
+	 * @param expected
+	 * @throws Exception 
+	 */
+	protected void assertAllLabels(CharSequence modelAsText, CharSequence expected) throws Exception {
+		assertAllLabels(getOutlineTree(modelAsText), expected);
+	}
+
+	/**
+	 * The outline node is expanded and a string representation of the tree is
+	 * built where children are indented of TAB_INDENT number of tabs; this
+	 * string representation is then compared with the expected representation.
+	 * 
+	 * @param rootNode
+	 * @param expected
+	 */
+	protected void assertAllLabels(IOutlineNode rootNode, CharSequence expected) {
+		assertEquals(expected.toString().trim(),
+				outlineStringRepresentation(rootNode).trim());
+	}
+
+	protected String outlineStringRepresentation(IOutlineNode node) {
+		StringBuffer buffer = new StringBuffer();
+		outlineStringRepresentation(node, buffer, 0);
+		return buffer.toString();
+	}
+
+	protected void outlineStringRepresentation(IOutlineNode node,
+			StringBuffer buffer, int tabs) {
+		if (getNodeText(node) != "<unnamed>") {
+			addToStringRepresentation(node, buffer, tabs);
+			tabs += TAB_INDENT;
+		}
+		for (IOutlineNode child : node.getChildren()) {
+			addToStringRepresentation(child, buffer, tabs);
+			if (child.hasChildren()) {
+				for (IOutlineNode child2 : child.getChildren()) {
+					outlineStringRepresentation(child2, buffer, tabs + TAB_INDENT);
+				}
+			}
+		}
+	}
+
+	protected void addToStringRepresentation(IOutlineNode node,
+			StringBuffer buffer, int tabs) {
+		indent(buffer, tabs);
+		buffer.append(getNodeText(node) + System.getProperty("line.separator"));
+	}
+
+	protected String getNodeText(IOutlineNode node) {
+		return node.getText().toString();
+	}
+
+	protected void indent(StringBuffer buffer, int tabs) {
+		for (int i = 0; i < tabs; ++i) {
+			buffer.append(" ");
+		}
+	}
+
+}


### PR DESCRIPTION
https://bugs.eclipse.org/bugs/show_bug.cgi?id=488966

This allows to easily test the outline of a DSL: it gives an indented string representation of the outline that can be easily compared with multiline strings.