### PR TITLE
[325658] Introduce AbstractGrammarElement as common base class for AbstractRule and AbstractElement

### DIFF
--- a/intellij/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/GrammarAccessExtensions.java
+++ b/intellij/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/GrammarAccessExtensions.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.Action;
 import org.eclipse.xtext.Assignment;
@@ -478,7 +479,7 @@ public class GrammarAccessExtensions {
     }
   }
   
-  public List<AbstractElement> contentsAsList(final EObject it) {
+  public List<AbstractElement> contentsAsList(final AbstractGrammarElement it) {
     if (it instanceof UnorderedGroup) {
       return _contentsAsList((UnorderedGroup)it);
     } else if (it instanceof CompoundElement) {

--- a/intellij/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/parsing/NodeModelPrinter.java
+++ b/intellij/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/parsing/NodeModelPrinter.java
@@ -15,6 +15,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.Action;
 import org.eclipse.xtext.CrossReference;
@@ -84,7 +85,7 @@ public class NodeModelPrinter {
     _builder.append(_totalTextRegion, "");
     _builder.newLineIfNotEmpty();
     _builder.append("grammarElements: ");
-    EObject _grammarElement = it.getGrammarElement();
+    AbstractGrammarElement _grammarElement = it.getGrammarElement();
     String _printGrammarElement = this.printGrammarElement(_grammarElement);
     _builder.append(_printGrammarElement, "");
     _builder.newLineIfNotEmpty();

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/documentation/XtendFileHeaderProvider.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/documentation/XtendFileHeaderProvider.java
@@ -16,6 +16,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtend.core.xtend.XtendFile;
 import org.eclipse.xtend.core.xtend.XtendTypeDeclaration;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.TerminalRule;
 import org.eclipse.xtext.documentation.IEObjectDocumentationProvider;
 import org.eclipse.xtext.documentation.IEObjectDocumentationProviderExtension;
@@ -46,7 +47,7 @@ public class XtendFileHeaderProvider extends MultiLineFileHeaderProvider {
         for (final ILeafNode leafNode : _leafNodes) {
           {
             boolean break_ = true;
-            final EObject grammarElement = leafNode.getGrammarElement();
+            final AbstractGrammarElement grammarElement = leafNode.getGrammarElement();
             if ((grammarElement instanceof TerminalRule)) {
               final String terminalRuleName = ((TerminalRule)grammarElement).getName();
               boolean _equalsIgnoreCase = this.ruleName.equalsIgnoreCase(terminalRuleName);

--- a/plugins/org.eclipse.xtext.xbase.ide/xtend-gen/org/eclipse/xtext/xbase/ide/contentassist/XbaseIdeContentProposalProvider.java
+++ b/plugins/org.eclipse.xtext.xbase.ide/xtend-gen/org/eclipse/xtext/xbase/ide/contentassist/XbaseIdeContentProposalProvider.java
@@ -17,6 +17,7 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.Assignment;
 import org.eclipse.xtext.CrossReference;
@@ -682,7 +683,7 @@ public class XbaseIdeContentProposalProvider extends IdeContentProposalProvider 
           _and = _greaterEqualsThan;
         }
         if (_and) {
-          EObject _grammarElement = currentNode.getGrammarElement();
+          AbstractGrammarElement _grammarElement = currentNode.getGrammarElement();
           if ((_grammarElement instanceof CrossReference)) {
             return;
           }

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/NodeModelAccess.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/NodeModelAccess.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Iterables;
 import java.util.List;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.formatting2.regionaccess.ITextRegionAccess;
 import org.eclipse.xtext.nodemodel.BidiTreeIterable;
@@ -41,7 +42,7 @@ public class NodeModelAccess {
           if (!_equals) {
             _and_1 = false;
           } else {
-            EObject _grammarElement = it.getGrammarElement();
+            AbstractGrammarElement _grammarElement = it.getGrammarElement();
             _and_1 = (_grammarElement instanceof Keyword);
           }
           if (!_and_1) {
@@ -76,7 +77,7 @@ public class NodeModelAccess {
           if (!_equals) {
             _and_1 = false;
           } else {
-            EObject _grammarElement = it.getGrammarElement();
+            AbstractGrammarElement _grammarElement = it.getGrammarElement();
             _and_1 = (_grammarElement instanceof Keyword);
           }
           if (!_and_1) {
@@ -125,7 +126,7 @@ public class NodeModelAccess {
           if (!_notEquals) {
             _and = false;
           } else {
-            EObject _grammarElement = it.getGrammarElement();
+            AbstractGrammarElement _grammarElement = it.getGrammarElement();
             _and = (_grammarElement instanceof Keyword);
           }
           return Boolean.valueOf(_and);

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/XbaseFormatter2.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/XbaseFormatter2.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.CrossReference;
 import org.eclipse.xtext.Keyword;
@@ -714,7 +715,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
       final Iterable<ILeafNode> leafs = ((ICompositeNode)node).getLeafNodes();
       for (final ILeafNode n : leafs) {
         boolean _and = false;
-        EObject _grammarElement = n.getGrammarElement();
+        AbstractGrammarElement _grammarElement = n.getGrammarElement();
         if (!(_grammarElement instanceof Keyword)) {
           _and = false;
         } else {
@@ -956,7 +957,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
         XExpression _last_1 = IterableExtensions.<XExpression>last(params);
         INode _nodeForEObject = this._nodeModelAccess.nodeForEObject(_last_1);
         INode _firstChild = ((ICompositeNode) _nodeForEObject).getFirstChild();
-        final EObject grammarElement = _firstChild.getGrammarElement();
+        final AbstractGrammarElement grammarElement = _firstChild.getGrammarElement();
         XClosure _xifexpression_1 = null;
         boolean _or = false;
         boolean _or_1 = false;
@@ -1627,11 +1628,11 @@ public class XbaseFormatter2 extends AbstractFormatter {
     if (!_notEquals) {
       _and = false;
     } else {
-      EObject _grammarElement = node.getGrammarElement();
+      AbstractGrammarElement _grammarElement = node.getGrammarElement();
       _and = (_grammarElement instanceof CrossReference);
     }
     if (_and) {
-      EObject _grammarElement_1 = node.getGrammarElement();
+      AbstractGrammarElement _grammarElement_1 = node.getGrammarElement();
       final AbstractElement terminal = ((CrossReference) _grammarElement_1).getTerminal();
       if ((terminal instanceof RuleCall)) {
         return ((RuleCall)terminal).getRule();

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/imports/ImportsCollector.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/imports/ImportsCollector.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.TerminalRule;
 import org.eclipse.xtext.common.types.JvmConstructor;
 import org.eclipse.xtext.common.types.JvmDeclaredType;
@@ -75,7 +76,7 @@ public class ImportsCollector {
           _and = false;
         } else {
           TerminalRule _mL_COMMENTRule = this.grammarAccess.getML_COMMENTRule();
-          EObject _grammarElement = node.getGrammarElement();
+          AbstractGrammarElement _grammarElement = node.getGrammarElement();
           boolean _equals = _mL_COMMENTRule.equals(_grammarElement);
           _and = _equals;
         }

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/grammarAccess/GrammarAccessExtensions.java
@@ -29,6 +29,7 @@ import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.Action;
 import org.eclipse.xtext.Assignment;
@@ -1105,7 +1106,7 @@ public class GrammarAccessExtensions {
     }
   }
   
-  public List<AbstractElement> contentsAsList(final EObject it) {
+  public List<AbstractElement> contentsAsList(final AbstractGrammarElement it) {
     if (it instanceof UnorderedGroup) {
       return _contentsAsList((UnorderedGroup)it);
     } else if (it instanceof CompoundElement) {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrContentAssistGrammarGenerator.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AntlrContentAssistGrammarGenerator.java
@@ -14,9 +14,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.eclipse.emf.common.util.EList;
-import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.Action;
 import org.eclipse.xtext.Alternatives;
@@ -251,22 +251,22 @@ public class AntlrContentAssistGrammarGenerator extends AbstractAntlrGrammarWith
       List<EnumRule> _allEnumRules = GrammarUtil.allEnumRules(g);
       Iterable<AbstractRule> _plus = Iterables.<AbstractRule>concat(_allParserRules, _allEnumRules);
       Collection<? extends AbstractElement> _allAlternatives = GrammarUtil.getAllAlternatives(g);
-      Iterable<EObject> _plus_1 = Iterables.<EObject>concat(_plus, _allAlternatives);
+      Iterable<AbstractGrammarElement> _plus_1 = Iterables.<AbstractGrammarElement>concat(_plus, _allAlternatives);
       Collection<? extends AbstractElement> _allGroups = GrammarUtil.getAllGroups(g);
-      Iterable<EObject> _plus_2 = Iterables.<EObject>concat(_plus_1, _allGroups);
+      Iterable<AbstractGrammarElement> _plus_2 = Iterables.<AbstractGrammarElement>concat(_plus_1, _allGroups);
       Collection<? extends AbstractElement> _allUnorderedGroups = GrammarUtil.getAllUnorderedGroups(g);
-      Iterable<EObject> _plus_3 = Iterables.<EObject>concat(_plus_2, _allUnorderedGroups);
+      Iterable<AbstractGrammarElement> _plus_3 = Iterables.<AbstractGrammarElement>concat(_plus_2, _allUnorderedGroups);
       Collection<? extends AbstractElement> _allAssignments = GrammarUtil.getAllAssignments(g);
-      Iterable<EObject> _plus_4 = Iterables.<EObject>concat(_plus_3, _allAssignments);
-      final Function1<EObject, Boolean> _function = new Function1<EObject, Boolean>() {
+      Iterable<AbstractGrammarElement> _plus_4 = Iterables.<AbstractGrammarElement>concat(_plus_3, _allAssignments);
+      final Function1<AbstractGrammarElement, Boolean> _function = new Function1<AbstractGrammarElement, Boolean>() {
         @Override
-        public Boolean apply(final EObject it) {
+        public Boolean apply(final AbstractGrammarElement it) {
           AbstractRule _containingRule = GrammarUtil.containingRule(it);
           return Boolean.valueOf(AntlrContentAssistGrammarGenerator.this._grammarAccessExtensions.isCalled(_containingRule, g));
         }
       };
-      Iterable<EObject> _filter = IterableExtensions.<EObject>filter(_plus_4, _function);
-      for(final EObject rule : _filter) {
+      Iterable<AbstractGrammarElement> _filter = IterableExtensions.<AbstractGrammarElement>filter(_plus_4, _function);
+      for(final AbstractGrammarElement rule : _filter) {
         _builder.newLine();
         CharSequence _compileRule = this.compileRule(rule, g, options);
         _builder.append(_compileRule, "");

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.java
@@ -31,6 +31,7 @@ import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.Action;
 import org.eclipse.xtext.Alternatives;
@@ -1054,7 +1055,7 @@ public class SerializerFragment2 extends AbstractStubGeneratingFragment {
   }
   
   private EObject getContextObject(final ISerializationContext context) {
-    EObject _elvis = null;
+    AbstractGrammarElement _elvis = null;
     Action _assignedAction = context.getAssignedAction();
     if (_assignedAction != null) {
       _elvis = _assignedAction;

--- a/plugins/org.eclipse.xtext/.settings/.api_filters
+++ b/plugins/org.eclipse.xtext/.settings/.api_filters
@@ -273,6 +273,59 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/xtext/nodemodel/INode.java" type="org.eclipse.xtext.nodemodel.INode">
+        <filter comment="Bug#325658: Introduced common base class AbstractGrammarElement for AbstractElement and AbstractRule. Use this base class instead of the generic EObject class." id="403804204">
+            <message_arguments>
+                <message_argument value="org.eclipse.xtext.nodemodel.INode"/>
+                <message_argument value="getGrammarElement()"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Bug#325658: Introduced common base class AbstractGrammarElement for AbstractElement and AbstractRule. Use this base class instead of the generic EObject class." id="405901410">
+            <message_arguments>
+                <message_argument value="org.eclipse.xtext.nodemodel.INode"/>
+                <message_argument value="getGrammarElement()"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Bug#325658: Introduced common base class AbstractGrammarElement for AbstractElement and AbstractRule. Use this base class instead of the generic EObject class." id="1211105284">
+            <message_arguments>
+                <message_argument value="getGrammarElement()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/xtext/nodemodel/impl/AbstractNode.java" type="org.eclipse.xtext.nodemodel.impl.AbstractNode">
+        <filter comment="Bug#325658: Introduced common base class AbstractGrammarElement for AbstractElement and AbstractRule. Use this base class instead of the generic EObject class." id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.xtext.nodemodel.impl.AbstractNode"/>
+                <message_argument value="getGrammarElement()"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Bug#325658: Introduced common base class AbstractGrammarElement for AbstractElement and AbstractRule. Use this base class instead of the generic EObject class." id="1143996420">
+            <message_arguments>
+                <message_argument value="getGrammarElement()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/xtext/nodemodel/impl/CompositeNode.java" type="org.eclipse.xtext.nodemodel.impl.CompositeNode">
+        <filter comment="Bug#325658: Introduced common base class AbstractGrammarElement for AbstractElement and AbstractRule. Use this base class instead of the generic EObject class." id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.xtext.nodemodel.impl.CompositeNode"/>
+                <message_argument value="getGrammarElement()"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/xtext/nodemodel/impl/SyntheticCompositeNode.java" type="org.eclipse.xtext.nodemodel.impl.SyntheticCompositeNode">
+        <filter comment="Bug#325658: Introduced common base class AbstractGrammarElement for AbstractElement and AbstractRule. Use this base class instead of the generic EObject class." id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.xtext.nodemodel.impl.SyntheticCompositeNode"/>
+                <message_argument value="getGrammarElement()"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Bug#325658: Introduced common base class AbstractGrammarElement for AbstractElement and AbstractRule. Use this base class instead of the generic EObject class." id="1143996420">
+            <message_arguments>
+                <message_argument value="getGrammarElement()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/xtext/parsetree/reconstr/impl/TreeConstState.java" type="org.eclipse.xtext.parsetree.reconstr.impl.TreeConstState">
         <filter id="576720909">
             <message_arguments>

--- a/plugins/org.eclipse.xtext/.settings/.api_filters
+++ b/plugins/org.eclipse.xtext/.settings/.api_filters
@@ -8,6 +8,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="emf-gen/org/eclipse/xtext/XtextPackage.java" type="org.eclipse.xtext.XtextPackage$Literals">
+        <filter comment="bug325658 Introduce common base class for AbstractElement and AbstractRule" id="403767336">
+            <message_arguments>
+                <message_argument value="org.eclipse.xtext.XtextPackage.Literals"/>
+                <message_argument value="ABSTRACT_GRAMMAR_ELEMENT"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src-gen/org/eclipse/xtext/parser/antlr/XtextParser.java" type="org.eclipse.xtext.parser.antlr.XtextParser">
         <filter id="643842064">
             <message_arguments>

--- a/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/AbstractElement.java
+++ b/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/AbstractElement.java
@@ -22,7 +22,7 @@ import org.eclipse.emf.ecore.EObject;
  * @model
  * @generated
  */
-public interface AbstractElement extends EObject {
+public interface AbstractElement extends AbstractGrammarElement {
 	/**
 	 * Returns the value of the '<em><b>Cardinality</b></em>' attribute.
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/AbstractGrammarElement.java
+++ b/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/AbstractGrammarElement.java
@@ -1,0 +1,19 @@
+/**
+ */
+package org.eclipse.xtext;
+
+import org.eclipse.emf.ecore.EObject;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Abstract Grammar Element</b></em>'.
+ * @since 2.10
+ * <!-- end-user-doc -->
+ *
+ *
+ * @see org.eclipse.xtext.XtextPackage#getAbstractGrammarElement()
+ * @model abstract="true"
+ * @generated
+ */
+public interface AbstractGrammarElement extends EObject {
+} // AbstractGrammarElement

--- a/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/AbstractRule.java
+++ b/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/AbstractRule.java
@@ -22,7 +22,7 @@ import org.eclipse.emf.ecore.EObject;
  * @model
  * @generated
  */
-public interface AbstractRule extends EObject {
+public interface AbstractRule extends AbstractGrammarElement {
 	/**
 	 * Returns the value of the '<em><b>Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/XtextPackage.java
+++ b/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/XtextPackage.java
@@ -131,6 +131,27 @@ public interface XtextPackage extends EPackage {
 	int GRAMMAR_FEATURE_COUNT = 6;
 
 	/**
+	 * The meta object id for the '{@link org.eclipse.xtext.impl.AbstractGrammarElementImpl <em>Abstract Grammar Element</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * @since 2.10
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.xtext.impl.AbstractGrammarElementImpl
+	 * @see org.eclipse.xtext.impl.XtextPackageImpl#getAbstractGrammarElement()
+	 * @generated
+	 */
+	int ABSTRACT_GRAMMAR_ELEMENT = 35;
+
+	/**
+	 * The number of structural features of the '<em>Abstract Grammar Element</em>' class.
+	 * <!-- begin-user-doc -->
+	 * @since 2.10
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ABSTRACT_GRAMMAR_ELEMENT_FEATURE_COUNT = 0;
+
+	/**
 	 * The meta object id for the '{@link org.eclipse.xtext.impl.AbstractRuleImpl <em>Abstract Rule</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -147,7 +168,7 @@ public interface XtextPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ABSTRACT_RULE__NAME = 0;
+	int ABSTRACT_RULE__NAME = ABSTRACT_GRAMMAR_ELEMENT_FEATURE_COUNT + 0;
 
 	/**
 	 * The feature id for the '<em><b>Type</b></em>' containment reference.
@@ -156,7 +177,7 @@ public interface XtextPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ABSTRACT_RULE__TYPE = 1;
+	int ABSTRACT_RULE__TYPE = ABSTRACT_GRAMMAR_ELEMENT_FEATURE_COUNT + 1;
 
 	/**
 	 * The feature id for the '<em><b>Alternatives</b></em>' containment reference.
@@ -165,7 +186,7 @@ public interface XtextPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ABSTRACT_RULE__ALTERNATIVES = 2;
+	int ABSTRACT_RULE__ALTERNATIVES = ABSTRACT_GRAMMAR_ELEMENT_FEATURE_COUNT + 2;
 
 	/**
 	 * The number of structural features of the '<em>Abstract Rule</em>' class.
@@ -174,7 +195,7 @@ public interface XtextPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ABSTRACT_RULE_FEATURE_COUNT = 3;
+	int ABSTRACT_RULE_FEATURE_COUNT = ABSTRACT_GRAMMAR_ELEMENT_FEATURE_COUNT + 3;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.xtext.impl.AbstractMetamodelDeclarationImpl <em>Abstract Metamodel Declaration</em>}' class.
@@ -445,7 +466,7 @@ public interface XtextPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ABSTRACT_ELEMENT__CARDINALITY = 0;
+	int ABSTRACT_ELEMENT__CARDINALITY = ABSTRACT_GRAMMAR_ELEMENT_FEATURE_COUNT + 0;
 
 	/**
 	 * The feature id for the '<em><b>Predicated</b></em>' attribute.
@@ -454,7 +475,7 @@ public interface XtextPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ABSTRACT_ELEMENT__PREDICATED = 1;
+	int ABSTRACT_ELEMENT__PREDICATED = ABSTRACT_GRAMMAR_ELEMENT_FEATURE_COUNT + 1;
 
 	/**
 	 * The feature id for the '<em><b>First Set Predicated</b></em>' attribute.
@@ -464,7 +485,7 @@ public interface XtextPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ABSTRACT_ELEMENT__FIRST_SET_PREDICATED = 2;
+	int ABSTRACT_ELEMENT__FIRST_SET_PREDICATED = ABSTRACT_GRAMMAR_ELEMENT_FEATURE_COUNT + 2;
 
 	/**
 	 * The number of structural features of the '<em>Abstract Element</em>' class.
@@ -473,7 +494,7 @@ public interface XtextPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ABSTRACT_ELEMENT_FEATURE_COUNT = 3;
+	int ABSTRACT_ELEMENT_FEATURE_COUNT = ABSTRACT_GRAMMAR_ELEMENT_FEATURE_COUNT + 3;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.xtext.impl.ActionImpl <em>Action</em>}' class.
@@ -2806,6 +2827,17 @@ public interface XtextPackage extends EPackage {
 	EAttribute getLiteralCondition_True();
 
 	/**
+	 * Returns the meta object for class '{@link org.eclipse.xtext.AbstractGrammarElement <em>Abstract Grammar Element</em>}'.
+	 * <!-- begin-user-doc -->
+	 * @since 2.10
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Abstract Grammar Element</em>'.
+	 * @see org.eclipse.xtext.AbstractGrammarElement
+	 * @generated
+	 */
+	EClass getAbstractGrammarElement();
+
+	/**
 	 * Returns the factory that creates the instances of the model.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -3611,6 +3643,17 @@ public interface XtextPackage extends EPackage {
 		 * @generated
 		 */
 		EAttribute LITERAL_CONDITION__TRUE = eINSTANCE.getLiteralCondition_True();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.xtext.impl.AbstractGrammarElementImpl <em>Abstract Grammar Element</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * @since 2.10
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.xtext.impl.AbstractGrammarElementImpl
+		 * @see org.eclipse.xtext.impl.XtextPackageImpl#getAbstractGrammarElement()
+		 * @generated
+		 */
+		EClass ABSTRACT_GRAMMAR_ELEMENT = eINSTANCE.getAbstractGrammarElement();
 
 	}
 

--- a/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/impl/AbstractElementImpl.java
+++ b/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/impl/AbstractElementImpl.java
@@ -27,7 +27,7 @@ import org.eclipse.xtext.XtextPackage;
  *
  * @generated
  */
-public class AbstractElementImpl extends MinimalEObjectImpl.Container implements AbstractElement {
+public class AbstractElementImpl extends AbstractGrammarElementImpl implements AbstractElement {
 	/**
 	 * The default value of the '{@link #getCardinality() <em>Cardinality</em>}' attribute.
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/impl/AbstractGrammarElementImpl.java
+++ b/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/impl/AbstractGrammarElementImpl.java
@@ -1,0 +1,40 @@
+/**
+ */
+package org.eclipse.xtext.impl;
+
+import org.eclipse.emf.ecore.EClass;
+
+import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
+
+import org.eclipse.xtext.AbstractGrammarElement;
+import org.eclipse.xtext.XtextPackage;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>Abstract Grammar Element</b></em>'.
+ * @since 2.10
+ * <!-- end-user-doc -->
+ *
+ * @generated
+ */
+public abstract class AbstractGrammarElementImpl extends MinimalEObjectImpl.Container implements AbstractGrammarElement {
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected AbstractGrammarElementImpl() {
+		super();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	protected EClass eStaticClass() {
+		return XtextPackage.Literals.ABSTRACT_GRAMMAR_ELEMENT;
+	}
+
+} //AbstractGrammarElementImpl

--- a/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/impl/AbstractRuleImpl.java
+++ b/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/impl/AbstractRuleImpl.java
@@ -31,7 +31,7 @@ import org.eclipse.xtext.XtextPackage;
  *
  * @generated
  */
-public class AbstractRuleImpl extends MinimalEObjectImpl.Container implements AbstractRule {
+public class AbstractRuleImpl extends AbstractGrammarElementImpl implements AbstractRule {
 	/**
 	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/impl/XtextPackageImpl.java
+++ b/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/impl/XtextPackageImpl.java
@@ -11,6 +11,7 @@ import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.impl.EPackageImpl;
 
 import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.AbstractMetamodelDeclaration;
 import org.eclipse.xtext.AbstractNegatedToken;
 import org.eclipse.xtext.AbstractRule;
@@ -301,6 +302,13 @@ public class XtextPackageImpl extends EPackageImpl implements XtextPackage {
 	 * @generated
 	 */
 	private EClass literalConditionEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass abstractGrammarElementEClass = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
@@ -1153,6 +1161,16 @@ public class XtextPackageImpl extends EPackageImpl implements XtextPackage {
 
 	/**
 	 * <!-- begin-user-doc -->
+	 * @since 2.10
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EClass getAbstractGrammarElement() {
+		return abstractGrammarElementEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
@@ -1299,6 +1317,8 @@ public class XtextPackageImpl extends EPackageImpl implements XtextPackage {
 
 		literalConditionEClass = createEClass(LITERAL_CONDITION);
 		createEAttribute(literalConditionEClass, LITERAL_CONDITION__TRUE);
+
+		abstractGrammarElementEClass = createEClass(ABSTRACT_GRAMMAR_ELEMENT);
 	}
 
 	/**
@@ -1332,9 +1352,11 @@ public class XtextPackageImpl extends EPackageImpl implements XtextPackage {
 		// Set bounds for type parameters
 
 		// Add supertypes to classes
+		abstractRuleEClass.getESuperTypes().add(this.getAbstractGrammarElement());
 		generatedMetamodelEClass.getESuperTypes().add(this.getAbstractMetamodelDeclaration());
 		referencedMetamodelEClass.getESuperTypes().add(this.getAbstractMetamodelDeclaration());
 		parserRuleEClass.getESuperTypes().add(this.getAbstractRule());
+		abstractElementEClass.getESuperTypes().add(this.getAbstractGrammarElement());
 		actionEClass.getESuperTypes().add(this.getAbstractElement());
 		keywordEClass.getESuperTypes().add(this.getAbstractElement());
 		ruleCallEClass.getESuperTypes().add(this.getAbstractElement());
@@ -1481,6 +1503,8 @@ public class XtextPackageImpl extends EPackageImpl implements XtextPackage {
 
 		initEClass(literalConditionEClass, LiteralCondition.class, "LiteralCondition", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getLiteralCondition_True(), theEcorePackage.getEBoolean(), "true", null, 0, 1, LiteralCondition.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(abstractGrammarElementEClass, AbstractGrammarElement.class, "AbstractGrammarElement", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
 		// Create resource
 		createResource(eNS_URI);

--- a/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/util/XtextAdapterFactory.java
+++ b/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/util/XtextAdapterFactory.java
@@ -208,6 +208,10 @@ public class XtextAdapterFactory extends AdapterFactoryImpl {
 				return createLiteralConditionAdapter();
 			}
 			@Override
+			public Adapter caseAbstractGrammarElement(AbstractGrammarElement object) {
+				return createAbstractGrammarElementAdapter();
+			}
+			@Override
 			public Adapter defaultCase(EObject object) {
 				return createEObjectAdapter();
 			}
@@ -723,6 +727,21 @@ public class XtextAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createLiteralConditionAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.xtext.AbstractGrammarElement <em>Abstract Grammar Element</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * @since 2.10
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.xtext.AbstractGrammarElement
+	 * @generated
+	 */
+	public Adapter createAbstractGrammarElementAdapter() {
 		return null;
 	}
 

--- a/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/util/XtextSwitch.java
+++ b/plugins/org.eclipse.xtext/emf-gen/org/eclipse/xtext/util/XtextSwitch.java
@@ -76,6 +76,7 @@ public class XtextSwitch<T> extends Switch<T> {
 			case XtextPackage.ABSTRACT_RULE: {
 				AbstractRule abstractRule = (AbstractRule)theEObject;
 				T result = caseAbstractRule(abstractRule);
+				if (result == null) result = caseAbstractGrammarElement(abstractRule);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -103,6 +104,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				ParserRule parserRule = (ParserRule)theEObject;
 				T result = caseParserRule(parserRule);
 				if (result == null) result = caseAbstractRule(parserRule);
+				if (result == null) result = caseAbstractGrammarElement(parserRule);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -115,6 +117,7 @@ public class XtextSwitch<T> extends Switch<T> {
 			case XtextPackage.ABSTRACT_ELEMENT: {
 				AbstractElement abstractElement = (AbstractElement)theEObject;
 				T result = caseAbstractElement(abstractElement);
+				if (result == null) result = caseAbstractGrammarElement(abstractElement);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -122,6 +125,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				Action action = (Action)theEObject;
 				T result = caseAction(action);
 				if (result == null) result = caseAbstractElement(action);
+				if (result == null) result = caseAbstractGrammarElement(action);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -129,6 +133,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				Keyword keyword = (Keyword)theEObject;
 				T result = caseKeyword(keyword);
 				if (result == null) result = caseAbstractElement(keyword);
+				if (result == null) result = caseAbstractGrammarElement(keyword);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -136,6 +141,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				RuleCall ruleCall = (RuleCall)theEObject;
 				T result = caseRuleCall(ruleCall);
 				if (result == null) result = caseAbstractElement(ruleCall);
+				if (result == null) result = caseAbstractGrammarElement(ruleCall);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -143,6 +149,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				Assignment assignment = (Assignment)theEObject;
 				T result = caseAssignment(assignment);
 				if (result == null) result = caseAbstractElement(assignment);
+				if (result == null) result = caseAbstractGrammarElement(assignment);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -150,6 +157,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				CrossReference crossReference = (CrossReference)theEObject;
 				T result = caseCrossReference(crossReference);
 				if (result == null) result = caseAbstractElement(crossReference);
+				if (result == null) result = caseAbstractGrammarElement(crossReference);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -157,6 +165,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				TerminalRule terminalRule = (TerminalRule)theEObject;
 				T result = caseTerminalRule(terminalRule);
 				if (result == null) result = caseAbstractRule(terminalRule);
+				if (result == null) result = caseAbstractGrammarElement(terminalRule);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -164,6 +173,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				AbstractNegatedToken abstractNegatedToken = (AbstractNegatedToken)theEObject;
 				T result = caseAbstractNegatedToken(abstractNegatedToken);
 				if (result == null) result = caseAbstractElement(abstractNegatedToken);
+				if (result == null) result = caseAbstractGrammarElement(abstractNegatedToken);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -172,6 +182,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				T result = caseNegatedToken(negatedToken);
 				if (result == null) result = caseAbstractNegatedToken(negatedToken);
 				if (result == null) result = caseAbstractElement(negatedToken);
+				if (result == null) result = caseAbstractGrammarElement(negatedToken);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -180,6 +191,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				T result = caseUntilToken(untilToken);
 				if (result == null) result = caseAbstractNegatedToken(untilToken);
 				if (result == null) result = caseAbstractElement(untilToken);
+				if (result == null) result = caseAbstractGrammarElement(untilToken);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -187,6 +199,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				Wildcard wildcard = (Wildcard)theEObject;
 				T result = caseWildcard(wildcard);
 				if (result == null) result = caseAbstractElement(wildcard);
+				if (result == null) result = caseAbstractGrammarElement(wildcard);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -194,6 +207,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				EnumRule enumRule = (EnumRule)theEObject;
 				T result = caseEnumRule(enumRule);
 				if (result == null) result = caseAbstractRule(enumRule);
+				if (result == null) result = caseAbstractGrammarElement(enumRule);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -201,6 +215,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				EnumLiteralDeclaration enumLiteralDeclaration = (EnumLiteralDeclaration)theEObject;
 				T result = caseEnumLiteralDeclaration(enumLiteralDeclaration);
 				if (result == null) result = caseAbstractElement(enumLiteralDeclaration);
+				if (result == null) result = caseAbstractGrammarElement(enumLiteralDeclaration);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -209,6 +224,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				T result = caseAlternatives(alternatives);
 				if (result == null) result = caseCompoundElement(alternatives);
 				if (result == null) result = caseAbstractElement(alternatives);
+				if (result == null) result = caseAbstractGrammarElement(alternatives);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -217,6 +233,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				T result = caseUnorderedGroup(unorderedGroup);
 				if (result == null) result = caseCompoundElement(unorderedGroup);
 				if (result == null) result = caseAbstractElement(unorderedGroup);
+				if (result == null) result = caseAbstractGrammarElement(unorderedGroup);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -225,6 +242,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				T result = caseGroup(group);
 				if (result == null) result = caseCompoundElement(group);
 				if (result == null) result = caseAbstractElement(group);
+				if (result == null) result = caseAbstractGrammarElement(group);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -232,6 +250,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				CharacterRange characterRange = (CharacterRange)theEObject;
 				T result = caseCharacterRange(characterRange);
 				if (result == null) result = caseAbstractElement(characterRange);
+				if (result == null) result = caseAbstractGrammarElement(characterRange);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -239,6 +258,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				CompoundElement compoundElement = (CompoundElement)theEObject;
 				T result = caseCompoundElement(compoundElement);
 				if (result == null) result = caseAbstractElement(compoundElement);
+				if (result == null) result = caseAbstractGrammarElement(compoundElement);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -246,6 +266,7 @@ public class XtextSwitch<T> extends Switch<T> {
 				EOF eof = (EOF)theEObject;
 				T result = caseEOF(eof);
 				if (result == null) result = caseAbstractElement(eof);
+				if (result == null) result = caseAbstractGrammarElement(eof);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -308,6 +329,12 @@ public class XtextSwitch<T> extends Switch<T> {
 				LiteralCondition literalCondition = (LiteralCondition)theEObject;
 				T result = caseLiteralCondition(literalCondition);
 				if (result == null) result = caseCondition(literalCondition);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case XtextPackage.ABSTRACT_GRAMMAR_ELEMENT: {
+				AbstractGrammarElement abstractGrammarElement = (AbstractGrammarElement)theEObject;
+				T result = caseAbstractGrammarElement(abstractGrammarElement);
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
@@ -846,6 +873,22 @@ public class XtextSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T caseLiteralCondition(LiteralCondition object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Abstract Grammar Element</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * @since 2.10
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Abstract Grammar Element</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseAbstractGrammarElement(AbstractGrammarElement object) {
 		return null;
 	}
 

--- a/plugins/org.eclipse.xtext/org/eclipse/xtext/Xtext.ecore
+++ b/plugins/org.eclipse.xtext/org/eclipse/xtext/Xtext.ecore
@@ -13,7 +13,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="rules" upperBound="-1"
         eType="#//AbstractRule" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="AbstractRule">
+  <eClassifiers xsi:type="ecore:EClass" name="AbstractRule" eSuperTypes="#//AbstractGrammarElement">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="type" eType="#//TypeRef"
         containment="true"/>
@@ -41,7 +41,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="metamodel" eType="#//AbstractMetamodelDeclaration"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="classifier" eType="ecore:EClass platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EClassifier"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="AbstractElement">
+  <eClassifiers xsi:type="ecore:EClass" name="AbstractElement" eSuperTypes="#//AbstractGrammarElement">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="cardinality" eType="ecore:EDataType platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="predicated" eType="ecore:EDataType platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="firstSetPredicated" eType="ecore:EDataType platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EBoolean"/>
@@ -134,4 +134,5 @@
   <eClassifiers xsi:type="ecore:EClass" name="LiteralCondition" eSuperTypes="#//Condition">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="true" eType="ecore:EDataType platform:/resource/org.eclipse.emf.ecore/model/Ecore.ecore#//EBoolean"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="AbstractGrammarElement" abstract="true"/>
 </ecore:EPackage>

--- a/plugins/org.eclipse.xtext/org/eclipse/xtext/Xtext.genmodel
+++ b/plugins/org.eclipse.xtext/org/eclipse/xtext/Xtext.genmodel
@@ -119,5 +119,6 @@
     <genClasses ecoreClass="Xtext.ecore#//LiteralCondition">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Xtext.ecore#//LiteralCondition/true"/>
     </genClasses>
+    <genClasses image="false" ecoreClass="Xtext.ecore#//AbstractGrammarElement"/>
   </genPackages>
 </genmodel:GenModel>

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/linking/lazy/SyntheticLinkingSupport.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/linking/lazy/SyntheticLinkingSupport.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.linking.lazy;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.XtextFactory;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.INode;
@@ -49,14 +50,14 @@ public class SyntheticLinkingSupport {
 	 */
 	protected INode createCrossReferenceNode(EObject obj, EReference eRef, String crossRefString, int offset, int length) {
 		CompositeNode parent = getParent(obj, eRef, crossRefString, offset, length);
-		EObject grammarElement = getGrammarElement(obj, eRef, crossRefString, offset, length);
+		AbstractGrammarElement grammarElement = getGrammarElement(obj, eRef, crossRefString, offset, length);
 		return new SyntheticLinkingLeafNode(obj, crossRefString, offset, length, grammarElement, parent);
 	}
 
 	/**
 	 * @since 2.10
 	 */
-	protected EObject getGrammarElement(EObject obj, EReference eRef, String crossRefString, int offset, int length) {
+	protected AbstractGrammarElement getGrammarElement(EObject obj, EReference eRef, String crossRefString, int offset, int length) {
 		return XtextFactory.eINSTANCE.createKeyword();
 	}
 
@@ -89,7 +90,7 @@ class SyntheticLinkingLeafNode extends LeafNode {
 	private final String text;
 	private final EObject semanticElement;
 
-	public SyntheticLinkingLeafNode(EObject semanticElement, String text, int offset, int length, EObject grammarElement, CompositeNode parent) {
+	public SyntheticLinkingLeafNode(EObject semanticElement, String text, int offset, int length, AbstractGrammarElement grammarElement, CompositeNode parent) {
 		this.text = text;
 		this.semanticElement = semanticElement;
 

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/INode.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/INode.java
@@ -8,6 +8,7 @@
 package org.eclipse.xtext.nodemodel;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.util.ITextRegionWithLineInformation;
 
@@ -165,7 +166,7 @@ public interface INode {
 	 * errors. This happens usually when a keyword occurred at an unexpected offset.
 	 * @return the grammar element that created this node. May return <code>null</code>.
 	 */
-	EObject getGrammarElement();
+	AbstractGrammarElement getGrammarElement();
 	
 	/**
 	 * Returns the nearest semantic object that is associated with the subtree of this node. May return <code>null</code> whenever

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/AbstractNode.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/AbstractNode.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.nodemodel.BidiIterator;
 import org.eclipse.xtext.nodemodel.BidiTreeIterable;
 import org.eclipse.xtext.nodemodel.BidiTreeIterator;
@@ -281,8 +282,8 @@ public abstract class AbstractNode implements INode, BidiTreeIterable<INode> {
 	}
 	
 	@Override
-	public EObject getGrammarElement() {
-		return (EObject) grammarElementOrArray;
+	public AbstractGrammarElement getGrammarElement() {
+		return (AbstractGrammarElement) grammarElementOrArray;
 	}
 	
 	protected Object basicGetGrammarElement() {
@@ -421,17 +422,17 @@ public abstract class AbstractNode implements INode, BidiTreeIterable<INode> {
 		SerializationUtil.writeInt(out, grammarId.intValue(), true);
 	}
 
-	int fillGrammarElementToIdMap(int currentId, Map<EObject, Integer> grammarElementToIdMap,
+	int fillGrammarElementToIdMap(int currentId, Map<AbstractGrammarElement, Integer> grammarElementToIdMap,
 			List<String> grammarIdToURIMap) {
 		if (grammarElementOrArray != null) {
-			if (grammarElementOrArray instanceof EObject) {
-				EObject grammarElement = (EObject) grammarElementOrArray;
+			if (grammarElementOrArray instanceof AbstractGrammarElement) {
+				AbstractGrammarElement grammarElement = (AbstractGrammarElement) grammarElementOrArray;
 				currentId = updateMapping(currentId, grammarElementToIdMap, grammarIdToURIMap, grammarElement);
 			}
 
-			if (grammarElementOrArray instanceof EObject[]) {
-				EObject[] grammarElements = (EObject[]) grammarElementOrArray;
-				for (EObject grammarElement : grammarElements) {
+			if (grammarElementOrArray instanceof AbstractGrammarElement[]) {
+				AbstractGrammarElement[] grammarElements = (AbstractGrammarElement[]) grammarElementOrArray;
+				for (AbstractGrammarElement grammarElement : grammarElements) {
 					currentId = updateMapping(currentId, grammarElementToIdMap, grammarIdToURIMap, grammarElement);
 				}
 			}
@@ -440,8 +441,8 @@ public abstract class AbstractNode implements INode, BidiTreeIterable<INode> {
 		return currentId;
 	}
 
-	private int updateMapping(int currentId, Map<EObject, Integer> grammarElementToIdMap,
-			List<String> grammarIdToURIMap, EObject grammarElement) {
+	private int updateMapping(int currentId, Map<AbstractGrammarElement, Integer> grammarElementToIdMap,
+			List<String> grammarIdToURIMap, AbstractGrammarElement grammarElement) {
 		if (!grammarElementToIdMap.containsKey(grammarElement)) {
 			URI uri = EcoreUtil.getURI(grammarElement);
 			if (uri == null) {

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/CompositeNode.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/CompositeNode.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.nodemodel.BidiIterable;
 import org.eclipse.xtext.nodemodel.BidiTreeIterator;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
@@ -151,23 +151,23 @@ public class CompositeNode extends AbstractNode implements ICompositeNode {
 	}
 
 	protected boolean isFolded(Object grammarElementOrArray) {
-		return !(grammarElementOrArray == null || grammarElementOrArray instanceof EObject);
+		return !(grammarElementOrArray == null || grammarElementOrArray instanceof AbstractGrammarElement);
 	}
 	
 	public ICompositeNode resolveAsParent() {
 		Object grammarElementOrArray = basicGetGrammarElement();
 		if (!isFolded())
 			return this;
-		EObject[] grammarElements = (EObject[]) grammarElementOrArray;
+		AbstractGrammarElement[] grammarElements = (AbstractGrammarElement[]) grammarElementOrArray;
 		return new SyntheticCompositeNode(this, grammarElements.length - 1);
 	}	
 	
 	@Override
-	public EObject getGrammarElement() {
+	public AbstractGrammarElement getGrammarElement() {
 		Object grammarElementOrArray = basicGetGrammarElement();
 		if (!isFolded())
-			return (EObject) grammarElementOrArray;
-		EObject[] grammarElements = (EObject[]) grammarElementOrArray;
+			return (AbstractGrammarElement) grammarElementOrArray;
+		AbstractGrammarElement[] grammarElements = (AbstractGrammarElement[]) grammarElementOrArray;
 		return grammarElements[0];
 	}
 
@@ -277,7 +277,7 @@ public class CompositeNode extends AbstractNode implements ICompositeNode {
 	}
 
 	@Override
-	int fillGrammarElementToIdMap(int currentId, Map<EObject, Integer> grammarElementToIdMap,
+	int fillGrammarElementToIdMap(int currentId, Map<AbstractGrammarElement, Integer> grammarElementToIdMap,
 			List<String> grammarIdToURIMap) {
 		currentId = super.fillGrammarElementToIdMap(currentId, grammarElementToIdMap, grammarIdToURIMap);
 

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/NodeModelBuilder.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/NodeModelBuilder.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.RandomAccess;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.RuleCall;
 import org.eclipse.xtext.nodemodel.BidiTreeIterator;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
@@ -200,13 +201,13 @@ public class NodeModelBuilder {
 				// it is our only child and has no direct semantic element
 				// so we can fold its grammar element into our own grammar elements
 				// if it refers not to a syntax error or a semantic object
-				EObject myGrammarElement = casted.getGrammarElement();
+				AbstractGrammarElement myGrammarElement = casted.getGrammarElement();
 				Object childGrammarElement = firstChild.basicGetGrammarElement();
-				EObject[] list = null;
-				if (childGrammarElement instanceof EObject) {
-					list = new EObject[] {myGrammarElement, (EObject) childGrammarElement};
+				AbstractGrammarElement[] list = null;
+				if (childGrammarElement instanceof AbstractGrammarElement) {
+					list = new AbstractGrammarElement[] {myGrammarElement, (AbstractGrammarElement) childGrammarElement};
 				} else {
-					list = newEObjectArray(myGrammarElement, (EObject[]) childGrammarElement);
+					list = newGrammarElementArray(myGrammarElement, (AbstractGrammarElement[]) childGrammarElement);
 				}
 				casted.basicSetGrammarElement(cachedFoldedGrammarElements.intern(list));
 				replaceChildren(firstChild, casted);
@@ -267,8 +268,8 @@ public class NodeModelBuilder {
 		}
 	}
 	
-	private /* @Nullable */ EObject[] newEObjectArray(/* @Nullable */ EObject first, EObject[] rest) {
-		EObject[] array = new EObject[rest.length + 1];
+	private /* @Nullable */ AbstractGrammarElement[] newGrammarElementArray(/* @Nullable */ AbstractGrammarElement first, AbstractGrammarElement[] rest) {
+		AbstractGrammarElement[] array = new AbstractGrammarElement[rest.length + 1];
 		array[0] = first;
 		System.arraycopy(rest, 0, array, 1, rest.length);
 		return array;

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/RootNode.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/RootNode.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.nodemodel.serialization.DeserializationConversionContext;
@@ -203,7 +203,7 @@ public class RootNode extends CompositeNodeWithSemanticElementAndSyntaxError {
 	 * @since 2.3
 	 * @noreference This method is not intended to be referenced by clients.
 	 */
-	public void fillGrammarElementToIdMap(Map<EObject, Integer> grammarElementToIdMap,
+	public void fillGrammarElementToIdMap(Map<AbstractGrammarElement, Integer> grammarElementToIdMap,
 			List<String> grammarIdToURIMap) {
 		fillGrammarElementToIdMap(0, grammarElementToIdMap, grammarIdToURIMap);
 	}

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/SyntheticCompositeNode.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/impl/SyntheticCompositeNode.java
@@ -8,6 +8,7 @@
 package org.eclipse.xtext.nodemodel.impl;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.nodemodel.BidiIterable;
 import org.eclipse.xtext.nodemodel.BidiTreeIterable;
 import org.eclipse.xtext.nodemodel.BidiTreeIterator;
@@ -127,8 +128,8 @@ public class SyntheticCompositeNode implements ICompositeNode, BidiTreeIterable<
 	}
 
 	@Override
-	public EObject getGrammarElement() {
-		EObject[] array = (EObject[]) delegate.basicGetGrammarElement();
+	public AbstractGrammarElement getGrammarElement() {
+		AbstractGrammarElement[] array = (AbstractGrammarElement[]) delegate.basicGetGrammarElement();
 		return array[grammarElementIdx];
 	}
 

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/serialization/SerializationConversionContext.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/nodemodel/serialization/SerializationConversionContext.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.nodemodel.impl.RootNode;
 import org.eclipse.xtext.parser.IParseResult;
 import org.eclipse.xtext.resource.XtextResource;
@@ -22,12 +23,12 @@ import org.eclipse.xtext.resource.XtextResource;
  * @since 2.3
  */
 public class SerializationConversionContext {
-	final private Map<EObject, Integer> grammarElementToIdMap;
+	final private Map<AbstractGrammarElement, Integer> grammarElementToIdMap;
 	final private ArrayList<String> grammarIdToURIMap;
 	final private Map<EObject, Integer> eObjectToIdMap;
 
 	public SerializationConversionContext(XtextResource resource) {
-		grammarElementToIdMap = new IdentityHashMap<EObject, Integer>();
+		grammarElementToIdMap = new IdentityHashMap<AbstractGrammarElement, Integer>();
 		grammarIdToURIMap = new ArrayList<String>();
 		eObjectToIdMap = new IdentityHashMap<EObject, Integer>();
 

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinder.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinder.java
@@ -11,8 +11,8 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import java.util.Collections;
 import java.util.List;
-import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.ILeafNode;
@@ -118,7 +118,7 @@ public class DefaultTaskFinder implements ITaskFinder {
   }
   
   protected boolean canContainTaskTags(final ILeafNode node) {
-    final EObject rule = node.getGrammarElement();
+    final AbstractGrammarElement rule = node.getGrammarElement();
     if ((rule instanceof AbstractRule)) {
       return this.hiddenTokenHelper.isComment(((AbstractRule)rule));
     }

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/resource/ResourceStorageTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/resource/ResourceStorageTest.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
 import org.eclipse.xtend.core.xtend.XtendFile;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.common.types.JvmField;
 import org.eclipse.xtext.common.types.JvmFormalParameter;
 import org.eclipse.xtext.common.types.JvmGenericType;
@@ -191,8 +192,8 @@ public class ResourceStorageTest extends AbstractXtendTestCase {
           int _totalLength = orig.getTotalLength();
           int _totalLength_1 = rest.getTotalLength();
           Assert.assertEquals(_totalLength, _totalLength_1);
-          EObject _grammarElement = orig.getGrammarElement();
-          EObject _grammarElement_1 = rest.getGrammarElement();
+          AbstractGrammarElement _grammarElement = orig.getGrammarElement();
+          AbstractGrammarElement _grammarElement_1 = rest.getGrammarElement();
           Assert.assertSame(_grammarElement, _grammarElement_1);
           Resource _eResource_3 = file.eResource();
           EObject _semanticElement = orig.getSemanticElement();

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/nodemodel/LeafNodeTest.java
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/nodemodel/LeafNodeTest.java
@@ -9,6 +9,8 @@ package org.eclipse.xtext.nodemodel;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.xtext.Keyword;
+import org.eclipse.xtext.XtextFactory;
 import org.junit.Test;
 
 /**
@@ -59,7 +61,7 @@ public class LeafNodeTest extends AbstractNodeTest {
 	@Override
 	@Test public void testGetGrammarElement() {
 		LeafNode leafNode = createNode();
-		EObject grammarElement = EcoreFactory.eINSTANCE.createEObject();
+		Keyword grammarElement = XtextFactory.eINSTANCE.createKeyword();
 		leafNode.basicSetGrammarElement(grammarElement);
 		assertSame(grammarElement, leafNode.getGrammarElement());
 	}

--- a/tests/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/parser/Bug480686Test.java
+++ b/tests/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/parser/Bug480686Test.java
@@ -13,6 +13,7 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.AbstractGrammarElement;
 import org.eclipse.xtext.junit4.InjectWith;
 import org.eclipse.xtext.junit4.XtextRunner;
 import org.eclipse.xtext.junit4.util.ParseHelper;
@@ -152,16 +153,16 @@ public class Bug480686Test {
       final ICompositeNode root = _parseResult.getRootNode();
       InvariantChecker _invariantChecker = new InvariantChecker();
       _invariantChecker.checkInvariant(root);
-      final HashSet<EObject> set = CollectionLiterals.<EObject>newHashSet();
+      final HashSet<AbstractGrammarElement> set = CollectionLiterals.<AbstractGrammarElement>newHashSet();
       BidiTreeIterable<INode> _asTreeIterable = root.getAsTreeIterable();
       for (final INode node : _asTreeIterable) {
         if ((node instanceof ICompositeNode)) {
-          EObject _grammarElement = ((ICompositeNode)node).getGrammarElement();
+          AbstractGrammarElement _grammarElement = ((ICompositeNode)node).getGrammarElement();
           boolean _tripleNotEquals = (_grammarElement != null);
           if (_tripleNotEquals) {
-            EObject _grammarElement_1 = ((ICompositeNode)node).getGrammarElement();
+            AbstractGrammarElement _grammarElement_1 = ((ICompositeNode)node).getGrammarElement();
             String _string = _grammarElement_1.toString();
-            EObject _grammarElement_2 = ((ICompositeNode)node).getGrammarElement();
+            AbstractGrammarElement _grammarElement_2 = ((ICompositeNode)node).getGrammarElement();
             boolean _add = set.add(_grammarElement_2);
             Assert.assertTrue(_string, _add);
           } else {
@@ -183,16 +184,16 @@ public class Bug480686Test {
       res.update(0, 0, "newArrayList()");
       IParseResult _parseResult = res.getParseResult();
       final ICompositeNode root = _parseResult.getRootNode();
-      final HashSet<EObject> set = CollectionLiterals.<EObject>newHashSet();
+      final HashSet<AbstractGrammarElement> set = CollectionLiterals.<AbstractGrammarElement>newHashSet();
       BidiTreeIterable<INode> _asTreeIterable = root.getAsTreeIterable();
       for (final INode node : _asTreeIterable) {
         if ((node instanceof ICompositeNode)) {
-          EObject _grammarElement = ((ICompositeNode)node).getGrammarElement();
+          AbstractGrammarElement _grammarElement = ((ICompositeNode)node).getGrammarElement();
           boolean _tripleNotEquals = (_grammarElement != null);
           if (_tripleNotEquals) {
-            EObject _grammarElement_1 = ((ICompositeNode)node).getGrammarElement();
+            AbstractGrammarElement _grammarElement_1 = ((ICompositeNode)node).getGrammarElement();
             String _string = _grammarElement_1.toString();
-            EObject _grammarElement_2 = ((ICompositeNode)node).getGrammarElement();
+            AbstractGrammarElement _grammarElement_2 = ((ICompositeNode)node).getGrammarElement();
             boolean _add = set.add(_grammarElement_2);
             Assert.assertTrue(_string, _add);
           } else {
@@ -336,8 +337,8 @@ public class Bug480686Test {
       int _totalLength_1 = other.getTotalLength();
       Assert.assertEquals(_totalLength, _totalLength_1);
     }
-    EObject _grammarElement = node.getGrammarElement();
-    EObject _grammarElement_1 = other.getGrammarElement();
+    AbstractGrammarElement _grammarElement = node.getGrammarElement();
+    AbstractGrammarElement _grammarElement_1 = other.getGrammarElement();
     Assert.assertEquals(_grammarElement, _grammarElement_1);
     boolean _hasDirectSemanticElement = node.hasDirectSemanticElement();
     boolean _hasDirectSemanticElement_1 = other.hasDirectSemanticElement();


### PR DESCRIPTION
The PR is organized in 2 commits: The first only introduces the AbstractGrammarElement EClass, the second commit changes INode#getGrammarElement and dependent code.

Note that changing the return type of INode#getGrammarElement causes API changes. Since the returned type is a subtype of the previous one (EObject) this should be OK. I have created API filters for the places detected by API tooling.