### PR TITLE
avoid calls to xbase.lib.IterableExtension.forEach()

### DIFF
--- a/examples/org.eclipse.xtend.examples-container/contents/xtend-annotation-examples/src/i18n/Externalized.xtend
+++ b/examples/org.eclipse.xtend.examples-container/contents/xtend-annotation-examples/src/i18n/Externalized.xtend
@@ -64,7 +64,9 @@ class ExternalizedProcessor extends AbstractClassProcessor implements CodeGenera
 				primarySourceElement = field
 			]
 		}
-		annotatedClass.declaredFields.forEach[remove]
+		for (it : annotatedClass.declaredFields) {
+			remove
+		}
 
 		//private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
 		annotatedClass.addField("RESOURCE_BUNDLE") [

--- a/examples/org.eclipse.xtend.examples-container/contents/xtend-annotation-examples/xtend-gen/i18n/ExternalizedProcessor.java
+++ b/examples/org.eclipse.xtend.examples-container/contents/xtend-annotation-examples/xtend-gen/i18n/ExternalizedProcessor.java
@@ -162,14 +162,10 @@ public class ExternalizedProcessor extends AbstractClassProcessor implements Cod
       }
     }
     Iterable<? extends MutableFieldDeclaration> _declaredFields_1 = annotatedClass.getDeclaredFields();
+    for (final MutableFieldDeclaration it : _declaredFields_1) {
+      it.remove();
+    }
     final Procedure1<MutableFieldDeclaration> _function = new Procedure1<MutableFieldDeclaration>() {
-      @Override
-      public void apply(final MutableFieldDeclaration it) {
-        it.remove();
-      }
-    };
-    IterableExtensions.forEach(_declaredFields_1, _function);
-    final Procedure1<MutableFieldDeclaration> _function_1 = new Procedure1<MutableFieldDeclaration>() {
       @Override
       public void apply(final MutableFieldDeclaration it) {
         it.setStatic(true);
@@ -189,7 +185,7 @@ public class ExternalizedProcessor extends AbstractClassProcessor implements Cod
         context.setPrimarySourceElement(it, annotatedClass);
       }
     };
-    annotatedClass.addField("RESOURCE_BUNDLE", _function_1);
+    annotatedClass.addField("RESOURCE_BUNDLE", _function);
   }
   
   @Override

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/outline/ArithmeticsOutlineTreeProvider.xtend
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/outline/ArithmeticsOutlineTreeProvider.xtend
@@ -19,9 +19,9 @@ import org.eclipse.xtext.ui.editor.outline.impl.DefaultOutlineTreeProvider
  */
 class ArithmeticsOutlineTreeProvider extends DefaultOutlineTreeProvider {
 	def _createChildren(IOutlineNode parentNode, Module module) {
-		module.eContents().filter(Definition).forEach [
+		for (it : module.eContents().filter(Definition)) {
 			createNode(parentNode, it);
-		]
+		}
 	}
 
 	def _isLeaf(Definition definition) {

--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/outline/ArithmeticsOutlineTreeProvider.java
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/outline/ArithmeticsOutlineTreeProvider.java
@@ -14,8 +14,6 @@ import org.eclipse.xtext.example.arithmetics.arithmetics.Definition;
 import org.eclipse.xtext.example.arithmetics.arithmetics.Module;
 import org.eclipse.xtext.ui.editor.outline.IOutlineNode;
 import org.eclipse.xtext.ui.editor.outline.impl.DefaultOutlineTreeProvider;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * Customization of the default outline structure.
@@ -27,13 +25,9 @@ public class ArithmeticsOutlineTreeProvider extends DefaultOutlineTreeProvider {
   public void _createChildren(final IOutlineNode parentNode, final Module module) {
     EList<EObject> _eContents = module.eContents();
     Iterable<Definition> _filter = Iterables.<Definition>filter(_eContents, Definition.class);
-    final Procedure1<Definition> _function = new Procedure1<Definition>() {
-      @Override
-      public void apply(final Definition it) {
-        ArithmeticsOutlineTreeProvider.this.createNode(parentNode, it);
-      }
-    };
-    IterableExtensions.<Definition>forEach(_filter, _function);
+    for (final Definition it : _filter) {
+      this.createNode(parentNode, it);
+    }
   }
   
   public boolean _isLeaf(final Definition definition) {

--- a/intellij/org.eclipse.xtend.idea.tests/src/org/eclipse/xtend/idea/navigation/IdeaTraceTest.xtend
+++ b/intellij/org.eclipse.xtend.idea.tests/src/org/eclipse/xtend/idea/navigation/IdeaTraceTest.xtend
@@ -120,9 +120,9 @@ class IdeaTraceTest extends LightXtendTest {
 		val generated = jarRoot.findFileByRelativePath("de/itemis/HelloXtend.java")
 		val traceToSource = traceProvider.getTraceToSource(new VirtualFileInProject(generated, project))
 		assertNotNull(traceToSource)
-		traceToSource.allAssociatedLocations.forEach [
+		for (it : traceToSource.allAssociatedLocations) {
 			assertTrue(it.absoluteResourceURI.toString.endsWith("smap-sources.jar!/de/itemis/HelloXtend.xtend"))
-		]
+		}
 	}
 	
 	def void testTraceForJar_02() {

--- a/intellij/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/navigation/IdeaTraceTest.java
+++ b/intellij/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/navigation/IdeaTraceTest.java
@@ -44,8 +44,6 @@ import org.eclipse.xtext.idea.trace.ITraceForVirtualFileProvider;
 import org.eclipse.xtext.idea.trace.VirtualFileInProject;
 import org.eclipse.xtext.util.TextRegion;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Ignore;
 
 /**
@@ -187,16 +185,12 @@ public class IdeaTraceTest extends LightXtendTest {
     final IIdeaTrace traceToSource = this.traceProvider.getTraceToSource(_virtualFileInProject);
     TestCase.assertNotNull(traceToSource);
     Iterable<? extends ILocationInVirtualFile> _allAssociatedLocations = traceToSource.getAllAssociatedLocations();
-    final Procedure1<ILocationInVirtualFile> _function = new Procedure1<ILocationInVirtualFile>() {
-      @Override
-      public void apply(final ILocationInVirtualFile it) {
-        AbsoluteURI _absoluteResourceURI = it.getAbsoluteResourceURI();
-        String _string = _absoluteResourceURI.toString();
-        boolean _endsWith = _string.endsWith("smap-sources.jar!/de/itemis/HelloXtend.xtend");
-        TestCase.assertTrue(_endsWith);
-      }
-    };
-    IterableExtensions.forEach(_allAssociatedLocations, _function);
+    for (final ILocationInVirtualFile it : _allAssociatedLocations) {
+      AbsoluteURI _absoluteResourceURI = it.getAbsoluteResourceURI();
+      String _string = _absoluteResourceURI.toString();
+      boolean _endsWith = _string.endsWith("smap-sources.jar!/de/itemis/HelloXtend.xtend");
+      TestCase.assertTrue(_endsWith);
+    }
   }
   
   public void testTraceForJar_02() {

--- a/intellij/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/config/XtendLibraryConfigurator.xtend
+++ b/intellij/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/config/XtendLibraryConfigurator.xtend
@@ -100,9 +100,9 @@ class XtendLibraryConfigurator {
 			val createdLib = model.createLibrary(libDescr.defaultLibraryName)
 			val libModel = createdLib.modifiableModel
 			xtendLibDescr.libraryRoots.forEach [ type, roots |
-				roots.forEach [
+				for (it : roots) {
 					libModel.addRoot(it, type)
-				]
+				}
 			]
 			libModel.commit
 			model.commit

--- a/intellij/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/framework/XtendLibraryDescription.xtend
+++ b/intellij/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/framework/XtendLibraryDescription.xtend
@@ -48,7 +48,9 @@ class XtendLibraryDescription extends CustomLibraryDescription {
 
 			override addRoots(LibraryEditor editor) {
 				roots.forEach [ k, v |
-					v.forEach[editor.addRoot(it, k)]
+					for (it : v) {
+						editor.addRoot(it, k)
+					}
 				]
 			}
 

--- a/intellij/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/javaconverter/ConvertJavaCodeHandler.xtend
+++ b/intellij/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/javaconverter/ConvertJavaCodeHandler.xtend
@@ -83,7 +83,7 @@ class ConvertJavaCodeHandler implements RefactoringActionHandler {
 
 			override void run(ProgressIndicator indicator) {
 
-				files.forEach [ javaFile |
+				for (javaFile : files) {
 					if (indicator.isCanceled()) {
 						return;
 					}
@@ -97,7 +97,7 @@ class ConvertJavaCodeHandler implements RefactoringActionHandler {
 					coversionResult.put(javaFile, result)
 					done++
 					indicator.fraction = done as double / files.size
-				]
+				}
 			}
 
 			override void onSuccess() {

--- a/intellij/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/config/XtendLibraryConfigurator.java
+++ b/intellij/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/config/XtendLibraryConfigurator.java
@@ -42,7 +42,6 @@ import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.MapExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure2;
 import org.jetbrains.annotations.Nullable;
 
@@ -212,13 +211,9 @@ public class XtendLibraryConfigurator {
       final Procedure2<OrderRootType, List<String>> _function_3 = new Procedure2<OrderRootType, List<String>>() {
         @Override
         public void apply(final OrderRootType type, final List<String> roots) {
-          final Procedure1<String> _function = new Procedure1<String>() {
-            @Override
-            public void apply(final String it) {
-              libModel.addRoot(it, type);
-            }
-          };
-          IterableExtensions.<String>forEach(roots, _function);
+          for (final String it : roots) {
+            libModel.addRoot(it, type);
+          }
         }
       };
       MapExtensions.<OrderRootType, List<String>>forEach(_libraryRoots, _function_3);

--- a/intellij/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/framework/XtendLibraryDescription.java
+++ b/intellij/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/framework/XtendLibraryDescription.java
@@ -36,7 +36,6 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.eclipse.xtext.xbase.lib.MapExtensions;
 import org.eclipse.xtext.xbase.lib.Pair;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure2;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 import org.jetbrains.annotations.NotNull;
@@ -84,13 +83,9 @@ public class XtendLibraryDescription extends CustomLibraryDescription {
         final Procedure2<OrderRootType, List<String>> _function = new Procedure2<OrderRootType, List<String>>() {
           @Override
           public void apply(final OrderRootType k, final List<String> v) {
-            final Procedure1<String> _function = new Procedure1<String>() {
-              @Override
-              public void apply(final String it) {
-                editor.addRoot(it, k);
-              }
-            };
-            IterableExtensions.<String>forEach(v, _function);
+            for (final String it : v) {
+              editor.addRoot(it, k);
+            }
           }
         };
         MapExtensions.<OrderRootType, List<String>>forEach(this.roots, _function);

--- a/intellij/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/javaconverter/ConvertJavaCodeHandler.java
+++ b/intellij/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/javaconverter/ConvertJavaCodeHandler.java
@@ -54,7 +54,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.InputOutput;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -237,9 +236,8 @@ public class ConvertJavaCodeHandler implements RefactoringActionHandler {
       }
       @Override
       public void run(final ProgressIndicator indicator) {
-        final Procedure1<PsiJavaFile> _function = new Procedure1<PsiJavaFile>() {
-          @Override
-          public void apply(final PsiJavaFile javaFile) {
+        for (final PsiJavaFile javaFile : files) {
+          {
             boolean _isCanceled = indicator.isCanceled();
             if (_isCanceled) {
               return;
@@ -260,7 +258,7 @@ public class ConvertJavaCodeHandler implements RefactoringActionHandler {
                   return _function.apply(null);
                 }
             }));
-            Project _project = _this__ConvertJavaCodeHandler_1.getProject();
+            Project _project = this.getProject();
             ProjectRootManager _instance = ProjectRootManager.getInstance(_project);
             ProjectFileIndex _fileIndex = _instance.getFileIndex();
             VirtualFile _virtualFile = javaFile.getVirtualFile();
@@ -272,13 +270,12 @@ public class ConvertJavaCodeHandler implements RefactoringActionHandler {
             String _format = ConvertJavaCodeHandler.this.formatter.format(_xtendCode);
             result.setXtendCode(_format);
             coversionResult.put(javaFile, result);
-            _this__ConvertJavaCodeHandler_1.done++;
+            this.done++;
             int _size = files.size();
-            double _divide = (((double) _this__ConvertJavaCodeHandler_1.done) / _size);
+            double _divide = (((double) this.done) / _size);
             indicator.setFraction(_divide);
           }
-        };
-        IterableExtensions.<PsiJavaFile>forEach(files, _function);
+        }
       }
       
       @Override

--- a/intellij/org.eclipse.xtext.idea.junit/src/org/eclipse/xtext/idea/tests/TestDecorator.xtend
+++ b/intellij/org.eclipse.xtext.idea.junit/src/org/eclipse/xtext/idea/tests/TestDecorator.xtend
@@ -29,17 +29,16 @@ class TestDecoratorProcessor extends AbstractClassProcessor {
 		val atTest = context.findTypeGlobally(Test)
 		val atIgnore = context.findTypeGlobally(Ignore)
 		delegate.markAsRead
-		delegate.type.allResolvedMethods
+		for (declaredMethod: delegate.type.allResolvedMethods
 			.map[declaration]
 			.filter [findAnnotation(atTest) !== null && findAnnotation(atIgnore) === null]
 			.filter[cls.findDeclaredMethod(simpleName) == null]
-			.sortBy[simpleName]
-			.forEach[declaredMethod|
+			.sortBy[simpleName]) {
 				cls.addMethod(declaredMethod.simpleName) [
 					body = '''delegate.«declaredMethod.simpleName»();'''
 					exceptions = declaredMethod.exceptions
 				]
-			]
+		}
 	}
 
 }

--- a/intellij/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/TestDecoratorProcessor.java
+++ b/intellij/org.eclipse.xtext.idea.junit/xtend-gen/org/eclipse/xtext/idea/tests/TestDecoratorProcessor.java
@@ -83,30 +83,26 @@ public class TestDecoratorProcessor extends AbstractClassProcessor {
       }
     };
     List<MethodDeclaration> _sortBy = IterableExtensions.<MethodDeclaration, String>sortBy(_filter_1, _function_3);
-    final Procedure1<MethodDeclaration> _function_4 = new Procedure1<MethodDeclaration>() {
-      @Override
-      public void apply(final MethodDeclaration declaredMethod) {
-        String _simpleName = declaredMethod.getSimpleName();
-        final Procedure1<MutableMethodDeclaration> _function = new Procedure1<MutableMethodDeclaration>() {
-          @Override
-          public void apply(final MutableMethodDeclaration it) {
-            StringConcatenationClient _client = new StringConcatenationClient() {
-              @Override
-              protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-                _builder.append("delegate.");
-                String _simpleName = declaredMethod.getSimpleName();
-                _builder.append(_simpleName, "");
-                _builder.append("();");
-              }
-            };
-            it.setBody(_client);
-            Iterable<? extends TypeReference> _exceptions = declaredMethod.getExceptions();
-            it.setExceptions(((TypeReference[])Conversions.unwrapArray(_exceptions, TypeReference.class)));
-          }
-        };
-        cls.addMethod(_simpleName, _function);
-      }
-    };
-    IterableExtensions.<MethodDeclaration>forEach(_sortBy, _function_4);
+    for (final MethodDeclaration declaredMethod : _sortBy) {
+      String _simpleName = declaredMethod.getSimpleName();
+      final Procedure1<MutableMethodDeclaration> _function_4 = new Procedure1<MutableMethodDeclaration>() {
+        @Override
+        public void apply(final MutableMethodDeclaration it) {
+          StringConcatenationClient _client = new StringConcatenationClient() {
+            @Override
+            protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
+              _builder.append("delegate.");
+              String _simpleName = declaredMethod.getSimpleName();
+              _builder.append(_simpleName, "");
+              _builder.append("();");
+            }
+          };
+          it.setBody(_client);
+          Iterable<? extends TypeReference> _exceptions = declaredMethod.getExceptions();
+          it.setExceptions(((TypeReference[])Conversions.unwrapArray(_exceptions, TypeReference.class)));
+        }
+      };
+      cls.addMethod(_simpleName, _function_4);
+    }
   }
 }

--- a/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/build/XtextAutoBuilderComponent.xtend
+++ b/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/build/XtextAutoBuilderComponent.xtend
@@ -419,7 +419,9 @@ import static extension org.eclipse.xtext.idea.resource.VirtualFileURIUtil.*
 			}
 		} else {
 			alarm.cancelAllRequests
-			cancelIndicators.forEach[canceled = true]
+			for (it : cancelIndicators) {
+				canceled = true
+			}
 			alarm.addRequest([build], 200, ApplicationManager.application.defaultModalityState)
 		}
 	}

--- a/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/completion/AbstractCompletionContributor.xtend
+++ b/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/completion/AbstractCompletionContributor.xtend
@@ -209,7 +209,11 @@ abstract class AbstractCompletionContributor extends CompletionContributor {
 		if (delegate == null)
 			return;
 		val contexts = delegate.create(parameters.text, parameters.selection, parameters.offset, parameters.resource)
-		contexts.forEach[c|c.firstSetGrammarElements.forEach[e|createProposal(e, c, parameters, result)]]
+		for (c : contexts) {
+			for (e : c.firstSetGrammarElements) {
+				createProposal(e, c, parameters, result)
+			}
+		}
 	}
 	
 	protected def supportParserBasedProposals(TokenSet tokenSet) {

--- a/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/EcoreGlobalRegistries.xtend
+++ b/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/extensions/EcoreGlobalRegistries.xtend
@@ -20,24 +20,24 @@ class EcoreGlobalRegistries {
 
 	new() {
 		val packageRegistry = EPackage.Registry.INSTANCE
-		Extensions.getExtensions(EPackageEP.EP_NAME).forEach [
+		for (it : Extensions.getExtensions(EPackageEP.EP_NAME)) {
 			packageRegistry.put(nsURI, createDescriptor)
-		]
+		}
 
 		val extensionToFactoryMap = Resource.Factory.Registry.INSTANCE.extensionToFactoryMap
-		Extensions.getExtensions(ResourceFactoryEP.EP_NAME).forEach [
+		for (it : Extensions.getExtensions(ResourceFactoryEP.EP_NAME)) {
 			extensionToFactoryMap.put(type, createDescriptor)
-		]
+		}
 
 		val registry = IResourceServiceProvider.Registry.INSTANCE
-		Extensions.getExtensions(ResourceServiceProviderEP.EP_NAME).forEach [
+		for (it : Extensions.getExtensions(ResourceServiceProviderEP.EP_NAME)) {
 			if (uriExtension != null)
 				registry.extensionToFactoryMap.put(uriExtension, createDescriptor)
 			if (protocolName != null)
 				registry.protocolToFactoryMap.put(protocolName, createDescriptor)
 			if (contentTypeIdentifier != null)
 				registry.contentTypeToFactoryMap.put(contentTypeIdentifier, createDescriptor)
-		]
+		}
 	}
 
 	static def ensureInitialized() {

--- a/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/DefaultXtextBlock.xtend
+++ b/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/formatting/DefaultXtextBlock.xtend
@@ -110,7 +110,9 @@ class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock {
 		groupBlock.indent = bracePair.getIndent(enforceIndentToChildren)
 
 		groupBlock.parentBlock = children.filter(ModifiableBlock).head.parentBlock
-		children.filter(ModifiableBlock).forEach[child|child.parentBlock = groupBlock]
+		for (child : children.filter(ModifiableBlock)) {
+			child.parentBlock = groupBlock
+		}
 
 		stack.addLast(groupBlock)
 	}

--- a/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/highlighting/SemanticHighlightVisitor.xtend
+++ b/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/highlighting/SemanticHighlightVisitor.xtend
@@ -48,11 +48,11 @@ abstract class SemanticHighlightVisitor implements HighlightVisitor {
 			acceptor = [ offset, length, styles |
 				ProgressIndicatorProvider.checkCanceled
 				if (length > 0) {
-					styles.forEach [
+					for (it : styles) {
 						val info = HighlightInfo.newHighlightInfo(highlightInfoType).range(offset, offset + length).
 							description(it).create
 						holder.add(info)
-					]
+					}
 				}
 			]
 			ProgressIndicatorProvider.checkCanceled

--- a/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/ProjectDescriptionProvider.xtend
+++ b/intellij/org.eclipse.xtext.idea/src/org/eclipse/xtext/idea/resource/ProjectDescriptionProvider.xtend
@@ -24,7 +24,7 @@ class ProjectDescriptionProvider {
 				name = module.name
 				val enumerator = ModuleRootManager.getInstance(module).getOrderEntries;
 				val dependencyNames = newArrayList
-				enumerator.forEach[
+				for (it : enumerator) {
 					switch it {
 						LibraryOrderEntry : {
 							dependencyNames += libraryName
@@ -33,7 +33,7 @@ class ProjectDescriptionProvider {
 							dependencyNames += moduleName
 						}
 					}
-				]
+				}
 				dependencies = dependencyNames
 			]
 		}

--- a/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/build/XtextAutoBuilderComponent.java
+++ b/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/build/XtextAutoBuilderComponent.java
@@ -661,14 +661,10 @@ public class XtextAutoBuilderComponent extends AbstractProjectComponent implemen
       }
     } else {
       this.alarm.cancelAllRequests();
-      final Procedure1<XtextAutoBuilderComponent.MutableCancelIndicator> _function = new Procedure1<XtextAutoBuilderComponent.MutableCancelIndicator>() {
-        @Override
-        public void apply(final XtextAutoBuilderComponent.MutableCancelIndicator it) {
-          it.canceled = true;
-        }
-      };
-      IterableExtensions.<XtextAutoBuilderComponent.MutableCancelIndicator>forEach(this.cancelIndicators, _function);
-      final Runnable _function_1 = new Runnable() {
+      for (final XtextAutoBuilderComponent.MutableCancelIndicator it : this.cancelIndicators) {
+        it.canceled = true;
+      }
+      final Runnable _function = new Runnable() {
         @Override
         public void run() {
           XtextAutoBuilderComponent.this.build();
@@ -676,7 +672,7 @@ public class XtextAutoBuilderComponent extends AbstractProjectComponent implemen
       };
       Application _application = ApplicationManager.getApplication();
       ModalityState _defaultModalityState = _application.getDefaultModalityState();
-      this.alarm.addRequest(_function_1, 200, _defaultModalityState);
+      this.alarm.addRequest(_function, 200, _defaultModalityState);
     }
   }
   

--- a/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/completion/AbstractCompletionContributor.java
+++ b/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/completion/AbstractCompletionContributor.java
@@ -67,9 +67,7 @@ import org.eclipse.xtext.psi.impl.BaseXtextFile;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.util.TextRegion;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -406,20 +404,12 @@ public abstract class AbstractCompletionContributor extends CompletionContributo
     int _offset_1 = parameters.getOffset();
     XtextResource _resource = this.getResource(parameters);
     final ContentAssistContext[] contexts = delegate.create(_text, _selection, _offset_1, _resource);
-    final Procedure1<ContentAssistContext> _function = new Procedure1<ContentAssistContext>() {
-      @Override
-      public void apply(final ContentAssistContext c) {
-        ImmutableList<AbstractElement> _firstSetGrammarElements = c.getFirstSetGrammarElements();
-        final Procedure1<AbstractElement> _function = new Procedure1<AbstractElement>() {
-          @Override
-          public void apply(final AbstractElement e) {
-            AbstractCompletionContributor.this.createProposal(e, c, parameters, result);
-          }
-        };
-        IterableExtensions.<AbstractElement>forEach(_firstSetGrammarElements, _function);
+    for (final ContentAssistContext c : contexts) {
+      ImmutableList<AbstractElement> _firstSetGrammarElements = c.getFirstSetGrammarElements();
+      for (final AbstractElement e : _firstSetGrammarElements) {
+        this.createProposal(e, c, parameters, result);
       }
-    };
-    IterableExtensions.<ContentAssistContext>forEach(((Iterable<ContentAssistContext>)Conversions.doWrapArray(contexts)), _function);
+    }
   }
   
   protected boolean supportParserBasedProposals(final TokenSet tokenSet) {

--- a/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/EcoreGlobalRegistries.java
+++ b/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/extensions/EcoreGlobalRegistries.java
@@ -20,9 +20,6 @@ import org.eclipse.xtext.idea.extensions.ResourceFactoryEP;
 import org.eclipse.xtext.idea.extensions.ResourceServiceProviderDescriptor;
 import org.eclipse.xtext.idea.extensions.ResourceServiceProviderEP;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
-import org.eclipse.xtext.xbase.lib.Conversions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * @author kosyakov - Initial contribution and API
@@ -32,58 +29,48 @@ public class EcoreGlobalRegistries {
   public EcoreGlobalRegistries() {
     final EPackage.Registry packageRegistry = EPackage.Registry.INSTANCE;
     EPackageEP[] _extensions = Extensions.<EPackageEP>getExtensions(EPackageEP.EP_NAME);
-    final Procedure1<EPackageEP> _function = new Procedure1<EPackageEP>() {
-      @Override
-      public void apply(final EPackageEP it) {
-        String _nsURI = it.getNsURI();
-        EPackageEP _createDescriptor = it.createDescriptor();
-        packageRegistry.put(_nsURI, _createDescriptor);
-      }
-    };
-    IterableExtensions.<EPackageEP>forEach(((Iterable<EPackageEP>)Conversions.doWrapArray(_extensions)), _function);
+    for (final EPackageEP it : _extensions) {
+      String _nsURI = it.getNsURI();
+      EPackageEP _createDescriptor = it.createDescriptor();
+      packageRegistry.put(_nsURI, _createDescriptor);
+    }
     final Map<String, Object> extensionToFactoryMap = Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap();
     ResourceFactoryEP[] _extensions_1 = Extensions.<ResourceFactoryEP>getExtensions(ResourceFactoryEP.EP_NAME);
-    final Procedure1<ResourceFactoryEP> _function_1 = new Procedure1<ResourceFactoryEP>() {
-      @Override
-      public void apply(final ResourceFactoryEP it) {
-        String _type = it.getType();
-        ResourceFactoryDescriptor _createDescriptor = it.createDescriptor();
-        extensionToFactoryMap.put(_type, _createDescriptor);
-      }
-    };
-    IterableExtensions.<ResourceFactoryEP>forEach(((Iterable<ResourceFactoryEP>)Conversions.doWrapArray(_extensions_1)), _function_1);
+    for (final ResourceFactoryEP it_1 : _extensions_1) {
+      String _type = it_1.getType();
+      ResourceFactoryDescriptor _createDescriptor_1 = it_1.createDescriptor();
+      extensionToFactoryMap.put(_type, _createDescriptor_1);
+    }
     final IResourceServiceProvider.Registry registry = IResourceServiceProvider.Registry.INSTANCE;
     ResourceServiceProviderEP[] _extensions_2 = Extensions.<ResourceServiceProviderEP>getExtensions(ResourceServiceProviderEP.EP_NAME);
-    final Procedure1<ResourceServiceProviderEP> _function_2 = new Procedure1<ResourceServiceProviderEP>() {
-      @Override
-      public void apply(final ResourceServiceProviderEP it) {
-        String _uriExtension = it.getUriExtension();
+    for (final ResourceServiceProviderEP it_2 : _extensions_2) {
+      {
+        String _uriExtension = it_2.getUriExtension();
         boolean _notEquals = (!Objects.equal(_uriExtension, null));
         if (_notEquals) {
           Map<String, Object> _extensionToFactoryMap = registry.getExtensionToFactoryMap();
-          String _uriExtension_1 = it.getUriExtension();
-          ResourceServiceProviderDescriptor _createDescriptor = it.createDescriptor();
-          _extensionToFactoryMap.put(_uriExtension_1, _createDescriptor);
+          String _uriExtension_1 = it_2.getUriExtension();
+          ResourceServiceProviderDescriptor _createDescriptor_2 = it_2.createDescriptor();
+          _extensionToFactoryMap.put(_uriExtension_1, _createDescriptor_2);
         }
-        String _protocolName = it.getProtocolName();
+        String _protocolName = it_2.getProtocolName();
         boolean _notEquals_1 = (!Objects.equal(_protocolName, null));
         if (_notEquals_1) {
           Map<String, Object> _protocolToFactoryMap = registry.getProtocolToFactoryMap();
-          String _protocolName_1 = it.getProtocolName();
-          ResourceServiceProviderDescriptor _createDescriptor_1 = it.createDescriptor();
-          _protocolToFactoryMap.put(_protocolName_1, _createDescriptor_1);
+          String _protocolName_1 = it_2.getProtocolName();
+          ResourceServiceProviderDescriptor _createDescriptor_3 = it_2.createDescriptor();
+          _protocolToFactoryMap.put(_protocolName_1, _createDescriptor_3);
         }
-        String _contentTypeIdentifier = it.getContentTypeIdentifier();
+        String _contentTypeIdentifier = it_2.getContentTypeIdentifier();
         boolean _notEquals_2 = (!Objects.equal(_contentTypeIdentifier, null));
         if (_notEquals_2) {
           Map<String, Object> _contentTypeToFactoryMap = registry.getContentTypeToFactoryMap();
-          String _contentTypeIdentifier_1 = it.getContentTypeIdentifier();
-          ResourceServiceProviderDescriptor _createDescriptor_2 = it.createDescriptor();
-          _contentTypeToFactoryMap.put(_contentTypeIdentifier_1, _createDescriptor_2);
+          String _contentTypeIdentifier_1 = it_2.getContentTypeIdentifier();
+          ResourceServiceProviderDescriptor _createDescriptor_4 = it_2.createDescriptor();
+          _contentTypeToFactoryMap.put(_contentTypeIdentifier_1, _createDescriptor_4);
         }
       }
-    };
-    IterableExtensions.<ResourceServiceProviderEP>forEach(((Iterable<ResourceServiceProviderEP>)Conversions.doWrapArray(_extensions_2)), _function_2);
+    }
   }
   
   public static EcoreGlobalRegistries ensureInitialized() {

--- a/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/DefaultXtextBlock.java
+++ b/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/formatting/DefaultXtextBlock.java
@@ -41,7 +41,6 @@ import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 
 /**
@@ -187,13 +186,9 @@ public class DefaultXtextBlock extends AbstractBlock implements ModifiableBlock 
     Block _parentBlock = _head.getParentBlock();
     groupBlock.setParentBlock(_parentBlock);
     Iterable<ModifiableBlock> _filter_1 = Iterables.<ModifiableBlock>filter(children, ModifiableBlock.class);
-    final Procedure1<ModifiableBlock> _function = new Procedure1<ModifiableBlock>() {
-      @Override
-      public void apply(final ModifiableBlock child) {
-        child.setParentBlock(groupBlock);
-      }
-    };
-    IterableExtensions.<ModifiableBlock>forEach(_filter_1, _function);
+    for (final ModifiableBlock child : _filter_1) {
+      child.setParentBlock(groupBlock);
+    }
     stack.addLast(groupBlock);
   }
   

--- a/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/highlighting/SemanticHighlightVisitor.java
+++ b/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/highlighting/SemanticHighlightVisitor.java
@@ -31,10 +31,8 @@ import org.eclipse.xtext.psi.impl.BaseXtextFile;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.service.OperationCanceledManager;
-import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
@@ -75,9 +73,8 @@ public abstract class SemanticHighlightVisitor implements HighlightVisitor {
         public void addPosition(final int offset, final int length, final String[] styles) {
           ProgressIndicatorProvider.checkCanceled();
           if ((length > 0)) {
-            final Procedure1<String> _function = new Procedure1<String>() {
-              @Override
-              public void apply(final String it) {
+            for (final String it : styles) {
+              {
                 HighlightInfoType _highlightInfoType = SemanticHighlightVisitor.this._ideaHighlightingAttributesProvider.getHighlightInfoType(it);
                 HighlightInfo.Builder _newHighlightInfo = HighlightInfo.newHighlightInfo(_highlightInfoType);
                 HighlightInfo.Builder _range = _newHighlightInfo.range(offset, (offset + length));
@@ -85,8 +82,7 @@ public abstract class SemanticHighlightVisitor implements HighlightVisitor {
                 final HighlightInfo info = _description.create();
                 holder.add(info);
               }
-            };
-            IterableExtensions.<String>forEach(((Iterable<String>)Conversions.doWrapArray(styles)), _function);
+            }
           }
         }
       };

--- a/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/ProjectDescriptionProvider.java
+++ b/intellij/org.eclipse.xtext.idea/xtend-gen/org/eclipse/xtext/idea/resource/ProjectDescriptionProvider.java
@@ -15,8 +15,6 @@ import com.intellij.openapi.roots.OrderEntry;
 import java.util.ArrayList;
 import org.eclipse.xtext.resource.impl.ProjectDescription;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Conversions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
@@ -36,27 +34,23 @@ public class ProjectDescriptionProvider {
           ModuleRootManager _instance = ModuleRootManager.getInstance(((Module)module));
           final OrderEntry[] enumerator = _instance.getOrderEntries();
           final ArrayList<String> dependencyNames = CollectionLiterals.<String>newArrayList();
-          final Procedure1<OrderEntry> _function = new Procedure1<OrderEntry>() {
-            @Override
-            public void apply(final OrderEntry it) {
-              boolean _matched = false;
-              if (!_matched) {
-                if (it instanceof LibraryOrderEntry) {
-                  _matched=true;
-                  String _libraryName = ((LibraryOrderEntry)it).getLibraryName();
-                  dependencyNames.add(_libraryName);
-                }
-              }
-              if (!_matched) {
-                if (it instanceof ModuleOrderEntry) {
-                  _matched=true;
-                  String _moduleName = ((ModuleOrderEntry)it).getModuleName();
-                  dependencyNames.add(_moduleName);
-                }
+          for (final OrderEntry it_1 : enumerator) {
+            boolean _matched = false;
+            if (!_matched) {
+              if (it_1 instanceof LibraryOrderEntry) {
+                _matched=true;
+                String _libraryName = ((LibraryOrderEntry)it_1).getLibraryName();
+                dependencyNames.add(_libraryName);
               }
             }
-          };
-          IterableExtensions.<OrderEntry>forEach(((Iterable<OrderEntry>)Conversions.doWrapArray(enumerator)), _function);
+            if (!_matched) {
+              if (it_1 instanceof ModuleOrderEntry) {
+                _matched=true;
+                String _moduleName = ((ModuleOrderEntry)it_1).getModuleName();
+                dependencyNames.add(_moduleName);
+              }
+            }
+          }
           it.setDependencies(dependencyNames);
         }
       };

--- a/intellij/org.eclipse.xtext.xtext.idea/src/org/eclipse/xtext/idea/wizard/IdeaProjectCreator.xtend
+++ b/intellij/org.eclipse.xtext.xtext.idea/src/org/eclipse/xtext/idea/wizard/IdeaProjectCreator.xtend
@@ -41,16 +41,16 @@ class IdeaProjectCreator implements ProjectsCreator {
 	}
 
 	override createProjects(WizardConfiguration config) {
-		config.enabledProjects.forEach [
+		for (it : config.enabledProjects) {
 			createProject
-		]
+		}
 	}
 
 	def Module createProject(ProjectDescriptor project) {
 		val projectRoot = VfsUtil.createDirectories(project.location)
 		val fileSystem = LocalFileSystem.getInstance()
 
-		project.files.forEach [
+		for (it : project.files) {
 			val projectRelativePath = project.config.sourceLayout.getPathFor(outlet) + "/" + relativePath
 			val ioFile = new File(new File(projectRoot.path), projectRelativePath)
 			ioFile.parentFile.mkdirs
@@ -65,7 +65,7 @@ class IdeaProjectCreator implements ProjectsCreator {
 				BinaryFile:
 					virtualFile.binaryContent = Resources.toByteArray(content)
 			}
-		]
+		}
 
 		val module = model.newModule(project.moduleFilePath, StdModuleTypes.JAVA.id)
 		val rootModel = ModuleRootManager.getInstance(module).modifiableModel
@@ -75,7 +75,7 @@ class IdeaProjectCreator implements ProjectsCreator {
 		val genFolders = Outlet.generateOutlets.map [
 			project.sourceFolder(it)
 		]
-		project.sourceFolders.forEach [
+		for (it : project.sourceFolders) {
 			val VirtualFile sourceRoot = VfsUtil.createDirectoryIfMissing(modelContentRootDir, it)
 			var rootType = JavaSourceRootType.SOURCE
 			// val testFolders = Outlet.testOutlets.map [
@@ -88,7 +88,7 @@ class IdeaProjectCreator implements ProjectsCreator {
 			val isGen = genFolders.contains(it)
 			val properties = JpsJavaExtensionService.getInstance().createSourceRootProperties("", isGen)
 			contentEntry.addSourceFolder(sourceRoot, rootType, properties)
-		]
+		}
 		// TODO re-enable when xtext.xtext is ready to use
 		// if (project instanceof RuntimeProjectDescriptor) {
 		// val conf = projectConfigrator.createOrGetFacetConf(module, XtextLanguage.INSTANCE.ID)

--- a/intellij/org.eclipse.xtext.xtext.idea/src/org/eclipse/xtext/idea/wizard/XtextWizardStep.xtend
+++ b/intellij/org.eclipse.xtext.xtext.idea/src/org/eclipse/xtext/idea/wizard/XtextWizardStep.xtend
@@ -94,7 +94,9 @@ class XtextWizardStep extends ModuleWizardStep {
 		config.intellijProject.enabled = idea.selected
 		// config.uiProject.enabled = eclipse.selected
 		config.webProject.enabled = web.selected
-		config.enabledProjects.filter(TestedProjectDescriptor).forEach[testProject.enabled = test.selected]
+		for (it : config.enabledProjects.filter(TestedProjectDescriptor)) {
+			testProject.enabled = test.selected
+		}
 
 		config.preferredBuildSystem = buildSystem.selectedItem as BuildSystem
 		config.sourceLayout = layout.selectedItem as SourceLayout

--- a/intellij/org.eclipse.xtext.xtext.idea/xtend-gen/org/eclipse/xtext/idea/wizard/XtextWizardStep.java
+++ b/intellij/org.eclipse.xtext.xtext.idea/xtend-gen/org/eclipse/xtext/idea/wizard/XtextWizardStep.java
@@ -21,8 +21,6 @@ import org.eclipse.xtext.idea.wizard.XtextModuleBuilder;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xtext.wizard.BuildSystem;
 import org.eclipse.xtext.xtext.wizard.IdeProjectDescriptor;
 import org.eclipse.xtext.xtext.wizard.IntellijProjectDescriptor;
@@ -281,15 +279,11 @@ public class XtextWizardStep extends ModuleWizardStep {
     _webProject.setEnabled(_isSelected_3);
     Set<ProjectDescriptor> _enabledProjects = config.getEnabledProjects();
     Iterable<TestedProjectDescriptor> _filter = Iterables.<TestedProjectDescriptor>filter(_enabledProjects, TestedProjectDescriptor.class);
-    final Procedure1<TestedProjectDescriptor> _function = new Procedure1<TestedProjectDescriptor>() {
-      @Override
-      public void apply(final TestedProjectDescriptor it) {
-        TestProjectDescriptor _testProject = it.getTestProject();
-        boolean _isSelected = XtextWizardStep.this.test.isSelected();
-        _testProject.setEnabled(_isSelected);
-      }
-    };
-    IterableExtensions.<TestedProjectDescriptor>forEach(_filter, _function);
+    for (final TestedProjectDescriptor it : _filter) {
+      TestProjectDescriptor _testProject = it.getTestProject();
+      boolean _isSelected_4 = this.test.isSelected();
+      _testProject.setEnabled(_isSelected_4);
+    }
     Object _selectedItem = this.buildSystem.getSelectedItem();
     config.setPreferredBuildSystem(((BuildSystem) _selectedItem));
     Object _selectedItem_1 = this.layout.getSelectedItem();

--- a/plugins/org.eclipse.xtend.core/generator-xtend-gen/org/eclipse/xtend/core/parser/XtendAntlrGrammarGeneratorHelper.java
+++ b/plugins/org.eclipse.xtend.core/generator-xtend-gen/org/eclipse/xtend/core/parser/XtendAntlrGrammarGeneratorHelper.java
@@ -25,8 +25,6 @@ import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.ParserRule;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xtext.generator.grammarAccess.GrammarAccessExtensions;
 import org.eclipse.xtext.xtext.generator.parser.antlr.AntlrGrammarGenUtil;
 import org.eclipse.xtext.xtext.generator.parser.antlr.AntlrOptions;
@@ -92,13 +90,9 @@ public class XtendAntlrGrammarGeneratorHelper {
   
   protected void _collectTokens(final EObject it, final Set<String> tokens) {
     EList<EObject> _eContents = it.eContents();
-    final Procedure1<EObject> _function = new Procedure1<EObject>() {
-      @Override
-      public void apply(final EObject it) {
-        XtendAntlrGrammarGeneratorHelper.this.collectTokens(it, tokens);
-      }
-    };
-    IterableExtensions.<EObject>forEach(_eContents, _function);
+    for (final EObject it_1 : _eContents) {
+      this.collectTokens(it_1, tokens);
+    }
   }
   
   public void collectTokens(final EObject it, final Set<String> tokens) {

--- a/plugins/org.eclipse.xtend.core/generator/org/eclipse/xtend/core/parser/XtendAntlrGrammarGeneratorHelper.xtend
+++ b/plugins/org.eclipse.xtend.core/generator/org/eclipse/xtend/core/parser/XtendAntlrGrammarGeneratorHelper.xtend
@@ -56,9 +56,9 @@ class XtendAntlrGrammarGeneratorHelper {
 	}
 
 	def dispatch void collectTokens(EObject it, Set<String> tokens) {
-		eContents.forEach [
+		for (it : eContents) {
 			collectTokens(tokens)
-		]
+		}
 	}
 
 }

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendGenerator.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendGenerator.xtend
@@ -163,7 +163,7 @@ class XtendGenerator extends JvmModelGenerator implements IGenerator2 {
 	}
 	
 	def compileLocalTypeStubs(JvmFeature feature, ITreeAppendable appendable, GeneratorConfig config) {
-		feature.localClasses.filter[ !anonymous ].forEach[
+		for (it : feature.localClasses.filter[!anonymous]) {
 			appendable.newLine
 			val anonymousClass = sourceElements.head as AnonymousClass
 			val childAppendable = appendable.trace(anonymousClass)
@@ -235,7 +235,7 @@ class XtendGenerator extends JvmModelGenerator implements IGenerator2 {
 				])
 			childAppendable.decreaseIndentation.newLine.append('}')
 			appendable.newLine
-		]
+		}
 	}
 	
 	private def generateJavaConstant(Object value, ITreeAppendable appendable) {

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/findReferences/Declarators.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/findReferences/Declarators.xtend
@@ -38,9 +38,9 @@ class Declarators {
 			return result
 		}
 		val declaratorNames = newHashSet()
-		targetURIs.targetResourceURIs.forEach [ uri |
+		for (uri : targetURIs.targetResourceURIs) {
 			resourceAccess.readOnly(uri) [
-				targetURIs.getEObjectURIs(uri).forEach [ objectURI |
+				for (objectURI : targetURIs.getEObjectURIs(uri)) {
 					val object = getEObject(objectURI, true)
 					if (object != null) {
 						val type = EcoreUtil2.getContainerOfType(object, JvmType)
@@ -49,10 +49,10 @@ class Declarators {
 							declaratorNames += nameConverter.toQualifiedName(type.getQualifiedName('.')).toLowerCase
 						}
 					}	
-				]
+				}
 				null				
 			]
-		]
+		}
 		result = new DeclaratorsData(declaratorNames)
 		targetURIs.putUserData(KEY, result)
 		return result		

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/findReferences/XtendReferenceFinder.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/findReferences/XtendReferenceFinder.xtend
@@ -92,9 +92,9 @@ class XtendReferenceFinder extends ReferenceFinder {
 	}
 	
 	protected def addReferenceToFeatureFromStaticImport(XImportDeclaration importDeclaration, TargetURIs targetURISet, Acceptor acceptor) {
-		importDeclaration.allFeatures.forEach [
+		for (it : importDeclaration.allFeatures) {
 			addReferenceIfTarget(targetURISet, importDeclaration, XIMPORT_DECLARATION__IMPORTED_TYPE, acceptor)
-		] 
+		} 
 	}
 	
 	protected def addReferenceToTypeFromStaticImport(XAbstractFeatureCall sourceCandidate, TargetURIs targetURISet, Acceptor acceptor) {

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/XtendFormatter.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/XtendFormatter.xtend
@@ -249,9 +249,9 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 	 * Always put existing modifiers into this fixed order
 	 */
 	def protected formatModifiers(XtendMember member, extension IFormattableDocument document) {
-		member.regionFor.ruleCallsTo(commonModifierRule, methodModifierRule, fieldModifierRule).forEach [
+		for (it : member.regionFor.ruleCallsTo(commonModifierRule, methodModifierRule, fieldModifierRule)) {
 			append[oneSpace]
-		]
+		}
 	}
 
 	override protected isSingleLineBlock(XBlockExpression expr) {

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/JavaASTFlattener.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/JavaASTFlattener.xtend
@@ -189,11 +189,15 @@ class JavaASTFlattener extends ASTVisitor {
 
 	def appendModifiers(ASTNode node, Iterable<IExtendedModifier> ext, (ASTNode)=>StringBuffer callBack) {
 		val appender = [IExtendedModifier p|(p as ASTNode).accept(this)]
-		ext.filter[isAnnotation && (it as Annotation).typeName.toString != "Override"].forEach(appender)
+		for (it : ext.filter[isAnnotation && (it as Annotation).typeName.toString != "Override"]) {
+			appender.apply(it)
+		}
 		if (callBack != null) {
 			callBack.apply(node)
 		}
-		ext.filter[isModifier && (it as Modifier).keyword.toString != "default"].forEach(appender)
+		for (it : ext.filter[isModifier && (it as Modifier).keyword.toString != "default"]) {
+			appender.apply(it)
+		}
 	}
 
 	def private appendSpaceToBuffer() {
@@ -443,10 +447,10 @@ class JavaASTFlattener extends ASTVisitor {
 		}
 		if (it.root instanceof CompilationUnit) {
 			val cu = it.root as CompilationUnit
-			cu.unAssignedComments.forEach [
+			for (it : cu.unAssignedComments) {
 				accept(this)
 				assignedComments.add(it)
-			]
+			}
 		}
 		decreaseIndent
 		appendLineWrapToBuffer
@@ -525,7 +529,7 @@ class JavaASTFlattener extends ASTVisitor {
 		if (javadoc != null) {
 			javadoc.accept(this)
 		}
-		fragments.forEach [ VariableDeclarationFragment frag |
+		for (frag : fragments.filter(VariableDeclarationFragment)) {
 			appendModifiers(modifiers())
 			if (modifiers().filter(Modifier).isPackageVisibility()) {
 				if (parent instanceof TypeDeclaration) {
@@ -538,7 +542,7 @@ class JavaASTFlattener extends ASTVisitor {
 			appendExtraDimensions(frag.getExtraDimensions())
 			appendSpaceToBuffer
 			frag.accept(this)
-		]
+		}
 		return false
 	}
 
@@ -606,7 +610,7 @@ class JavaASTFlattener extends ASTVisitor {
 
 	override visit(VariableDeclarationStatement it) {
 		val hasAnnotations = !modifiers().filter(Annotation).empty
-		fragments.forEach [ VariableDeclarationFragment frag |
+		for (frag : fragments.filter(VariableDeclarationFragment)) {
 			if (hasAnnotations) {
 				appendToBuffer("/*FIXME Cannot add Annotation to Variable declaration. Java code: ")
 			}
@@ -625,7 +629,7 @@ class JavaASTFlattener extends ASTVisitor {
 			appendSpaceToBuffer
 			frag.accept(this)
 			appendSpaceToBuffer
-		]
+		}
 		return false
 	}
 
@@ -708,7 +712,7 @@ class JavaASTFlattener extends ASTVisitor {
 			name.accept(this)
 		}
 		appendToBuffer("(")
-		parameters.reverseView.forEach [ SingleVariableDeclaration p |
+		for (p : parameters.reverseView.filter(SingleVariableDeclaration)) {
 			if (body.isAssignedInBody(p.name)) {
 				if (isConstructor && !body.statements.empty) {
 					val firstInBody = body.findAssignmentsInBlock(p).head
@@ -730,7 +734,7 @@ class JavaASTFlattener extends ASTVisitor {
 				body.statements.add(0, varDecl)
 
 			}
-		]
+		}
 		parameters.visitAllSeparatedByComma
 		appendToBuffer(")")
 		appendExtraDimensions(getExtraDimensions())
@@ -835,15 +839,13 @@ class JavaASTFlattener extends ASTVisitor {
 		// collect orphaned comments
 		if (node.root instanceof CompilationUnit) {
 			val cu = node.root as CompilationUnit
-			cu.unAssignedComments.filter [
-				startPosition < node.startPosition + node.length
-			].forEach [
+			for (it : cu.unAssignedComments.filter[startPosition < node.startPosition + node.length]) {
 				if (!(it instanceof LineComment)) {
 					appendLineWrapToBuffer
 				}
 				accept(this)
 				assignedComments.add(it)
-			]
+			}
 		}
 		decreaseIndent
 		appendLineWrapToBuffer
@@ -966,9 +968,9 @@ class JavaASTFlattener extends ASTVisitor {
 			node.handleInfixRightSide(operator, node.getRightOperand())
 			val extendedOperands = node.extendedOperands()
 			if (extendedOperands.size() != 0) {
-				extendedOperands.forEach [ Expression e |
+				for (e : extendedOperands.filter(Expression)) {
 					node.handleInfixRightSide(operator, e)
-				]
+				}
 			}
 		}
 		return false
@@ -1342,7 +1344,9 @@ class JavaASTFlattener extends ASTVisitor {
 			node.addProblem("Try with resource is not yet supported.")
 		}
 		node.getBody().accept(this)
-		node.catchClauses.forEach[(it as ASTNode).accept(this)]
+		for (it : node.catchClauses) {
+			(it as ASTNode).accept(this)
+		}
 
 		if (node.getFinally() != null) {
 			appendToBuffer(" finally ")
@@ -1547,10 +1551,10 @@ class JavaASTFlattener extends ASTVisitor {
 			node.genericChildProperty("elementType")?.accept(this)
 			var dimensions = node.genericChildListProperty("dimensions")
 			if (!dimensions.nullOrEmpty) {
-				dimensions.forEach [ dim |
+				for (dim : dimensions) {
 					dim.genericChildListProperty("annotations")?.visitAll
 					appendToBuffer("[]")
-				]
+				}
 			}
 		}
 		return false
@@ -1834,12 +1838,10 @@ class JavaASTFlattener extends ASTVisitor {
 		}
 		if (node.root instanceof CompilationUnit) {
 			val cu = node.root as CompilationUnit
-			cu.unAssignedComments.filter [
-				startPosition < node.startPosition
-			].forEach [
+			for (it : cu.unAssignedComments.filter[startPosition < node.startPosition]) {
 				accept(this)
 				assignedComments.add(it)
-			]
+			}
 		}
 	}
 

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/JavaConverter.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/JavaConverter.xtend
@@ -140,7 +140,9 @@ class JavaConverter {
 		ASTParserWrapper parser) {
 		val javaSrcBuilder = new StringBuilder()
 		if (imports != null) {
-			imports.forEach[javaSrcBuilder.append("import " + it + ";")]
+			for (it : imports) {
+				javaSrcBuilder.append("import " + it + ";")
+			}
 		}
 		if (unitName == null) {
 			parser.unitName = "MISSING"

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ActiveAnnotationContext.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ActiveAnnotationContext.xtend
@@ -164,45 +164,45 @@ class ActiveAnnotationContextProvider {
 	def private void searchAnnotatedElements(EObject element, IAcceptor<Pair<JvmAnnotationType, XAnnotation>> acceptor) {
 		switch element {
 			XtendFile : {
-				element.xtendTypes.forEach [
+				for (it : element.xtendTypes) {
 					searchAnnotatedElements(acceptor)
-				]
+				}
 			}
 			XtendClass : {
 				element.registerMacroAnnotations(acceptor)
-				element.members.forEach [
+				for (it : element.members) {
 					searchAnnotatedElements(acceptor)
-				]
+				}
 			}
 			XtendInterface : {
 				element.registerMacroAnnotations(acceptor)
-				element.members.forEach [
+				for (it : element.members) {
 					searchAnnotatedElements(acceptor)
-				]
+				}
 			}
 			XtendEnum : {
 				element.registerMacroAnnotations(acceptor)
-				element.members.forEach [
+				for (it : element.members) {
 					searchAnnotatedElements(acceptor)
-				]
+				}
 			}
 			XtendAnnotationType : {
 				element.registerMacroAnnotations(acceptor)
-				element.members.forEach [
+				for (it : element.members) {
 					searchAnnotatedElements(acceptor)
-				]
+				}
 			}
 			XtendFunction : {
 				element.registerMacroAnnotations(acceptor)
-				element.parameters.forEach [
+				for (it : element.parameters) {
 					searchAnnotatedElements(acceptor)
-				]
+				}
 			}
 			XtendConstructor : {
 				element.registerMacroAnnotations(acceptor)
-				element.parameters.forEach [
+				for (it : element.parameters) {
 					searchAnnotatedElements(acceptor)
-				]
+				}
 			}
 			XtendAnnotationTarget : {
 				element.registerMacroAnnotations(acceptor)

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ConstantExpressionsInterpreter.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ConstantExpressionsInterpreter.xtend
@@ -254,9 +254,9 @@ class ConstantExpressionsInterpreter extends AbstractConstantExpressionsInterpre
 				JvmArrayType: expectedRawType.componentType as JvmEnumerationType
 			}
 			val copy = new HashMap(ctx.visibleFeatures)
-			enumType.literals.forEach [
-				copy.put(simpleName, it)
-			]
+			for (it : enumType.literals) {
+					copy.put(simpleName, it)
+				}
 			copy
 		} else {
 			ctx.visibleFeatures

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceBuildContextImpl.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceBuildContextImpl.xtend
@@ -366,27 +366,39 @@ class AnnotationReferenceBuildContextImpl implements AnnotationReferenceBuildCon
 	}
 	
 	protected def dispatch void setValue(JvmDoubleAnnotationValue it, float[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as double]
+		for (v : value) {
+			values += v as double
+		}
 	}
 	
 	protected def dispatch void setValue(JvmDoubleAnnotationValue it, long[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as double]
+		for (v : value) {
+			values += v as double
+		}
 	}
 	
 	protected def dispatch void setValue(JvmDoubleAnnotationValue it, int[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as double]
+		for (v : value) {
+			values += v as double
+		}
 	}
 	
 	protected def dispatch void setValue(JvmDoubleAnnotationValue it, short[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as double]
+		for (v : value) {
+			values += v as double
+		}
 	}
 	
 	protected def dispatch void setValue(JvmDoubleAnnotationValue it, byte[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as double]
+		for (v : value) {
+			values += v as double
+		}
 	}
 	
 	protected def dispatch void setValue(JvmDoubleAnnotationValue it, char[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as double]
+		for (v : value) {
+			values += v as double
+		}
 	}
 	
 	protected def dispatch void setValue(JvmFloatAnnotationValue it, float[] value, String componentType, boolean mustBeArray) {
@@ -394,23 +406,33 @@ class AnnotationReferenceBuildContextImpl implements AnnotationReferenceBuildCon
 	}
 	
 	protected def dispatch void setValue(JvmFloatAnnotationValue it, long[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as float]
+		for (v : value) {
+			values += v as float
+		}
 	}
 	
 	protected def dispatch void setValue(JvmFloatAnnotationValue it, int[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as float]
+		for (v : value) {
+			values += v as float
+		}
 	}
 	
 	protected def dispatch void setValue(JvmFloatAnnotationValue it, short[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as float]
+		for (v : value) {
+			values += v as float
+		}
 	}
 	
 	protected def dispatch void setValue(JvmFloatAnnotationValue it, byte[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as float]
+		for (v : value) {
+			values += v as float
+		}
 	}
 	
 	protected def dispatch void setValue(JvmFloatAnnotationValue it, char[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as float]
+		for (v : value) {
+			values += v as float
+		}
 	}
 	
 	protected def dispatch void setValue(JvmLongAnnotationValue it, long[] value, String componentType, boolean mustBeArray) {
@@ -418,19 +440,27 @@ class AnnotationReferenceBuildContextImpl implements AnnotationReferenceBuildCon
 	}
 	
 	protected def dispatch void setValue(JvmLongAnnotationValue it, int[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as long]
+		for (v : value) {
+			values += v as long
+		}
 	}
 	
 	protected def dispatch void setValue(JvmLongAnnotationValue it, short[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as long]
+		for (v : value) {
+			values += v as long
+		}
 	}
 	
 	protected def dispatch void setValue(JvmLongAnnotationValue it, byte[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as long]
+		for (v : value) {
+			values += v as long
+		}
 	}
 	
 	protected def dispatch void setValue(JvmLongAnnotationValue it, char[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as long]
+		for (v : value) {
+			values += v as long
+		}
 	}
 	
 	protected def dispatch void setValue(JvmIntAnnotationValue it, int[] value, String componentType, boolean mustBeArray) {
@@ -438,15 +468,21 @@ class AnnotationReferenceBuildContextImpl implements AnnotationReferenceBuildCon
 	}
 	
 	protected def dispatch void setValue(JvmIntAnnotationValue it, short[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as int]
+		for (v : value) {
+			values += v as int
+		}
 	}
 	
 	protected def dispatch void setValue(JvmIntAnnotationValue it, byte[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as int]
+		for (v : value) {
+			values += v as int
+		}
 	}
 	
 	protected def dispatch void setValue(JvmIntAnnotationValue it, char[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as int]
+		for (v : value) {
+			values += v as int
+		}
 	}
 	
 	protected def dispatch void setValue(JvmShortAnnotationValue it, short[] value, String componentType, boolean mustBeArray) {
@@ -454,7 +490,9 @@ class AnnotationReferenceBuildContextImpl implements AnnotationReferenceBuildCon
 	}
 	
 	protected def dispatch void setValue(JvmShortAnnotationValue it, byte[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as short]
+		for (v : value) {
+			values += v as short
+		}
 	}
 	
 	protected def dispatch void setValue(JvmCharAnnotationValue it, char[] value, String componentType, boolean mustBeArray) {
@@ -462,7 +500,9 @@ class AnnotationReferenceBuildContextImpl implements AnnotationReferenceBuildCon
 	}
 	
 	protected def dispatch void setValue(JvmCharAnnotationValue it, byte[] value, String componentType, boolean mustBeArray) {
-		value.forEach[v | values += v as char]
+		for (v : value) {
+			values += v as char
+		}
 	}
 	
 	protected def dispatch void setValue(JvmByteAnnotationValue it, byte[] value, String componentType, boolean mustBeArray) {

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/ProblemSupportImpl.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/ProblemSupportImpl.xtend
@@ -69,7 +69,9 @@ class ProblemSupportImpl implements ProblemSupport {
 	
 	def validationPhaseStarted() {
 		try {
-			delayedTasks.forEach[apply]
+			for (it : delayedTasks) {
+				apply
+			}
 		} catch (Throwable t) {
 			compilationUnit.handleProcessingError(Collections.singleton(compilationUnit.xtendFile) , compilationUnit.xtendFile.eResource, t)
 		} finally {

--- a/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/resource/XtendResourceDescriptionManager.xtend
+++ b/plugins/org.eclipse.xtend.core/src/org/eclipse/xtend/core/resource/XtendResourceDescriptionManager.xtend
@@ -149,9 +149,9 @@ class XtendResourceDescription extends DefaultResourceDescription {
 				JvmGenericType : {
 					registerAllTypes(type.declaringType, acceptor)
 					registerAllTypes(type?.extendedClass?.type, acceptor)
-					type.extendedInterfaces.forEach[
+					for (it : type.extendedInterfaces) {
 						registerAllTypes(it?.type, acceptor)
-					]
+					}
 				}
 			}
 		}

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/compiler/XtendGenerator.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/compiler/XtendGenerator.java
@@ -293,16 +293,15 @@ public class XtendGenerator extends JvmModelGenerator implements IGenerator2 {
       }
     };
     Iterable<JvmGenericType> _filter = IterableExtensions.<JvmGenericType>filter(_localClasses, _function);
-    final Procedure1<JvmGenericType> _function_1 = new Procedure1<JvmGenericType>() {
-      @Override
-      public void apply(final JvmGenericType it) {
+    for (final JvmGenericType it : _filter) {
+      {
         appendable.newLine();
-        Set<EObject> _sourceElements = XtendGenerator.this.getSourceElements(it);
+        Set<EObject> _sourceElements = this.getSourceElements(it);
         EObject _head = IterableExtensions.<EObject>head(_sourceElements);
         final AnonymousClass anonymousClass = ((AnonymousClass) _head);
         final ITreeAppendable childAppendable = appendable.trace(anonymousClass);
         childAppendable.append("abstract class ");
-        ITreeAppendable _traceSignificant = XtendGenerator.this._treeAppendableUtil.traceSignificant(childAppendable, anonymousClass);
+        ITreeAppendable _traceSignificant = this._treeAppendableUtil.traceSignificant(childAppendable, anonymousClass);
         String _simpleName = it.getSimpleName();
         _traceSignificant.append(_simpleName);
         EList<JvmTypeParameter> _typeParameters = it.getTypeParameters();
@@ -310,10 +309,10 @@ public class XtendGenerator extends JvmModelGenerator implements IGenerator2 {
         if (_isEmpty) {
           childAppendable.append(" ");
         }
-        XtendGenerator.this.generateExtendsClause(it, childAppendable, null);
+        this.generateExtendsClause(it, childAppendable, null);
         ITreeAppendable _append = childAppendable.append("{");
         _append.increaseIndentation();
-        boolean _needSyntheticThisVariable = XtendGenerator.this.needSyntheticThisVariable(anonymousClass, it);
+        boolean _needSyntheticThisVariable = this.needSyntheticThisVariable(anonymousClass, it);
         if (_needSyntheticThisVariable) {
           Pair<String, JvmGenericType> _mappedTo = Pair.<String, JvmGenericType>of("this", it);
           String _simpleName_1 = it.getSimpleName();
@@ -328,8 +327,8 @@ public class XtendGenerator extends JvmModelGenerator implements IGenerator2 {
           ITreeAppendable _append_5 = _append_4.append(" = this;");
           _append_5.newLine();
         }
-        ArrayList<JvmMember> _addedDeclarations = XtendGenerator.this.getAddedDeclarations(it, anonymousClass);
-        final Procedure1<LoopParams> _function = new Procedure1<LoopParams>() {
+        ArrayList<JvmMember> _addedDeclarations = this.getAddedDeclarations(it, anonymousClass);
+        final Procedure1<LoopParams> _function_1 = new Procedure1<LoopParams>() {
           @Override
           public void apply(final LoopParams it) {
             final Function1<ITreeAppendable, ITreeAppendable> _function = new Function1<ITreeAppendable, ITreeAppendable>() {
@@ -341,7 +340,7 @@ public class XtendGenerator extends JvmModelGenerator implements IGenerator2 {
             it.setSeparator(_function);
           }
         };
-        final Procedure1<JvmMember> _function_1 = new Procedure1<JvmMember>() {
+        final Procedure1<JvmMember> _function_2 = new Procedure1<JvmMember>() {
           @Override
           public void apply(final JvmMember it) {
             final ITreeAppendable memberAppendable = XtendGenerator.this._treeAppendableUtil.traceWithComments(childAppendable, it);
@@ -433,14 +432,13 @@ public class XtendGenerator extends JvmModelGenerator implements IGenerator2 {
             memberAppendable.closeScope();
           }
         };
-        XtendGenerator.this._loopExtensions.<JvmMember>forEach(childAppendable, _addedDeclarations, _function, _function_1);
+        this._loopExtensions.<JvmMember>forEach(childAppendable, _addedDeclarations, _function_1, _function_2);
         ITreeAppendable _decreaseIndentation = childAppendable.decreaseIndentation();
         ITreeAppendable _newLine_1 = _decreaseIndentation.newLine();
         _newLine_1.append("}");
         appendable.newLine();
       }
-    };
-    IterableExtensions.<JvmGenericType>forEach(_filter, _function_1);
+    }
   }
   
   private ITreeAppendable generateJavaConstant(final Object value, final ITreeAppendable appendable) {

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/findReferences/Declarators.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/findReferences/Declarators.java
@@ -24,8 +24,6 @@ import org.eclipse.xtext.naming.IQualifiedNameConverter;
 import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -97,46 +95,40 @@ public class Declarators {
     }
     final HashSet<QualifiedName> declaratorNames = CollectionLiterals.<QualifiedName>newHashSet();
     Collection<URI> _targetResourceURIs = targetURIs.getTargetResourceURIs();
-    final Procedure1<URI> _function = new Procedure1<URI>() {
-      @Override
-      public void apply(final URI uri) {
-        final IUnitOfWork<Object, ResourceSet> _function = new IUnitOfWork<Object, ResourceSet>() {
-          @Override
-          public Object exec(final ResourceSet it) throws Exception {
-            Object _xblockexpression = null;
-            {
-              Collection<URI> _eObjectURIs = targetURIs.getEObjectURIs(uri);
-              final Procedure1<URI> _function = new Procedure1<URI>() {
-                @Override
-                public void apply(final URI objectURI) {
-                  final EObject object = it.getEObject(objectURI, true);
-                  boolean _notEquals = (!Objects.equal(object, null));
-                  if (_notEquals) {
-                    final JvmType type = EcoreUtil2.<JvmType>getContainerOfType(object, JvmType.class);
-                    boolean _notEquals_1 = (!Objects.equal(type, null));
-                    if (_notEquals_1) {
-                      String _identifier = type.getIdentifier();
-                      QualifiedName _qualifiedName = Declarators.this.nameConverter.toQualifiedName(_identifier);
-                      QualifiedName _lowerCase = _qualifiedName.toLowerCase();
-                      declaratorNames.add(_lowerCase);
-                      String _qualifiedName_1 = type.getQualifiedName('.');
-                      QualifiedName _qualifiedName_2 = Declarators.this.nameConverter.toQualifiedName(_qualifiedName_1);
-                      QualifiedName _lowerCase_1 = _qualifiedName_2.toLowerCase();
-                      declaratorNames.add(_lowerCase_1);
-                    }
+    for (final URI uri : _targetResourceURIs) {
+      final IUnitOfWork<Object, ResourceSet> _function = new IUnitOfWork<Object, ResourceSet>() {
+        @Override
+        public Object exec(final ResourceSet it) throws Exception {
+          Object _xblockexpression = null;
+          {
+            Collection<URI> _eObjectURIs = targetURIs.getEObjectURIs(uri);
+            for (final URI objectURI : _eObjectURIs) {
+              {
+                final EObject object = it.getEObject(objectURI, true);
+                boolean _notEquals = (!Objects.equal(object, null));
+                if (_notEquals) {
+                  final JvmType type = EcoreUtil2.<JvmType>getContainerOfType(object, JvmType.class);
+                  boolean _notEquals_1 = (!Objects.equal(type, null));
+                  if (_notEquals_1) {
+                    String _identifier = type.getIdentifier();
+                    QualifiedName _qualifiedName = Declarators.this.nameConverter.toQualifiedName(_identifier);
+                    QualifiedName _lowerCase = _qualifiedName.toLowerCase();
+                    declaratorNames.add(_lowerCase);
+                    String _qualifiedName_1 = type.getQualifiedName('.');
+                    QualifiedName _qualifiedName_2 = Declarators.this.nameConverter.toQualifiedName(_qualifiedName_1);
+                    QualifiedName _lowerCase_1 = _qualifiedName_2.toLowerCase();
+                    declaratorNames.add(_lowerCase_1);
                   }
                 }
-              };
-              IterableExtensions.<URI>forEach(_eObjectURIs, _function);
-              _xblockexpression = null;
+              }
             }
-            return _xblockexpression;
+            _xblockexpression = null;
           }
-        };
-        resourceAccess.<Object>readOnly(uri, _function);
-      }
-    };
-    IterableExtensions.<URI>forEach(_targetResourceURIs, _function);
+          return _xblockexpression;
+        }
+      };
+      resourceAccess.<Object>readOnly(uri, _function);
+    }
     Declarators.DeclaratorsData _declaratorsData = new Declarators.DeclaratorsData(declaratorNames);
     result = _declaratorsData;
     targetURIs.<Declarators.DeclaratorsData>putUserData(Declarators.KEY, result);

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/findReferences/XtendReferenceFinder.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/findReferences/XtendReferenceFinder.java
@@ -43,7 +43,6 @@ import org.eclipse.xtext.xbase.imports.StaticallyImportedMemberProvider;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xtype.XImportDeclaration;
 import org.eclipse.xtext.xtype.XtypePackage;
 
@@ -185,13 +184,9 @@ public class XtendReferenceFinder extends ReferenceFinder {
   
   protected void addReferenceToFeatureFromStaticImport(final XImportDeclaration importDeclaration, final TargetURIs targetURISet, final IReferenceFinder.Acceptor acceptor) {
     Iterable<JvmFeature> _allFeatures = this._staticallyImportedMemberProvider.getAllFeatures(importDeclaration);
-    final Procedure1<JvmFeature> _function = new Procedure1<JvmFeature>() {
-      @Override
-      public void apply(final JvmFeature it) {
-        XtendReferenceFinder.this.addReferenceIfTarget(it, targetURISet, importDeclaration, XtypePackage.Literals.XIMPORT_DECLARATION__IMPORTED_TYPE, acceptor);
-      }
-    };
-    IterableExtensions.<JvmFeature>forEach(_allFeatures, _function);
+    for (final JvmFeature it : _allFeatures) {
+      this.addReferenceIfTarget(it, targetURISet, importDeclaration, XtypePackage.Literals.XIMPORT_DECLARATION__IMPORTED_TYPE, acceptor);
+    }
   }
   
   protected void addReferenceToTypeFromStaticImport(final XAbstractFeatureCall sourceCandidate, final TargetURIs targetURISet, final IReferenceFinder.Acceptor acceptor) {

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
@@ -733,19 +733,15 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     ParserRule _methodModifierRule = this._xtendGrammarAccess.getMethodModifierRule();
     ParserRule _fieldModifierRule = this._xtendGrammarAccess.getFieldModifierRule();
     List<ISemanticRegion> _ruleCallsTo = _regionFor.ruleCallsTo(_commonModifierRule, _methodModifierRule, _fieldModifierRule);
-    final Procedure1<ISemanticRegion> _function = new Procedure1<ISemanticRegion>() {
-      @Override
-      public void apply(final ISemanticRegion it) {
-        final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.oneSpace();
-          }
-        };
-        document.append(it, _function);
-      }
-    };
-    IterableExtensions.<ISemanticRegion>forEach(_ruleCallsTo, _function);
+    for (final ISemanticRegion it : _ruleCallsTo) {
+      final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
+        @Override
+        public void apply(final IHiddenRegionFormatter it) {
+          it.oneSpace();
+        }
+      };
+      document.append(it, _function);
+    }
   }
   
   @Override

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/JavaASTFlattener.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/JavaASTFlattener.java
@@ -248,7 +248,9 @@ public class JavaASTFlattener extends ASTVisitor {
       }
     };
     Iterable<IExtendedModifier> _filter = IterableExtensions.<IExtendedModifier>filter(ext, _function_1);
-    IterableExtensions.<IExtendedModifier>forEach(_filter, appender);
+    for (final IExtendedModifier it : _filter) {
+      appender.apply(it);
+    }
     boolean _notEquals = (!Objects.equal(callBack, null));
     if (_notEquals) {
       callBack.apply(node);
@@ -270,7 +272,9 @@ public class JavaASTFlattener extends ASTVisitor {
       }
     };
     Iterable<IExtendedModifier> _filter_1 = IterableExtensions.<IExtendedModifier>filter(ext, _function_2);
-    IterableExtensions.<IExtendedModifier>forEach(_filter_1, appender);
+    for (final IExtendedModifier it_1 : _filter_1) {
+      appender.apply(it_1);
+    }
   }
   
   private StringBuffer appendSpaceToBuffer() {
@@ -729,14 +733,12 @@ public class JavaASTFlattener extends ASTVisitor {
       ASTNode _root_1 = it.getRoot();
       final CompilationUnit cu = ((CompilationUnit) _root_1);
       Iterable<Comment> _unAssignedComments = this.unAssignedComments(cu);
-      final Procedure1<Comment> _function = new Procedure1<Comment>() {
-        @Override
-        public void apply(final Comment it) {
-          it.accept(JavaASTFlattener.this);
-          JavaASTFlattener.this.assignedComments.add(it);
+      for (final Comment it_1 : _unAssignedComments) {
+        {
+          it_1.accept(this);
+          this.assignedComments.add(it_1);
         }
-      };
-      IterableExtensions.<Comment>forEach(_unAssignedComments, _function);
+      }
     }
     this.decreaseIndent();
     this.appendLineWrapToBuffer();
@@ -909,14 +911,14 @@ public class JavaASTFlattener extends ASTVisitor {
       _javadoc_1.accept(this);
     }
     List _fragments = it.fragments();
-    final Procedure1<VariableDeclarationFragment> _function = new Procedure1<VariableDeclarationFragment>() {
-      @Override
-      public void apply(final VariableDeclarationFragment frag) {
+    Iterable<VariableDeclarationFragment> _filter = Iterables.<VariableDeclarationFragment>filter(_fragments, VariableDeclarationFragment.class);
+    for (final VariableDeclarationFragment frag : _filter) {
+      {
         List _modifiers = it.modifiers();
-        JavaASTFlattener.this.appendModifiers(it, _modifiers);
+        this.appendModifiers(it, _modifiers);
         List _modifiers_1 = it.modifiers();
-        Iterable<Modifier> _filter = Iterables.<Modifier>filter(_modifiers_1, Modifier.class);
-        boolean _isPackageVisibility = JavaASTFlattener.this._aSTFlattenerUtils.isPackageVisibility(_filter);
+        Iterable<Modifier> _filter_1 = Iterables.<Modifier>filter(_modifiers_1, Modifier.class);
+        boolean _isPackageVisibility = this._aSTFlattenerUtils.isPackageVisibility(_filter_1);
         if (_isPackageVisibility) {
           ASTNode _parent = it.getParent();
           if ((_parent instanceof TypeDeclaration)) {
@@ -924,19 +926,18 @@ public class JavaASTFlattener extends ASTVisitor {
             boolean _isInterface = ((TypeDeclaration) _parent_1).isInterface();
             boolean _not = (!_isInterface);
             if (_not) {
-              JavaASTFlattener.this.appendToBuffer("package ");
+              this.appendToBuffer("package ");
             }
           }
         }
         Type _type = it.getType();
-        _type.accept(JavaASTFlattener.this);
+        _type.accept(this);
         int _extraDimensions = frag.getExtraDimensions();
-        JavaASTFlattener.this.appendExtraDimensions(_extraDimensions);
-        JavaASTFlattener.this.appendSpaceToBuffer();
-        frag.accept(JavaASTFlattener.this);
+        this.appendExtraDimensions(_extraDimensions);
+        this.appendSpaceToBuffer();
+        frag.accept(this);
       }
-    };
-    IterableExtensions.<VariableDeclarationFragment>forEach(_fragments, _function);
+    }
     return false;
   }
   
@@ -1055,13 +1056,13 @@ public class JavaASTFlattener extends ASTVisitor {
     boolean _isEmpty = IterableExtensions.isEmpty(_filter);
     final boolean hasAnnotations = (!_isEmpty);
     List _fragments = it.fragments();
-    final Procedure1<VariableDeclarationFragment> _function = new Procedure1<VariableDeclarationFragment>() {
-      @Override
-      public void apply(final VariableDeclarationFragment frag) {
+    Iterable<VariableDeclarationFragment> _filter_1 = Iterables.<VariableDeclarationFragment>filter(_fragments, VariableDeclarationFragment.class);
+    for (final VariableDeclarationFragment frag : _filter_1) {
+      {
         if (hasAnnotations) {
-          JavaASTFlattener.this.appendToBuffer("/*FIXME Cannot add Annotation to Variable declaration. Java code: ");
+          this.appendToBuffer("/*FIXME Cannot add Annotation to Variable declaration. Java code: ");
         }
-        List _modifiers = it.modifiers();
+        List _modifiers_1 = it.modifiers();
         final Function1<ASTNode, StringBuffer> _function = new Function1<ASTNode, StringBuffer>() {
           @Override
           public StringBuffer apply(final ASTNode it) {
@@ -1077,26 +1078,25 @@ public class JavaASTFlattener extends ASTVisitor {
             return _xifexpression;
           }
         };
-        JavaASTFlattener.this.appendModifiers(it, _modifiers, _function);
-        List _modifiers_1 = it.modifiers();
-        String _handleVariableDeclaration = JavaASTFlattener.this._aSTFlattenerUtils.handleVariableDeclaration(_modifiers_1);
-        JavaASTFlattener.this.appendToBuffer(_handleVariableDeclaration);
-        JavaASTFlattener.this.appendSpaceToBuffer();
+        this.appendModifiers(it, _modifiers_1, _function);
+        List _modifiers_2 = it.modifiers();
+        String _handleVariableDeclaration = this._aSTFlattenerUtils.handleVariableDeclaration(_modifiers_2);
+        this.appendToBuffer(_handleVariableDeclaration);
+        this.appendSpaceToBuffer();
         Type _type = it.getType();
-        boolean _isMissingType = JavaASTFlattener.this.isMissingType(_type);
+        boolean _isMissingType = this.isMissingType(_type);
         boolean _not = (!_isMissingType);
         if (_not) {
           Type _type_1 = it.getType();
-          _type_1.accept(JavaASTFlattener.this);
+          _type_1.accept(this);
         }
         int _extraDimensions = frag.getExtraDimensions();
-        JavaASTFlattener.this.appendExtraDimensions(_extraDimensions);
-        JavaASTFlattener.this.appendSpaceToBuffer();
-        frag.accept(JavaASTFlattener.this);
-        JavaASTFlattener.this.appendSpaceToBuffer();
+        this.appendExtraDimensions(_extraDimensions);
+        this.appendSpaceToBuffer();
+        frag.accept(this);
+        this.appendSpaceToBuffer();
       }
-    };
-    IterableExtensions.<VariableDeclarationFragment>forEach(_fragments, _function);
+    }
     return false;
   }
   
@@ -1239,73 +1239,70 @@ public class JavaASTFlattener extends ASTVisitor {
     }
     this.appendToBuffer("(");
     List _parameters = it.parameters();
-    List<SingleVariableDeclaration> _reverseView = ListExtensions.<SingleVariableDeclaration>reverseView(_parameters);
-    final Procedure1<SingleVariableDeclaration> _function_1 = new Procedure1<SingleVariableDeclaration>() {
-      @Override
-      public void apply(final SingleVariableDeclaration p) {
-        Block _body = it.getBody();
-        SimpleName _name = p.getName();
-        Boolean _isAssignedInBody = JavaASTFlattener.this._aSTFlattenerUtils.isAssignedInBody(_body, _name);
-        if ((_isAssignedInBody).booleanValue()) {
-          boolean _and = false;
-          boolean _isConstructor = it.isConstructor();
-          if (!_isConstructor) {
-            _and = false;
-          } else {
-            Block _body_1 = it.getBody();
-            List _statements = _body_1.statements();
-            boolean _isEmpty = _statements.isEmpty();
-            boolean _not = (!_isEmpty);
-            _and = _not;
-          }
-          if (_and) {
-            Block _body_2 = it.getBody();
-            Iterable<Expression> _findAssignmentsInBlock = JavaASTFlattener.this._aSTFlattenerUtils.findAssignmentsInBlock(_body_2, p);
-            final Expression firstInBody = IterableExtensions.<Expression>head(_findAssignmentsInBlock);
-            if ((firstInBody != null)) {
-              ConstructorInvocation _findParentOfType = JavaASTFlattener.this._aSTFlattenerUtils.<ConstructorInvocation>findParentOfType(firstInBody, ConstructorInvocation.class);
-              boolean _tripleNotEquals = (_findParentOfType != null);
-              if (_tripleNotEquals) {
-                JavaASTFlattener.this.addProblem(p, "Final parameter modified in constructor call");
-              } else {
-                SuperConstructorInvocation _findParentOfType_1 = JavaASTFlattener.this._aSTFlattenerUtils.<SuperConstructorInvocation>findParentOfType(firstInBody, SuperConstructorInvocation.class);
-                boolean _tripleNotEquals_1 = (_findParentOfType_1 != null);
-                if (_tripleNotEquals_1) {
-                  JavaASTFlattener.this.addProblem(p, "Final parameter modified in super constructor call");
-                }
+    List<Object> _reverseView = ListExtensions.<Object>reverseView(_parameters);
+    Iterable<SingleVariableDeclaration> _filter_1 = Iterables.<SingleVariableDeclaration>filter(_reverseView, SingleVariableDeclaration.class);
+    for (final SingleVariableDeclaration p : _filter_1) {
+      Block _body = it.getBody();
+      SimpleName _name_1 = p.getName();
+      Boolean _isAssignedInBody = this._aSTFlattenerUtils.isAssignedInBody(_body, _name_1);
+      if ((_isAssignedInBody).booleanValue()) {
+        boolean _and = false;
+        boolean _isConstructor_3 = it.isConstructor();
+        if (!_isConstructor_3) {
+          _and = false;
+        } else {
+          Block _body_1 = it.getBody();
+          List _statements = _body_1.statements();
+          boolean _isEmpty_1 = _statements.isEmpty();
+          boolean _not_3 = (!_isEmpty_1);
+          _and = _not_3;
+        }
+        if (_and) {
+          Block _body_2 = it.getBody();
+          Iterable<Expression> _findAssignmentsInBlock = this._aSTFlattenerUtils.findAssignmentsInBlock(_body_2, p);
+          final Expression firstInBody = IterableExtensions.<Expression>head(_findAssignmentsInBlock);
+          if ((firstInBody != null)) {
+            ConstructorInvocation _findParentOfType = this._aSTFlattenerUtils.<ConstructorInvocation>findParentOfType(firstInBody, ConstructorInvocation.class);
+            boolean _tripleNotEquals = (_findParentOfType != null);
+            if (_tripleNotEquals) {
+              this.addProblem(p, "Final parameter modified in constructor call");
+            } else {
+              SuperConstructorInvocation _findParentOfType_1 = this._aSTFlattenerUtils.<SuperConstructorInvocation>findParentOfType(firstInBody, SuperConstructorInvocation.class);
+              boolean _tripleNotEquals_1 = (_findParentOfType_1 != null);
+              if (_tripleNotEquals_1) {
+                this.addProblem(p, "Final parameter modified in super constructor call");
               }
             }
           }
-          AST _aST = p.getAST();
-          final VariableDeclarationFragment varFrag = _aST.newVariableDeclarationFragment();
-          AST _aST_1 = p.getAST();
-          SimpleName _name_1 = p.getName();
-          String _string = _name_1.toString();
-          SimpleName _newSimpleName = _aST_1.newSimpleName(_string);
-          varFrag.setName(_newSimpleName);
-          AST _aST_2 = p.getAST();
-          SimpleName _name_2 = p.getName();
-          String _plus = (_name_2 + "_finalParam_");
-          SimpleName _newSimpleName_1 = _aST_2.newSimpleName(_plus);
-          p.setName(_newSimpleName_1);
-          AST _aST_3 = p.getAST();
-          SimpleName _name_3 = p.getName();
-          String _string_1 = _name_3.toString();
-          SimpleName _newSimpleName_2 = _aST_3.newSimpleName(_string_1);
-          varFrag.setInitializer(_newSimpleName_2);
-          AST _aST_4 = p.getAST();
-          final VariableDeclarationStatement varDecl = _aST_4.newVariableDeclarationStatement(varFrag);
-          AST _aST_5 = p.getAST();
-          ASTNode _createInstance = _aST_5.createInstance(SimpleType.class);
-          final Type typeCopy = ((Type) _createInstance);
-          varDecl.setType(typeCopy);
-          Block _body_3 = it.getBody();
-          List _statements_1 = _body_3.statements();
-          _statements_1.add(0, varDecl);
         }
+        AST _aST = p.getAST();
+        final VariableDeclarationFragment varFrag = _aST.newVariableDeclarationFragment();
+        AST _aST_1 = p.getAST();
+        SimpleName _name_2 = p.getName();
+        String _string = _name_2.toString();
+        SimpleName _newSimpleName = _aST_1.newSimpleName(_string);
+        varFrag.setName(_newSimpleName);
+        AST _aST_2 = p.getAST();
+        SimpleName _name_3 = p.getName();
+        String _plus = (_name_3 + "_finalParam_");
+        SimpleName _newSimpleName_1 = _aST_2.newSimpleName(_plus);
+        p.setName(_newSimpleName_1);
+        AST _aST_3 = p.getAST();
+        SimpleName _name_4 = p.getName();
+        String _string_1 = _name_4.toString();
+        SimpleName _newSimpleName_2 = _aST_3.newSimpleName(_string_1);
+        varFrag.setInitializer(_newSimpleName_2);
+        AST _aST_4 = p.getAST();
+        final VariableDeclarationStatement varDecl = _aST_4.newVariableDeclarationStatement(varFrag);
+        AST _aST_5 = p.getAST();
+        ASTNode _createInstance = _aST_5.createInstance(SimpleType.class);
+        final Type typeCopy = ((Type) _createInstance);
+        varDecl.setType(typeCopy);
+        Block _body_3 = it.getBody();
+        List _statements_1 = _body_3.statements();
+        _statements_1.add(0, varDecl);
       }
-    };
-    IterableExtensions.<SingleVariableDeclaration>forEach(_reverseView, _function_1);
+    }
     List _parameters_1 = it.parameters();
     this.visitAllSeparatedByComma(_parameters_1);
     this.appendToBuffer(")");
@@ -1313,26 +1310,26 @@ public class JavaASTFlattener extends ASTVisitor {
     this.appendExtraDimensions(_extraDimensions);
     List<? extends ASTNode> throwsTypes = CollectionLiterals.<ASTNode>newArrayList();
     boolean _java8orHigher = this.java8orHigher();
-    boolean _not_3 = (!_java8orHigher);
-    if (_not_3) {
+    boolean _not_4 = (!_java8orHigher);
+    if (_not_4) {
       List _thrownExceptions = it.thrownExceptions();
       throwsTypes = _thrownExceptions;
     } else {
       List<ASTNode> _genericChildListProperty = this._aSTFlattenerUtils.genericChildListProperty(it, "thrownExceptionTypes");
       throwsTypes = _genericChildListProperty;
     }
-    boolean _isEmpty_1 = throwsTypes.isEmpty();
-    boolean _not_4 = (!_isEmpty_1);
-    if (_not_4) {
+    boolean _isEmpty_2 = throwsTypes.isEmpty();
+    boolean _not_5 = (!_isEmpty_2);
+    if (_not_5) {
       this.appendToBuffer(" throws ");
       this.visitAllSeparatedByComma(throwsTypes);
     }
     this.appendSpaceToBuffer();
-    Block _body = it.getBody();
-    boolean _notEquals_2 = (!Objects.equal(_body, null));
+    Block _body_4 = it.getBody();
+    boolean _notEquals_2 = (!Objects.equal(_body_4, null));
     if (_notEquals_2) {
-      Block _body_1 = it.getBody();
-      _body_1.accept(this);
+      Block _body_5 = it.getBody();
+      _body_5.accept(this);
     } else {
       this.appendLineWrapToBuffer();
     }
@@ -1507,17 +1504,15 @@ public class JavaASTFlattener extends ASTVisitor {
         }
       };
       Iterable<Comment> _filter = IterableExtensions.<Comment>filter(_unAssignedComments, _function_1);
-      final Procedure1<Comment> _function_2 = new Procedure1<Comment>() {
-        @Override
-        public void apply(final Comment it) {
+      for (final Comment it : _filter) {
+        {
           if ((!(it instanceof LineComment))) {
-            JavaASTFlattener.this.appendLineWrapToBuffer();
+            this.appendLineWrapToBuffer();
           }
-          it.accept(JavaASTFlattener.this);
-          JavaASTFlattener.this.assignedComments.add(it);
+          it.accept(this);
+          this.assignedComments.add(it);
         }
-      };
-      IterableExtensions.<Comment>forEach(_filter, _function_2);
+      }
     }
     this.decreaseIndent();
     this.appendLineWrapToBuffer();
@@ -1705,13 +1700,10 @@ public class JavaASTFlattener extends ASTVisitor {
       int _size = extendedOperands.size();
       boolean _notEquals = (_size != 0);
       if (_notEquals) {
-        final Procedure1<Expression> _function_1 = new Procedure1<Expression>() {
-          @Override
-          public void apply(final Expression e) {
-            JavaASTFlattener.this.handleInfixRightSide(node, operator, e);
-          }
-        };
-        IterableExtensions.<Expression>forEach(extendedOperands, _function_1);
+        Iterable<Expression> _filter = Iterables.<Expression>filter(extendedOperands, Expression.class);
+        for (final Expression e : _filter) {
+          this.handleInfixRightSide(node, operator, e);
+        }
       }
     }
     return false;
@@ -2354,13 +2346,9 @@ public class JavaASTFlattener extends ASTVisitor {
     Block _body = node.getBody();
     _body.accept(this);
     List _catchClauses = node.catchClauses();
-    final Procedure1<Object> _function = new Procedure1<Object>() {
-      @Override
-      public void apply(final Object it) {
-        ((ASTNode) it).accept(JavaASTFlattener.this);
-      }
-    };
-    IterableExtensions.<Object>forEach(_catchClauses, _function);
+    for (final Object it : _catchClauses) {
+      ((ASTNode) it).accept(this);
+    }
     Block _finally = node.getFinally();
     boolean _notEquals = (!Objects.equal(_finally, null));
     if (_notEquals) {
@@ -2703,17 +2691,15 @@ public class JavaASTFlattener extends ASTVisitor {
       boolean _isNullOrEmpty = IterableExtensions.isNullOrEmpty(dimensions);
       boolean _not_1 = (!_isNullOrEmpty);
       if (_not_1) {
-        final Procedure1<ASTNode> _function = new Procedure1<ASTNode>() {
-          @Override
-          public void apply(final ASTNode dim) {
-            List<ASTNode> _genericChildListProperty = JavaASTFlattener.this._aSTFlattenerUtils.genericChildListProperty(dim, "annotations");
+        for (final ASTNode dim : dimensions) {
+          {
+            List<ASTNode> _genericChildListProperty = this._aSTFlattenerUtils.genericChildListProperty(dim, "annotations");
             if (_genericChildListProperty!=null) {
-              JavaASTFlattener.this.visitAll(_genericChildListProperty);
+              this.visitAll(_genericChildListProperty);
             }
-            JavaASTFlattener.this.appendToBuffer("[]");
+            this.appendToBuffer("[]");
           }
-        };
-        IterableExtensions.<ASTNode>forEach(dimensions, _function);
+        }
       }
     }
     return false;
@@ -3187,14 +3173,12 @@ public class JavaASTFlattener extends ASTVisitor {
         }
       };
       Iterable<Comment> _filter = IterableExtensions.<Comment>filter(_unAssignedComments, _function);
-      final Procedure1<Comment> _function_1 = new Procedure1<Comment>() {
-        @Override
-        public void apply(final Comment it) {
-          it.accept(JavaASTFlattener.this);
-          JavaASTFlattener.this.assignedComments.add(it);
+      for (final Comment it : _filter) {
+        {
+          it.accept(this);
+          this.assignedComments.add(it);
         }
-      };
-      IterableExtensions.<Comment>forEach(_filter, _function_1);
+      }
     }
   }
   

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/JavaConverter.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/JavaConverter.java
@@ -25,10 +25,7 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.xbase.annotations.xAnnotations.XAnnotation;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 
 /**
@@ -237,13 +234,9 @@ public class JavaConverter {
     final StringBuilder javaSrcBuilder = new StringBuilder();
     boolean _notEquals = (!Objects.equal(imports, null));
     if (_notEquals) {
-      final Procedure1<String> _function = new Procedure1<String>() {
-        @Override
-        public void apply(final String it) {
-          javaSrcBuilder.append((("import " + it) + ";"));
-        }
-      };
-      IterableExtensions.<String>forEach(((Iterable<String>)Conversions.doWrapArray(imports)), _function);
+      for (final String it : imports) {
+        javaSrcBuilder.append((("import " + it) + ";"));
+      }
     }
     boolean _equals = Objects.equal(unitName, null);
     if (_equals) {

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ActiveAnnotationContextProvider.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ActiveAnnotationContextProvider.java
@@ -48,7 +48,6 @@ import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Pair;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * @author Sven Efftinge
@@ -188,13 +187,9 @@ public class ActiveAnnotationContextProvider {
       if (element instanceof XtendFile) {
         _matched=true;
         EList<XtendTypeDeclaration> _xtendTypes = ((XtendFile)element).getXtendTypes();
-        final Procedure1<XtendTypeDeclaration> _function = new Procedure1<XtendTypeDeclaration>() {
-          @Override
-          public void apply(final XtendTypeDeclaration it) {
-            ActiveAnnotationContextProvider.this.searchAnnotatedElements(it, acceptor);
-          }
-        };
-        IterableExtensions.<XtendTypeDeclaration>forEach(_xtendTypes, _function);
+        for (final XtendTypeDeclaration it : _xtendTypes) {
+          this.searchAnnotatedElements(it, acceptor);
+        }
       }
     }
     if (!_matched) {
@@ -202,13 +197,9 @@ public class ActiveAnnotationContextProvider {
         _matched=true;
         this.registerMacroAnnotations(((XtendAnnotationTarget)element), acceptor);
         EList<XtendMember> _members = ((XtendClass)element).getMembers();
-        final Procedure1<XtendMember> _function = new Procedure1<XtendMember>() {
-          @Override
-          public void apply(final XtendMember it) {
-            ActiveAnnotationContextProvider.this.searchAnnotatedElements(it, acceptor);
-          }
-        };
-        IterableExtensions.<XtendMember>forEach(_members, _function);
+        for (final XtendMember it : _members) {
+          this.searchAnnotatedElements(it, acceptor);
+        }
       }
     }
     if (!_matched) {
@@ -216,13 +207,9 @@ public class ActiveAnnotationContextProvider {
         _matched=true;
         this.registerMacroAnnotations(((XtendAnnotationTarget)element), acceptor);
         EList<XtendMember> _members = ((XtendInterface)element).getMembers();
-        final Procedure1<XtendMember> _function = new Procedure1<XtendMember>() {
-          @Override
-          public void apply(final XtendMember it) {
-            ActiveAnnotationContextProvider.this.searchAnnotatedElements(it, acceptor);
-          }
-        };
-        IterableExtensions.<XtendMember>forEach(_members, _function);
+        for (final XtendMember it : _members) {
+          this.searchAnnotatedElements(it, acceptor);
+        }
       }
     }
     if (!_matched) {
@@ -230,13 +217,9 @@ public class ActiveAnnotationContextProvider {
         _matched=true;
         this.registerMacroAnnotations(((XtendAnnotationTarget)element), acceptor);
         EList<XtendMember> _members = ((XtendEnum)element).getMembers();
-        final Procedure1<XtendMember> _function = new Procedure1<XtendMember>() {
-          @Override
-          public void apply(final XtendMember it) {
-            ActiveAnnotationContextProvider.this.searchAnnotatedElements(it, acceptor);
-          }
-        };
-        IterableExtensions.<XtendMember>forEach(_members, _function);
+        for (final XtendMember it : _members) {
+          this.searchAnnotatedElements(it, acceptor);
+        }
       }
     }
     if (!_matched) {
@@ -244,13 +227,9 @@ public class ActiveAnnotationContextProvider {
         _matched=true;
         this.registerMacroAnnotations(((XtendAnnotationTarget)element), acceptor);
         EList<XtendMember> _members = ((XtendAnnotationType)element).getMembers();
-        final Procedure1<XtendMember> _function = new Procedure1<XtendMember>() {
-          @Override
-          public void apply(final XtendMember it) {
-            ActiveAnnotationContextProvider.this.searchAnnotatedElements(it, acceptor);
-          }
-        };
-        IterableExtensions.<XtendMember>forEach(_members, _function);
+        for (final XtendMember it : _members) {
+          this.searchAnnotatedElements(it, acceptor);
+        }
       }
     }
     if (!_matched) {
@@ -258,13 +237,9 @@ public class ActiveAnnotationContextProvider {
         _matched=true;
         this.registerMacroAnnotations(((XtendAnnotationTarget)element), acceptor);
         EList<XtendParameter> _parameters = ((XtendFunction)element).getParameters();
-        final Procedure1<XtendParameter> _function = new Procedure1<XtendParameter>() {
-          @Override
-          public void apply(final XtendParameter it) {
-            ActiveAnnotationContextProvider.this.searchAnnotatedElements(it, acceptor);
-          }
-        };
-        IterableExtensions.<XtendParameter>forEach(_parameters, _function);
+        for (final XtendParameter it : _parameters) {
+          this.searchAnnotatedElements(it, acceptor);
+        }
       }
     }
     if (!_matched) {
@@ -272,13 +247,9 @@ public class ActiveAnnotationContextProvider {
         _matched=true;
         this.registerMacroAnnotations(((XtendAnnotationTarget)element), acceptor);
         EList<XtendParameter> _parameters = ((XtendConstructor)element).getParameters();
-        final Procedure1<XtendParameter> _function = new Procedure1<XtendParameter>() {
-          @Override
-          public void apply(final XtendParameter it) {
-            ActiveAnnotationContextProvider.this.searchAnnotatedElements(it, acceptor);
-          }
-        };
-        IterableExtensions.<XtendParameter>forEach(_parameters, _function);
+        for (final XtendParameter it : _parameters) {
+          this.searchAnnotatedElements(it, acceptor);
+        }
       }
     }
     if (!_matched) {

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ConstantExpressionsInterpreter.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ConstantExpressionsInterpreter.java
@@ -78,7 +78,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.eclipse.xtext.xbase.lib.Pair;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.typesystem.computation.NumberLiterals;
 import org.eclipse.xtext.xbase.typesystem.util.PendingLinkingCandidateResolver;
 import org.eclipse.xtext.xbase.typesystem.util.TypeLiteralLinkingCandidateResolver;
@@ -528,14 +527,10 @@ public class ConstantExpressionsInterpreter extends AbstractConstantExpressionsI
         Map<String, JvmIdentifiableElement> _visibleFeatures = ctx.getVisibleFeatures();
         final HashMap<String, JvmIdentifiableElement> copy = new HashMap<String, JvmIdentifiableElement>(_visibleFeatures);
         EList<JvmEnumerationLiteral> _literals = enumType.getLiterals();
-        final Procedure1<JvmEnumerationLiteral> _function = new Procedure1<JvmEnumerationLiteral>() {
-          @Override
-          public void apply(final JvmEnumerationLiteral it) {
-            String _simpleName = it.getSimpleName();
-            copy.put(_simpleName, it);
-          }
-        };
-        IterableExtensions.<JvmEnumerationLiteral>forEach(_literals, _function);
+        for (final JvmEnumerationLiteral it_2 : _literals) {
+          String _simpleName = it_2.getSimpleName();
+          copy.put(_simpleName, it_2);
+        }
         _xblockexpression = copy;
       }
       _xifexpression = _xblockexpression;

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceBuildContextImpl.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceBuildContextImpl.java
@@ -62,7 +62,6 @@ import org.eclipse.xtext.xbase.annotations.xAnnotations.XAnnotation;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 
 /**
@@ -659,69 +658,45 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
   }
   
   protected void _setValue(final JvmDoubleAnnotationValue it, final float[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Float> _function = new Procedure1<Float>() {
-      @Override
-      public void apply(final Float v) {
-        EList<Double> _values = it.getValues();
-        _values.add(Double.valueOf(((double) (v).floatValue())));
-      }
-    };
-    IterableExtensions.<Float>forEach(((Iterable<Float>)Conversions.doWrapArray(value)), _function);
+    for (final float v : value) {
+      EList<Double> _values = it.getValues();
+      _values.add(Double.valueOf(((double) v)));
+    }
   }
   
   protected void _setValue(final JvmDoubleAnnotationValue it, final long[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Long> _function = new Procedure1<Long>() {
-      @Override
-      public void apply(final Long v) {
-        EList<Double> _values = it.getValues();
-        _values.add(Double.valueOf(((double) (v).longValue())));
-      }
-    };
-    IterableExtensions.<Long>forEach(((Iterable<Long>)Conversions.doWrapArray(value)), _function);
+    for (final long v : value) {
+      EList<Double> _values = it.getValues();
+      _values.add(Double.valueOf(((double) v)));
+    }
   }
   
   protected void _setValue(final JvmDoubleAnnotationValue it, final int[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Integer> _function = new Procedure1<Integer>() {
-      @Override
-      public void apply(final Integer v) {
-        EList<Double> _values = it.getValues();
-        _values.add(Double.valueOf(((double) (v).intValue())));
-      }
-    };
-    IterableExtensions.<Integer>forEach(((Iterable<Integer>)Conversions.doWrapArray(value)), _function);
+    for (final int v : value) {
+      EList<Double> _values = it.getValues();
+      _values.add(Double.valueOf(((double) v)));
+    }
   }
   
   protected void _setValue(final JvmDoubleAnnotationValue it, final short[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Short> _function = new Procedure1<Short>() {
-      @Override
-      public void apply(final Short v) {
-        EList<Double> _values = it.getValues();
-        _values.add(Double.valueOf(((double) (v).shortValue())));
-      }
-    };
-    IterableExtensions.<Short>forEach(((Iterable<Short>)Conversions.doWrapArray(value)), _function);
+    for (final short v : value) {
+      EList<Double> _values = it.getValues();
+      _values.add(Double.valueOf(((double) v)));
+    }
   }
   
   protected void _setValue(final JvmDoubleAnnotationValue it, final byte[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Byte> _function = new Procedure1<Byte>() {
-      @Override
-      public void apply(final Byte v) {
-        EList<Double> _values = it.getValues();
-        _values.add(Double.valueOf(((double) (v).byteValue())));
-      }
-    };
-    IterableExtensions.<Byte>forEach(((Iterable<Byte>)Conversions.doWrapArray(value)), _function);
+    for (final byte v : value) {
+      EList<Double> _values = it.getValues();
+      _values.add(Double.valueOf(((double) v)));
+    }
   }
   
   protected void _setValue(final JvmDoubleAnnotationValue it, final char[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Character> _function = new Procedure1<Character>() {
-      @Override
-      public void apply(final Character v) {
-        EList<Double> _values = it.getValues();
-        _values.add(Double.valueOf(((double) (v).charValue())));
-      }
-    };
-    IterableExtensions.<Character>forEach(((Iterable<Character>)Conversions.doWrapArray(value)), _function);
+    for (final char v : value) {
+      EList<Double> _values = it.getValues();
+      _values.add(Double.valueOf(((double) v)));
+    }
   }
   
   protected void _setValue(final JvmFloatAnnotationValue it, final float[] value, final String componentType, final boolean mustBeArray) {
@@ -730,58 +705,38 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
   }
   
   protected void _setValue(final JvmFloatAnnotationValue it, final long[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Long> _function = new Procedure1<Long>() {
-      @Override
-      public void apply(final Long v) {
-        EList<Float> _values = it.getValues();
-        _values.add(Float.valueOf(((float) (v).longValue())));
-      }
-    };
-    IterableExtensions.<Long>forEach(((Iterable<Long>)Conversions.doWrapArray(value)), _function);
+    for (final long v : value) {
+      EList<Float> _values = it.getValues();
+      _values.add(Float.valueOf(((float) v)));
+    }
   }
   
   protected void _setValue(final JvmFloatAnnotationValue it, final int[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Integer> _function = new Procedure1<Integer>() {
-      @Override
-      public void apply(final Integer v) {
-        EList<Float> _values = it.getValues();
-        _values.add(Float.valueOf(((float) (v).intValue())));
-      }
-    };
-    IterableExtensions.<Integer>forEach(((Iterable<Integer>)Conversions.doWrapArray(value)), _function);
+    for (final int v : value) {
+      EList<Float> _values = it.getValues();
+      _values.add(Float.valueOf(((float) v)));
+    }
   }
   
   protected void _setValue(final JvmFloatAnnotationValue it, final short[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Short> _function = new Procedure1<Short>() {
-      @Override
-      public void apply(final Short v) {
-        EList<Float> _values = it.getValues();
-        _values.add(Float.valueOf(((float) (v).shortValue())));
-      }
-    };
-    IterableExtensions.<Short>forEach(((Iterable<Short>)Conversions.doWrapArray(value)), _function);
+    for (final short v : value) {
+      EList<Float> _values = it.getValues();
+      _values.add(Float.valueOf(((float) v)));
+    }
   }
   
   protected void _setValue(final JvmFloatAnnotationValue it, final byte[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Byte> _function = new Procedure1<Byte>() {
-      @Override
-      public void apply(final Byte v) {
-        EList<Float> _values = it.getValues();
-        _values.add(Float.valueOf(((float) (v).byteValue())));
-      }
-    };
-    IterableExtensions.<Byte>forEach(((Iterable<Byte>)Conversions.doWrapArray(value)), _function);
+    for (final byte v : value) {
+      EList<Float> _values = it.getValues();
+      _values.add(Float.valueOf(((float) v)));
+    }
   }
   
   protected void _setValue(final JvmFloatAnnotationValue it, final char[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Character> _function = new Procedure1<Character>() {
-      @Override
-      public void apply(final Character v) {
-        EList<Float> _values = it.getValues();
-        _values.add(Float.valueOf(((float) (v).charValue())));
-      }
-    };
-    IterableExtensions.<Character>forEach(((Iterable<Character>)Conversions.doWrapArray(value)), _function);
+    for (final char v : value) {
+      EList<Float> _values = it.getValues();
+      _values.add(Float.valueOf(((float) v)));
+    }
   }
   
   protected void _setValue(final JvmLongAnnotationValue it, final long[] value, final String componentType, final boolean mustBeArray) {
@@ -790,47 +745,31 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
   }
   
   protected void _setValue(final JvmLongAnnotationValue it, final int[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Integer> _function = new Procedure1<Integer>() {
-      @Override
-      public void apply(final Integer v) {
-        EList<Long> _values = it.getValues();
-        _values.add(Long.valueOf(((long) (v).intValue())));
-      }
-    };
-    IterableExtensions.<Integer>forEach(((Iterable<Integer>)Conversions.doWrapArray(value)), _function);
+    for (final int v : value) {
+      EList<Long> _values = it.getValues();
+      _values.add(Long.valueOf(((long) v)));
+    }
   }
   
   protected void _setValue(final JvmLongAnnotationValue it, final short[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Short> _function = new Procedure1<Short>() {
-      @Override
-      public void apply(final Short v) {
-        EList<Long> _values = it.getValues();
-        _values.add(Long.valueOf(((long) (v).shortValue())));
-      }
-    };
-    IterableExtensions.<Short>forEach(((Iterable<Short>)Conversions.doWrapArray(value)), _function);
+    for (final short v : value) {
+      EList<Long> _values = it.getValues();
+      _values.add(Long.valueOf(((long) v)));
+    }
   }
   
   protected void _setValue(final JvmLongAnnotationValue it, final byte[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Byte> _function = new Procedure1<Byte>() {
-      @Override
-      public void apply(final Byte v) {
-        EList<Long> _values = it.getValues();
-        _values.add(Long.valueOf(((long) (v).byteValue())));
-      }
-    };
-    IterableExtensions.<Byte>forEach(((Iterable<Byte>)Conversions.doWrapArray(value)), _function);
+    for (final byte v : value) {
+      EList<Long> _values = it.getValues();
+      _values.add(Long.valueOf(((long) v)));
+    }
   }
   
   protected void _setValue(final JvmLongAnnotationValue it, final char[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Character> _function = new Procedure1<Character>() {
-      @Override
-      public void apply(final Character v) {
-        EList<Long> _values = it.getValues();
-        _values.add(Long.valueOf(((long) (v).charValue())));
-      }
-    };
-    IterableExtensions.<Character>forEach(((Iterable<Character>)Conversions.doWrapArray(value)), _function);
+    for (final char v : value) {
+      EList<Long> _values = it.getValues();
+      _values.add(Long.valueOf(((long) v)));
+    }
   }
   
   protected void _setValue(final JvmIntAnnotationValue it, final int[] value, final String componentType, final boolean mustBeArray) {
@@ -839,36 +778,24 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
   }
   
   protected void _setValue(final JvmIntAnnotationValue it, final short[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Short> _function = new Procedure1<Short>() {
-      @Override
-      public void apply(final Short v) {
-        EList<Integer> _values = it.getValues();
-        _values.add(Integer.valueOf(((int) (v).shortValue())));
-      }
-    };
-    IterableExtensions.<Short>forEach(((Iterable<Short>)Conversions.doWrapArray(value)), _function);
+    for (final short v : value) {
+      EList<Integer> _values = it.getValues();
+      _values.add(Integer.valueOf(((int) v)));
+    }
   }
   
   protected void _setValue(final JvmIntAnnotationValue it, final byte[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Byte> _function = new Procedure1<Byte>() {
-      @Override
-      public void apply(final Byte v) {
-        EList<Integer> _values = it.getValues();
-        _values.add(Integer.valueOf(((int) (v).byteValue())));
-      }
-    };
-    IterableExtensions.<Byte>forEach(((Iterable<Byte>)Conversions.doWrapArray(value)), _function);
+    for (final byte v : value) {
+      EList<Integer> _values = it.getValues();
+      _values.add(Integer.valueOf(((int) v)));
+    }
   }
   
   protected void _setValue(final JvmIntAnnotationValue it, final char[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Character> _function = new Procedure1<Character>() {
-      @Override
-      public void apply(final Character v) {
-        EList<Integer> _values = it.getValues();
-        _values.add(Integer.valueOf(((int) (v).charValue())));
-      }
-    };
-    IterableExtensions.<Character>forEach(((Iterable<Character>)Conversions.doWrapArray(value)), _function);
+    for (final char v : value) {
+      EList<Integer> _values = it.getValues();
+      _values.add(Integer.valueOf(((int) v)));
+    }
   }
   
   protected void _setValue(final JvmShortAnnotationValue it, final short[] value, final String componentType, final boolean mustBeArray) {
@@ -877,14 +804,10 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
   }
   
   protected void _setValue(final JvmShortAnnotationValue it, final byte[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Byte> _function = new Procedure1<Byte>() {
-      @Override
-      public void apply(final Byte v) {
-        EList<Short> _values = it.getValues();
-        _values.add(Short.valueOf(((short) (v).byteValue())));
-      }
-    };
-    IterableExtensions.<Byte>forEach(((Iterable<Byte>)Conversions.doWrapArray(value)), _function);
+    for (final byte v : value) {
+      EList<Short> _values = it.getValues();
+      _values.add(Short.valueOf(((short) v)));
+    }
   }
   
   protected void _setValue(final JvmCharAnnotationValue it, final char[] value, final String componentType, final boolean mustBeArray) {
@@ -893,14 +816,10 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
   }
   
   protected void _setValue(final JvmCharAnnotationValue it, final byte[] value, final String componentType, final boolean mustBeArray) {
-    final Procedure1<Byte> _function = new Procedure1<Byte>() {
-      @Override
-      public void apply(final Byte v) {
-        EList<Character> _values = it.getValues();
-        _values.add(Character.valueOf(((char) (v).byteValue())));
-      }
-    };
-    IterableExtensions.<Byte>forEach(((Iterable<Byte>)Conversions.doWrapArray(value)), _function);
+    for (final byte v : value) {
+      EList<Character> _values = it.getValues();
+      _values.add(Character.valueOf(((char) v)));
+    }
   }
   
   protected void _setValue(final JvmByteAnnotationValue it, final byte[] value, final String componentType, final boolean mustBeArray) {

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/ProblemSupportImpl.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/ProblemSupportImpl.java
@@ -41,7 +41,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure0;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 @SuppressWarnings("all")
 public class ProblemSupportImpl implements ProblemSupport {
@@ -106,13 +105,9 @@ public class ProblemSupportImpl implements ProblemSupport {
   
   public void validationPhaseStarted() {
     try {
-      final Procedure1<Procedure0> _function = new Procedure1<Procedure0>() {
-        @Override
-        public void apply(final Procedure0 it) {
-          it.apply();
-        }
-      };
-      IterableExtensions.<Procedure0>forEach(this.delayedTasks, _function);
+      for (final Procedure0 it : this.delayedTasks) {
+        it.apply();
+      }
     } catch (final Throwable _t) {
       if (_t instanceof Throwable) {
         final Throwable t = (Throwable)_t;

--- a/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/resource/XtendResourceDescription.java
+++ b/plugins/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/resource/XtendResourceDescription.java
@@ -33,7 +33,6 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.IteratorExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.typesystem.IBatchTypeResolver;
 import org.eclipse.xtext.xbase.typesystem.IResolvedTypes;
 import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReference;
@@ -265,17 +264,13 @@ public class XtendResourceDescription extends DefaultResourceDescription {
           }
           this.registerAllTypes(_type, acceptor);
           Iterable<JvmTypeReference> _extendedInterfaces = ((JvmGenericType)type).getExtendedInterfaces();
-          final Procedure1<JvmTypeReference> _function = new Procedure1<JvmTypeReference>() {
-            @Override
-            public void apply(final JvmTypeReference it) {
-              JvmType _type = null;
-              if (it!=null) {
-                _type=it.getType();
-              }
-              XtendResourceDescription.this.registerAllTypes(_type, acceptor);
+          for (final JvmTypeReference it : _extendedInterfaces) {
+            JvmType _type_1 = null;
+            if (it!=null) {
+              _type_1=it.getType();
             }
-          };
-          IterableExtensions.<JvmTypeReference>forEach(_extendedInterfaces, _function);
+            this.registerAllTypes(_type_1, acceptor);
+          }
         }
       }
     }

--- a/plugins/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/outline/AbstractXtendOutlineTreeBuilder.xtend
+++ b/plugins/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/outline/AbstractXtendOutlineTreeBuilder.xtend
@@ -42,7 +42,9 @@ abstract class AbstractXtendOutlineTreeBuilder implements IXtendOutlineTreeBuild
 	}
 
 	def dispatch build(EObject modelElement, IXtendOutlineContext context) {
-		modelElement.eContents.forEach[buildEObjectNode(context)]
+		for (it : modelElement.eContents) {
+			buildEObjectNode(context)
+		}
 	}
 
 	protected def void buildPackageAndImportSection(XtendFile xtendFile, IXtendOutlineContext context) {
@@ -80,7 +82,9 @@ abstract class AbstractXtendOutlineTreeBuilder implements IXtendOutlineTreeBuild
 			val declaredType = superTypeRef.type
 			if (declaredType instanceof JvmDeclaredType) {
 				val nestedTypeContext = superTypeContext.hideInherited
-				declaredType.members.filter(JvmDeclaredType).forEach[buildJvmType(nestedTypeContext)]
+				for (it : declaredType.members.filter(JvmDeclaredType)) {
+					buildJvmType(nestedTypeContext)
+				}
 			}
 		}
 	}
@@ -120,7 +124,9 @@ abstract class AbstractXtendOutlineTreeBuilder implements IXtendOutlineTreeBuild
 				} else if (member instanceof JvmFeature) {
 					if (!member.skipFeature) {
 						val featureContext = baseType.buildFeature(member, member, context)
-						member.localClasses.forEach[buildJvmType(featureContext.newContext)]
+						for (it : member.localClasses) {
+							buildJvmType(featureContext.newContext)
+						}
 					}
 				}
 				member.markAsProcessed

--- a/plugins/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/outline/XtendOutlineJvmTreeBuilder.xtend
+++ b/plugins/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/outline/XtendOutlineJvmTreeBuilder.xtend
@@ -19,7 +19,9 @@ class XtendOutlineJvmTreeBuilder extends AbstractXtendOutlineTreeBuilder {
 
 	def dispatch void build(XtendFile xtendFile, IXtendOutlineContext context) {
 		xtendFile.buildPackageAndImportSection(context)
-		xtendFile.eResource.contents.filter(JvmDeclaredType).forEach[buildType(context)]
+		for (it : xtendFile.eResource.contents.filter(JvmDeclaredType)) {
+			buildType(context)
+		}
 	}
 
 	def dispatch void build(JvmDeclaredType jvmDeclaredType, IXtendOutlineContext context) {

--- a/plugins/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/outline/XtendOutlineSourceTreeBuilder.xtend
+++ b/plugins/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/outline/XtendOutlineSourceTreeBuilder.xtend
@@ -27,7 +27,9 @@ class XtendOutlineSourceTreeBuilder extends AbstractXtendOutlineTreeBuilder impl
 
 	def dispatch void build(XtendFile xtendFile, IXtendOutlineContext context) {
 		xtendFile.buildPackageAndImportSection(context)
-		xtendFile.xtendTypes.forEach[buildXtendType(context)]
+		for (it : xtendFile.xtendTypes) {
+			buildXtendType(context)
+		}
 	}
 
 	def dispatch void build(XtendTypeDeclaration xtendType, IXtendOutlineContext context) {
@@ -49,7 +51,9 @@ class XtendOutlineSourceTreeBuilder extends AbstractXtendOutlineTreeBuilder impl
 			val membersContext = context.newContext
 			xtendType.buildMembers(inferredType, inferredType, membersContext)
 		} else {
-			xtendType.members.forEach[buildEObjectNode(context)]
+			for (it : xtendType.members) {
+				buildEObjectNode(context)
+			}
 		}
 	}
 

--- a/plugins/org.eclipse.xtend.ide.common/xtend-gen/org/eclipse/xtend/ide/common/outline/AbstractXtendOutlineTreeBuilder.java
+++ b/plugins/org.eclipse.xtend.ide.common/xtend-gen/org/eclipse/xtend/ide/common/outline/AbstractXtendOutlineTreeBuilder.java
@@ -34,8 +34,6 @@ import org.eclipse.xtext.common.types.JvmOperation;
 import org.eclipse.xtext.common.types.JvmType;
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypeExtensions;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.typesystem.override.IResolvedConstructor;
 import org.eclipse.xtext.xbase.typesystem.override.IResolvedField;
 import org.eclipse.xtext.xbase.typesystem.override.IResolvedOperation;
@@ -71,13 +69,9 @@ public abstract class AbstractXtendOutlineTreeBuilder implements IXtendOutlineTr
   
   protected void _build(final EObject modelElement, final IXtendOutlineContext context) {
     EList<EObject> _eContents = modelElement.eContents();
-    final Procedure1<EObject> _function = new Procedure1<EObject>() {
-      @Override
-      public void apply(final EObject it) {
-        AbstractXtendOutlineTreeBuilder.this.xtendOutlineNodeBuilder.buildEObjectNode(it, context);
-      }
-    };
-    IterableExtensions.<EObject>forEach(_eContents, _function);
+    for (final EObject it : _eContents) {
+      this.xtendOutlineNodeBuilder.buildEObjectNode(it, context);
+    }
   }
   
   protected void buildPackageAndImportSection(final XtendFile xtendFile, final IXtendOutlineContext context) {
@@ -156,13 +150,9 @@ public abstract class AbstractXtendOutlineTreeBuilder implements IXtendOutlineTr
           final IXtendOutlineContext nestedTypeContext = superTypeContext.hideInherited();
           EList<JvmMember> _members = ((JvmDeclaredType)declaredType).getMembers();
           Iterable<JvmDeclaredType> _filter = Iterables.<JvmDeclaredType>filter(_members, JvmDeclaredType.class);
-          final Procedure1<JvmDeclaredType> _function = new Procedure1<JvmDeclaredType>() {
-            @Override
-            public void apply(final JvmDeclaredType it) {
-              AbstractXtendOutlineTreeBuilder.this.buildJvmType(it, nestedTypeContext);
-            }
-          };
-          IterableExtensions.<JvmDeclaredType>forEach(_filter, _function);
+          for (final JvmDeclaredType it : _filter) {
+            this.buildJvmType(it, nestedTypeContext);
+          }
         }
       }
     }
@@ -221,14 +211,10 @@ public abstract class AbstractXtendOutlineTreeBuilder implements IXtendOutlineTr
             if (_not_1) {
               final IXtendOutlineContext featureContext = this.buildFeature(baseType, ((JvmFeature)member), member, context);
               EList<JvmGenericType> _localClasses = ((JvmFeature)member).getLocalClasses();
-              final Procedure1<JvmGenericType> _function = new Procedure1<JvmGenericType>() {
-                @Override
-                public void apply(final JvmGenericType it) {
-                  IXtendOutlineContext _newContext = featureContext.newContext();
-                  AbstractXtendOutlineTreeBuilder.this.buildJvmType(it, _newContext);
-                }
-              };
-              IterableExtensions.<JvmGenericType>forEach(_localClasses, _function);
+              for (final JvmGenericType it : _localClasses) {
+                IXtendOutlineContext _newContext = featureContext.newContext();
+                this.buildJvmType(it, _newContext);
+              }
             }
           }
         }

--- a/plugins/org.eclipse.xtend.ide.common/xtend-gen/org/eclipse/xtend/ide/common/outline/XtendOutlineJvmTreeBuilder.java
+++ b/plugins/org.eclipse.xtend.ide.common/xtend-gen/org/eclipse/xtend/ide/common/outline/XtendOutlineJvmTreeBuilder.java
@@ -17,8 +17,6 @@ import org.eclipse.xtend.core.xtend.XtendTypeDeclaration;
 import org.eclipse.xtend.ide.common.outline.AbstractXtendOutlineTreeBuilder;
 import org.eclipse.xtend.ide.common.outline.IXtendOutlineContext;
 import org.eclipse.xtext.common.types.JvmDeclaredType;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * @author kosyakov - Initial contribution and API
@@ -30,13 +28,9 @@ public class XtendOutlineJvmTreeBuilder extends AbstractXtendOutlineTreeBuilder 
     Resource _eResource = xtendFile.eResource();
     EList<EObject> _contents = _eResource.getContents();
     Iterable<JvmDeclaredType> _filter = Iterables.<JvmDeclaredType>filter(_contents, JvmDeclaredType.class);
-    final Procedure1<JvmDeclaredType> _function = new Procedure1<JvmDeclaredType>() {
-      @Override
-      public void apply(final JvmDeclaredType it) {
-        XtendOutlineJvmTreeBuilder.this.buildType(it, context);
-      }
-    };
-    IterableExtensions.<JvmDeclaredType>forEach(_filter, _function);
+    for (final JvmDeclaredType it : _filter) {
+      this.buildType(it, context);
+    }
   }
   
   protected void _build(final JvmDeclaredType jvmDeclaredType, final IXtendOutlineContext context) {

--- a/plugins/org.eclipse.xtend.ide.common/xtend-gen/org/eclipse/xtend/ide/common/outline/XtendOutlineSourceTreeBuilder.java
+++ b/plugins/org.eclipse.xtend.ide.common/xtend-gen/org/eclipse/xtend/ide/common/outline/XtendOutlineSourceTreeBuilder.java
@@ -31,7 +31,6 @@ import org.eclipse.xtext.common.types.JvmOperation;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * @author kosyakov - Initial contribution and API
@@ -45,13 +44,9 @@ public class XtendOutlineSourceTreeBuilder extends AbstractXtendOutlineTreeBuild
   protected void _build(final XtendFile xtendFile, final IXtendOutlineContext context) {
     this.buildPackageAndImportSection(xtendFile, context);
     EList<XtendTypeDeclaration> _xtendTypes = xtendFile.getXtendTypes();
-    final Procedure1<XtendTypeDeclaration> _function = new Procedure1<XtendTypeDeclaration>() {
-      @Override
-      public void apply(final XtendTypeDeclaration it) {
-        XtendOutlineSourceTreeBuilder.this.buildXtendType(it, context);
-      }
-    };
-    IterableExtensions.<XtendTypeDeclaration>forEach(_xtendTypes, _function);
+    for (final XtendTypeDeclaration it : _xtendTypes) {
+      this.buildXtendType(it, context);
+    }
   }
   
   protected void _build(final XtendTypeDeclaration xtendType, final IXtendOutlineContext context) {
@@ -73,13 +68,9 @@ public class XtendOutlineSourceTreeBuilder extends AbstractXtendOutlineTreeBuild
       this.buildMembers(xtendType, inferredType, inferredType, membersContext);
     } else {
       EList<XtendMember> _members = xtendType.getMembers();
-      final Procedure1<XtendMember> _function = new Procedure1<XtendMember>() {
-        @Override
-        public void apply(final XtendMember it) {
-          XtendOutlineSourceTreeBuilder.this.xtendOutlineNodeBuilder.buildEObjectNode(it, context);
-        }
-      };
-      IterableExtensions.<XtendMember>forEach(_members, _function);
+      for (final XtendMember it : _members) {
+        this.xtendOutlineNodeBuilder.buildEObjectNode(it, context);
+      }
     }
   }
   

--- a/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.xtend
+++ b/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.xtend
@@ -52,7 +52,9 @@ abstract class AbstractExecutableBuilder extends AbstractCodeBuilder {
 
 	override setContext(EObject ctx) {
 		super.setContext(ctx)
-		parameterBuilders.forEach[context = ctx]
+		for (it : parameterBuilders) {
+			context = ctx
+		}
 	}
 
 	def newParameterBuilder() {

--- a/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/MemberFromSuperImplementor.xtend
+++ b/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/MemberFromSuperImplementor.xtend
@@ -46,11 +46,11 @@ class MemberFromSuperImplementor {
 			overriddenOperation.resolvedTypeParameters.forEach [ typeParam, idx |
 				val newTypeParam = createJvmTypeParameter
 				newTypeParam.name = typeParam.name
-				overriddenOperation.getResolvedTypeParameterConstraints(idx).forEach[
+				for (it : overriddenOperation.getResolvedTypeParameterConstraints(idx)) {
 					val upperBound = createJvmUpperBound
 					upperBound.typeReference = it.toJavaCompliantTypeReference
 					newTypeParam.constraints += upperBound
-				]
+				}
 				typeParameters.add(newTypeParam)
 			]
 			methodBuilder.typeParameters = typeParameters

--- a/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/CodeBuilderQuickfix.xtend
+++ b/plugins/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/CodeBuilderQuickfix.xtend
@@ -94,9 +94,9 @@ class CodeBuilderQuickfix {
 			val importManager = new ImportManager(true, ".".charAt(0))
 			val content = new StringBuilderBasedAppendable(importManager)
 			builder.build(content)
-			importManager.imports.forEach [
+			for (it : importManager.imports) {
 				type.compilationUnit.createImport(it, null, new NullProgressMonitor)
-			]
+			}
 			val element = 
 				switch(builder) {
 					JavaFieldBuilder:  type.createField(content.toString, null, true, new NullProgressMonitor)

--- a/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.java
+++ b/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.java
@@ -91,13 +91,9 @@ public abstract class AbstractExecutableBuilder extends AbstractCodeBuilder {
   @Override
   public void setContext(final EObject ctx) {
     super.setContext(ctx);
-    final Procedure1<AbstractParameterBuilder> _function = new Procedure1<AbstractParameterBuilder>() {
-      @Override
-      public void apply(final AbstractParameterBuilder it) {
-        it.setContext(ctx);
-      }
-    };
-    IterableExtensions.<AbstractParameterBuilder>forEach(this.parameterBuilders, _function);
+    for (final AbstractParameterBuilder it : this.parameterBuilders) {
+      it.setContext(ctx);
+    }
   }
   
   public AbstractParameterBuilder newParameterBuilder() {

--- a/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/MemberFromSuperImplementor.java
+++ b/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/MemberFromSuperImplementor.java
@@ -90,17 +90,15 @@ public class MemberFromSuperImplementor {
           String _name = typeParam.getName();
           newTypeParam.setName(_name);
           List<LightweightTypeReference> _resolvedTypeParameterConstraints = overriddenOperation.getResolvedTypeParameterConstraints((idx).intValue());
-          final Procedure1<LightweightTypeReference> _function = new Procedure1<LightweightTypeReference>() {
-            @Override
-            public void apply(final LightweightTypeReference it) {
+          for (final LightweightTypeReference it : _resolvedTypeParameterConstraints) {
+            {
               final JvmUpperBound upperBound = MemberFromSuperImplementor.this.typesFactory.createJvmUpperBound();
               JvmTypeReference _javaCompliantTypeReference = it.toJavaCompliantTypeReference();
               upperBound.setTypeReference(_javaCompliantTypeReference);
               EList<JvmTypeConstraint> _constraints = newTypeParam.getConstraints();
               _constraints.add(upperBound);
             }
-          };
-          IterableExtensions.<LightweightTypeReference>forEach(_resolvedTypeParameterConstraints, _function);
+          }
           typeParameters.add(newTypeParam);
         }
       };

--- a/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/quickfix/CodeBuilderQuickfix.java
+++ b/plugins/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/quickfix/CodeBuilderQuickfix.java
@@ -37,8 +37,6 @@ import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.xbase.compiler.ImportManager;
 import org.eclipse.xtext.xbase.compiler.StringBuilderBasedAppendable;
-import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.ui.contentassist.ReplacingAppendable;
@@ -167,43 +165,35 @@ public class CodeBuilderQuickfix {
         final StringBuilderBasedAppendable content = new StringBuilderBasedAppendable(importManager);
         builder.build(content);
         List<String> _imports = importManager.getImports();
-        final Procedure1<String> _function = new Procedure1<String>() {
-          @Override
-          public void apply(final String it) {
-            try {
-              ICompilationUnit _compilationUnit = type.getCompilationUnit();
-              NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
-              _compilationUnit.createImport(it, null, _nullProgressMonitor);
-            } catch (Throwable _e) {
-              throw Exceptions.sneakyThrow(_e);
-            }
-          }
-        };
-        IterableExtensions.<String>forEach(_imports, _function);
+        for (final String it_1 : _imports) {
+          ICompilationUnit _compilationUnit = type.getCompilationUnit();
+          NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+          _compilationUnit.createImport(it_1, null, _nullProgressMonitor);
+        }
         Object _switchResult = null;
         boolean _matched = false;
         if (!_matched) {
           if (builder instanceof JavaFieldBuilder) {
             _matched=true;
             String _string = content.toString();
-            NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
-            _switchResult = type.createField(_string, null, true, _nullProgressMonitor);
+            NullProgressMonitor _nullProgressMonitor_1 = new NullProgressMonitor();
+            _switchResult = type.createField(_string, null, true, _nullProgressMonitor_1);
           }
         }
         if (!_matched) {
           if (builder instanceof JavaConstructorBuilder) {
             _matched=true;
             String _string = content.toString();
-            NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
-            _switchResult = type.createMethod(_string, null, true, _nullProgressMonitor);
+            NullProgressMonitor _nullProgressMonitor_1 = new NullProgressMonitor();
+            _switchResult = type.createMethod(_string, null, true, _nullProgressMonitor_1);
           }
         }
         if (!_matched) {
           if (builder instanceof JavaMethodBuilder) {
             _matched=true;
             String _string = content.toString();
-            NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
-            _switchResult = type.createMethod(_string, null, true, _nullProgressMonitor);
+            NullProgressMonitor _nullProgressMonitor_1 = new NullProgressMonitor();
+            _switchResult = type.createMethod(_string, null, true, _nullProgressMonitor_1);
           }
         }
         if (!_matched) {
@@ -213,14 +203,14 @@ public class CodeBuilderQuickfix {
         boolean _notEquals = (!Objects.equal(element, null));
         if (_notEquals) {
           JdtHyperlink _jdtHyperlink = new JdtHyperlink();
-          final Procedure1<JdtHyperlink> _function_1 = new Procedure1<JdtHyperlink>() {
+          final Procedure1<JdtHyperlink> _function = new Procedure1<JdtHyperlink>() {
             @Override
             public void apply(final JdtHyperlink it) {
               it.setJavaElement(((IMember)element));
               it.open();
             }
           };
-          ObjectExtensions.<JdtHyperlink>operator_doubleArrow(_jdtHyperlink, _function_1);
+          ObjectExtensions.<JdtHyperlink>operator_doubleArrow(_jdtHyperlink, _function);
         }
       }
     };

--- a/plugins/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/Data.xtend
+++ b/plugins/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/Data.xtend
@@ -49,9 +49,8 @@ class DataProcessor extends AbstractClassProcessor {
 		extension val toStringUtil = new ToStringProcessor.Util(context)
 		extension val requiredArgsUtil = new FinalFieldsConstructorProcessor.Util(context)
 
-		dataFields.forEach [
+		for (it : dataFields)
 			final = true
-		]
 		if (needsFinalFieldConstructor) {
 			addFinalFieldsConstructor
 		}
@@ -64,12 +63,12 @@ class DataProcessor extends AbstractClassProcessor {
 		if (!hasToString) {
 			addDataToString
 		}
-		dataFields.forEach [
+		for (it : dataFields) {
 			if (shouldAddGetter) {
 				addGetter(Visibility.PUBLIC)
 			}
 			simpleName = "_" + simpleName.toFirstLower
-		]
+		}
 	}
 
 	/**

--- a/plugins/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/Accessors.xtend
+++ b/plugins/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/Accessors.xtend
@@ -84,7 +84,8 @@ enum AccessorType {
 class AccessorsProcessor implements TransformationParticipant<MutableMemberDeclaration> {
 
 	override doTransform(List<? extends MutableMemberDeclaration> elements, extension TransformationContext context) {
-		elements.forEach[transform(context)]
+		for (it : elements)
+			transform(context)
 	}
 
 	def dispatch void transform(MutableFieldDeclaration it, extension TransformationContext context) {
@@ -105,7 +106,8 @@ class AccessorsProcessor implements TransformationParticipant<MutableMemberDecla
 		if (needsFinalFieldConstructor || findAnnotation(FinalFieldsConstructor.findTypeGlobally) !== null) {
 			addFinalFieldsConstructor
 		}
-		declaredFields.filter[!static && thePrimaryGeneratedJavaElement].forEach[_transform(context)]
+		for (it : declaredFields.filter[!static && thePrimaryGeneratedJavaElement])
+			_transform(context)
 	}
 
 	/**

--- a/plugins/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/Data.xtend
+++ b/plugins/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/Data.xtend
@@ -49,12 +49,12 @@ class DataProcessor extends AbstractClassProcessor {
 		extension val toStringUtil = new ToStringProcessor.Util(context)
 		extension val requiredArgsUtil = new FinalFieldsConstructorProcessor.Util(context)
 
-		dataFields.forEach [
-			if ((primarySourceElement as FieldDeclaration).modifiers.contains(Modifier.VAR)){
+		for (it : dataFields) {
+			if ((primarySourceElement as FieldDeclaration).modifiers.contains(Modifier.VAR)) {
 				addError("Cannot use the 'var' keyword on a data field")
 			}
 			final = true
-		]
+		}
 		if (needsFinalFieldConstructor || findAnnotation(FinalFieldsConstructor.findTypeGlobally) !== null) {
 			addFinalFieldsConstructor
 		}
@@ -71,11 +71,11 @@ class DataProcessor extends AbstractClassProcessor {
 				addReflectiveToString(toStringConfig ?: new ToStringConfiguration)
 			}
 		}
-		dataFields.forEach [
+		for (it : dataFields) {
 			if (shouldAddGetter) {
 				addGetter(getterType?.toVisibility ?: Visibility.PUBLIC)
 			}
-		]
+		}
 	}
 
 	/**

--- a/plugins/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/Delegate.xtend
+++ b/plugins/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/Delegate.xtend
@@ -84,11 +84,12 @@ class DelegateProcessor implements TransformationParticipant<MutableMemberDeclar
 
 	override doTransform(List<? extends MutableMemberDeclaration> elements, extension TransformationContext context) {
 		val extension util = new DelegateProcessor.Util(context)
-		elements.forEach [
+		for (it : elements) {
 			if (validDelegate) {
-				methodsToImplement.forEach[method|implementMethod(method)]
+				for (method : methodsToImplement)
+					implementMethod(method)
 			}
-		]
+		}
 	}
 
 	/**
@@ -201,7 +202,8 @@ class DelegateProcessor implements TransformationParticipant<MutableMemberDeclar
 			val cycle = !seen.add(it)
 			if (cycle)
 				return;
-			declaredSuperTypes.forEach[collectAllSuperTypes(seen)]
+			for (it : declaredSuperTypes)
+				collectAllSuperTypes(seen)
 		}
 
 		def getDelegatedInterfaces(MemberDeclaration delegate) {
@@ -239,15 +241,16 @@ class DelegateProcessor implements TransformationParticipant<MutableMemberDeclar
 			delegate.declaringType.addMethod(declaration.simpleName) [ impl |
 				impl.primarySourceElement = delegate.primarySourceElement
 				val typeParameterMappings = newHashMap
-				resolvedMethod.resolvedTypeParameters.forEach[param|
+				for (param : resolvedMethod.resolvedTypeParameters) {
 					val copy = impl.addTypeParameter(param.declaration.simpleName, param.resolvedUpperBounds)
 					typeParameterMappings.put(param.declaration.newTypeReference, copy.newTypeReference)
 					copy.upperBounds = copy.upperBounds.map[replace(typeParameterMappings)]
-				]
+				}
 				impl.exceptions = resolvedMethod.resolvedExceptionTypes.map[replace(typeParameterMappings)]
 				impl.varArgs = declaration.varArgs
 				impl.returnType = resolvedMethod.resolvedReturnType.replace(typeParameterMappings)
-				resolvedMethod.resolvedParameters.forEach[p|impl.addParameter(p.declaration.simpleName, p.resolvedType.replace(typeParameterMappings))]
+				for (p : resolvedMethod.resolvedParameters)
+					impl.addParameter(p.declaration.simpleName, p.resolvedType.replace(typeParameterMappings))
 				impl.body = '''
 					«resolvedMethod.returnIfNeeded»«delegate.delegateAccess(declaration)».«declaration.simpleName»(«declaration.parameters.join(", ")[simpleName]»);
 				'''

--- a/plugins/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/FinalFieldsConstructor.xtend
+++ b/plugins/org.eclipse.xtend.lib/src/org/eclipse/xtend/lib/annotations/FinalFieldsConstructor.xtend
@@ -55,7 +55,8 @@ class FinalFieldsConstructorProcessor implements TransformationParticipant<Mutab
 
 	override doTransform(List<? extends MutableTypeParameterDeclarator> elements,
 		extension TransformationContext context) {
-		elements.forEach[transform(context)]
+		for (it : elements)
+			transform(context)
 	}
 
 	def dispatch void transform(MutableClassDeclaration it, extension TransformationContext context) {
@@ -151,15 +152,15 @@ class FinalFieldsConstructorProcessor implements TransformationParticipant<Mutab
 				addError("Body must be empty")
 			}
 			val superParameters = declaringType.superConstructor?.resolvedParameters ?: #[]
-			superParameters.forEach [ p |
+			for (p : superParameters) {
 				addParameter(p.declaration.simpleName, p.resolvedType)
-			]
+			}
 			val fieldToParameter = newHashMap
-			declaringType.finalFields.forEach [ p |
+			for (p : declaringType.finalFields) {
 				p.markAsInitializedBy(it)
 				val param = addParameter(p.simpleName, p.type.orObject)
 				fieldToParameter.put(p, param)
-			]
+			}
 			body = '''
 				super(«superParameters.join(", ")[declaration.simpleName]»);
 				«FOR arg : declaringType.finalFields»

--- a/plugins/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/DataProcessor.java
+++ b/plugins/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/DataProcessor.java
@@ -129,13 +129,9 @@ public class DataProcessor extends AbstractClassProcessor {
     @Extension
     final FinalFieldsConstructorProcessor.Util requiredArgsUtil = new FinalFieldsConstructorProcessor.Util(context);
     Iterable<? extends MutableFieldDeclaration> _dataFields = util.getDataFields(it);
-    final Procedure1<MutableFieldDeclaration> _function = new Procedure1<MutableFieldDeclaration>() {
-      @Override
-      public void apply(final MutableFieldDeclaration it) {
-        it.setFinal(true);
-      }
-    };
-    IterableExtensions.forEach(_dataFields, _function);
+    for (final MutableFieldDeclaration it_1 : _dataFields) {
+      it_1.setFinal(true);
+    }
     boolean _needsFinalFieldConstructor = requiredArgsUtil.needsFinalFieldConstructor(it);
     if (_needsFinalFieldConstructor) {
       requiredArgsUtil.addFinalFieldsConstructor(it);
@@ -160,19 +156,17 @@ public class DataProcessor extends AbstractClassProcessor {
       util.addDataToString(it);
     }
     Iterable<? extends MutableFieldDeclaration> _dataFields_3 = util.getDataFields(it);
-    final Procedure1<MutableFieldDeclaration> _function_1 = new Procedure1<MutableFieldDeclaration>() {
-      @Override
-      public void apply(final MutableFieldDeclaration it) {
-        boolean _shouldAddGetter = getterUtil.shouldAddGetter(it);
+    for (final MutableFieldDeclaration it_2 : _dataFields_3) {
+      {
+        boolean _shouldAddGetter = getterUtil.shouldAddGetter(it_2);
         if (_shouldAddGetter) {
-          getterUtil.addGetter(it, Visibility.PUBLIC);
+          getterUtil.addGetter(it_2, Visibility.PUBLIC);
         }
-        String _simpleName = it.getSimpleName();
+        String _simpleName = it_2.getSimpleName();
         String _firstLower = StringExtensions.toFirstLower(_simpleName);
         String _plus = ("_" + _firstLower);
-        it.setSimpleName(_plus);
+        it_2.setSimpleName(_plus);
       }
-    };
-    IterableExtensions.forEach(_dataFields_3, _function_1);
+    }
   }
 }

--- a/plugins/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/AccessorsProcessor.java
+++ b/plugins/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/AccessorsProcessor.java
@@ -455,13 +455,9 @@ public class AccessorsProcessor implements TransformationParticipant<MutableMemb
   
   @Override
   public void doTransform(final List<? extends MutableMemberDeclaration> elements, @Extension final TransformationContext context) {
-    final Procedure1<MutableMemberDeclaration> _function = new Procedure1<MutableMemberDeclaration>() {
-      @Override
-      public void apply(final MutableMemberDeclaration it) {
-        AccessorsProcessor.this.transform(it, context);
-      }
-    };
-    IterableExtensions.forEach(elements, _function);
+    for (final MutableMemberDeclaration it : elements) {
+      this.transform(it, context);
+    }
   }
   
   protected void _transform(final MutableFieldDeclaration it, @Extension final TransformationContext context) {
@@ -520,13 +516,9 @@ public class AccessorsProcessor implements TransformationParticipant<MutableMemb
       }
     };
     Iterable<? extends MutableFieldDeclaration> _filter = IterableExtensions.filter(_declaredFields, _function);
-    final Procedure1<MutableFieldDeclaration> _function_1 = new Procedure1<MutableFieldDeclaration>() {
-      @Override
-      public void apply(final MutableFieldDeclaration it) {
-        AccessorsProcessor.this._transform(it, context);
-      }
-    };
-    IterableExtensions.forEach(_filter, _function_1);
+    for (final MutableFieldDeclaration it_1 : _filter) {
+      this._transform(it_1, context);
+    }
   }
   
   public void transform(final MutableMemberDeclaration it, final TransformationContext context) {

--- a/plugins/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/DataProcessor.java
+++ b/plugins/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/DataProcessor.java
@@ -23,7 +23,6 @@ import org.eclipse.xtend.lib.macro.declaration.Visibility;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * @since 2.7
@@ -89,19 +88,17 @@ public class DataProcessor extends AbstractClassProcessor {
     @Extension
     final FinalFieldsConstructorProcessor.Util requiredArgsUtil = new FinalFieldsConstructorProcessor.Util(context);
     Iterable<? extends MutableFieldDeclaration> _dataFields = util.getDataFields(it);
-    final Procedure1<MutableFieldDeclaration> _function = new Procedure1<MutableFieldDeclaration>() {
-      @Override
-      public void apply(final MutableFieldDeclaration it) {
-        Element _primarySourceElement = context.getPrimarySourceElement(it);
+    for (final MutableFieldDeclaration it_1 : _dataFields) {
+      {
+        Element _primarySourceElement = context.getPrimarySourceElement(it_1);
         Set<Modifier> _modifiers = ((FieldDeclaration) _primarySourceElement).getModifiers();
         boolean _contains = _modifiers.contains(Modifier.VAR);
         if (_contains) {
-          context.addError(it, "Cannot use the \'var\' keyword on a data field");
+          context.addError(it_1, "Cannot use the \'var\' keyword on a data field");
         }
-        it.setFinal(true);
+        it_1.setFinal(true);
       }
-    };
-    IterableExtensions.forEach(_dataFields, _function);
+    }
     boolean _or = false;
     boolean _needsFinalFieldConstructor = requiredArgsUtil.needsFinalFieldConstructor(it);
     if (_needsFinalFieldConstructor) {
@@ -158,26 +155,22 @@ public class DataProcessor extends AbstractClassProcessor {
       }
     }
     Iterable<? extends MutableFieldDeclaration> _dataFields_4 = util.getDataFields(it);
-    final Procedure1<MutableFieldDeclaration> _function_1 = new Procedure1<MutableFieldDeclaration>() {
-      @Override
-      public void apply(final MutableFieldDeclaration it) {
-        boolean _shouldAddGetter = getterUtil.shouldAddGetter(it);
-        if (_shouldAddGetter) {
-          Visibility _elvis = null;
-          AccessorType _getterType = getterUtil.getGetterType(it);
-          Visibility _visibility = null;
-          if (_getterType!=null) {
-            _visibility=getterUtil.toVisibility(_getterType);
-          }
-          if (_visibility != null) {
-            _elvis = _visibility;
-          } else {
-            _elvis = Visibility.PUBLIC;
-          }
-          getterUtil.addGetter(it, _elvis);
+    for (final MutableFieldDeclaration it_2 : _dataFields_4) {
+      boolean _shouldAddGetter = getterUtil.shouldAddGetter(it_2);
+      if (_shouldAddGetter) {
+        Visibility _elvis_2 = null;
+        AccessorType _getterType = getterUtil.getGetterType(it_2);
+        Visibility _visibility = null;
+        if (_getterType!=null) {
+          _visibility=getterUtil.toVisibility(_getterType);
         }
+        if (_visibility != null) {
+          _elvis_2 = _visibility;
+        } else {
+          _elvis_2 = Visibility.PUBLIC;
+        }
+        getterUtil.addGetter(it_2, _elvis_2);
       }
-    };
-    IterableExtensions.forEach(_dataFields_4, _function_1);
+    }
   }
 }

--- a/plugins/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/DelegateProcessor.java
+++ b/plugins/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/DelegateProcessor.java
@@ -362,13 +362,9 @@ public class DelegateProcessor implements TransformationParticipant<MutableMembe
         return;
       }
       Iterable<? extends TypeReference> _declaredSuperTypes = it.getDeclaredSuperTypes();
-      final Procedure1<TypeReference> _function = new Procedure1<TypeReference>() {
-        @Override
-        public void apply(final TypeReference it) {
-          Util.this.collectAllSuperTypes(it, seen);
-        }
-      };
-      IterableExtensions.forEach(_declaredSuperTypes, _function);
+      for (final TypeReference it_1 : _declaredSuperTypes) {
+        this.collectAllSuperTypes(it_1, seen);
+      }
     }
     
     public Set<TypeReference> getDelegatedInterfaces(final MemberDeclaration delegate) {
@@ -566,9 +562,8 @@ public class DelegateProcessor implements TransformationParticipant<MutableMembe
             Util.this.context.setPrimarySourceElement(impl, _primarySourceElement);
             final HashMap<TypeReference, TypeReference> typeParameterMappings = CollectionLiterals.<TypeReference, TypeReference>newHashMap();
             Iterable<? extends ResolvedTypeParameter> _resolvedTypeParameters = resolvedMethod.getResolvedTypeParameters();
-            final Procedure1<ResolvedTypeParameter> _function = new Procedure1<ResolvedTypeParameter>() {
-              @Override
-              public void apply(final ResolvedTypeParameter param) {
+            for (final ResolvedTypeParameter param : _resolvedTypeParameters) {
+              {
                 TypeParameterDeclaration _declaration = param.getDeclaration();
                 String _simpleName = _declaration.getSimpleName();
                 Iterable<? extends TypeReference> _resolvedUpperBounds = param.getResolvedUpperBounds();
@@ -587,16 +582,15 @@ public class DelegateProcessor implements TransformationParticipant<MutableMembe
                 Iterable<TypeReference> _map = IterableExtensions.map(_upperBounds, _function);
                 copy.setUpperBounds(_map);
               }
-            };
-            IterableExtensions.forEach(_resolvedTypeParameters, _function);
+            }
             Iterable<? extends TypeReference> _resolvedExceptionTypes = resolvedMethod.getResolvedExceptionTypes();
-            final Function1<TypeReference, TypeReference> _function_1 = new Function1<TypeReference, TypeReference>() {
+            final Function1<TypeReference, TypeReference> _function = new Function1<TypeReference, TypeReference>() {
               @Override
               public TypeReference apply(final TypeReference it) {
                 return Util.this.replace(it, typeParameterMappings);
               }
             };
-            Iterable<TypeReference> _map = IterableExtensions.map(_resolvedExceptionTypes, _function_1);
+            Iterable<TypeReference> _map = IterableExtensions.map(_resolvedExceptionTypes, _function);
             impl.setExceptions(((TypeReference[])Conversions.unwrapArray(_map, TypeReference.class)));
             boolean _isVarArgs = declaration.isVarArgs();
             impl.setVarArgs(_isVarArgs);
@@ -604,17 +598,13 @@ public class DelegateProcessor implements TransformationParticipant<MutableMembe
             TypeReference _replace = Util.this.replace(_resolvedReturnType, typeParameterMappings);
             impl.setReturnType(_replace);
             Iterable<? extends ResolvedParameter> _resolvedParameters = resolvedMethod.getResolvedParameters();
-            final Procedure1<ResolvedParameter> _function_2 = new Procedure1<ResolvedParameter>() {
-              @Override
-              public void apply(final ResolvedParameter p) {
-                ParameterDeclaration _declaration = p.getDeclaration();
-                String _simpleName = _declaration.getSimpleName();
-                TypeReference _resolvedType = p.getResolvedType();
-                TypeReference _replace = Util.this.replace(_resolvedType, typeParameterMappings);
-                impl.addParameter(_simpleName, _replace);
-              }
-            };
-            IterableExtensions.forEach(_resolvedParameters, _function_2);
+            for (final ResolvedParameter p : _resolvedParameters) {
+              ParameterDeclaration _declaration = p.getDeclaration();
+              String _simpleName = _declaration.getSimpleName();
+              TypeReference _resolvedType = p.getResolvedType();
+              TypeReference _replace_1 = Util.this.replace(_resolvedType, typeParameterMappings);
+              impl.addParameter(_simpleName, _replace_1);
+            }
             StringConcatenationClient _client = new StringConcatenationClient() {
               @Override
               protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
@@ -854,22 +844,14 @@ public class DelegateProcessor implements TransformationParticipant<MutableMembe
   public void doTransform(final List<? extends MutableMemberDeclaration> elements, @Extension final TransformationContext context) {
     @Extension
     final DelegateProcessor.Util util = new DelegateProcessor.Util(context);
-    final Procedure1<MutableMemberDeclaration> _function = new Procedure1<MutableMemberDeclaration>() {
-      @Override
-      public void apply(final MutableMemberDeclaration it) {
-        boolean _isValidDelegate = util.isValidDelegate(it);
-        if (_isValidDelegate) {
-          Set<ResolvedMethod> _methodsToImplement = util.getMethodsToImplement(it);
-          final Procedure1<ResolvedMethod> _function = new Procedure1<ResolvedMethod>() {
-            @Override
-            public void apply(final ResolvedMethod method) {
-              util.implementMethod(it, method);
-            }
-          };
-          IterableExtensions.<ResolvedMethod>forEach(_methodsToImplement, _function);
+    for (final MutableMemberDeclaration it : elements) {
+      boolean _isValidDelegate = util.isValidDelegate(it);
+      if (_isValidDelegate) {
+        Set<ResolvedMethod> _methodsToImplement = util.getMethodsToImplement(it);
+        for (final ResolvedMethod method : _methodsToImplement) {
+          util.implementMethod(it, method);
         }
       }
-    };
-    IterableExtensions.forEach(elements, _function);
+    }
   }
 }

--- a/plugins/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/FinalFieldsConstructorProcessor.java
+++ b/plugins/org.eclipse.xtend.lib/xtend-gen/org/eclipse/xtend/lib/annotations/FinalFieldsConstructorProcessor.java
@@ -266,31 +266,25 @@ public class FinalFieldsConstructorProcessor implements TransformationParticipan
         _elvis = Collections.<ResolvedParameter>unmodifiableList(CollectionLiterals.<ResolvedParameter>newArrayList());
       }
       final Iterable<? extends ResolvedParameter> superParameters = _elvis;
-      final Procedure1<ResolvedParameter> _function = new Procedure1<ResolvedParameter>() {
-        @Override
-        public void apply(final ResolvedParameter p) {
-          ParameterDeclaration _declaration = p.getDeclaration();
-          String _simpleName = _declaration.getSimpleName();
-          TypeReference _resolvedType = p.getResolvedType();
-          it.addParameter(_simpleName, _resolvedType);
-        }
-      };
-      IterableExtensions.forEach(superParameters, _function);
+      for (final ResolvedParameter p : superParameters) {
+        ParameterDeclaration _declaration = p.getDeclaration();
+        String _simpleName = _declaration.getSimpleName();
+        TypeReference _resolvedType = p.getResolvedType();
+        it.addParameter(_simpleName, _resolvedType);
+      }
       final HashMap<MutableFieldDeclaration, MutableParameterDeclaration> fieldToParameter = CollectionLiterals.<MutableFieldDeclaration, MutableParameterDeclaration>newHashMap();
       MutableTypeDeclaration _declaringType_4 = it.getDeclaringType();
       Iterable<? extends MutableFieldDeclaration> _finalFields = this.getFinalFields(_declaringType_4);
-      final Procedure1<MutableFieldDeclaration> _function_1 = new Procedure1<MutableFieldDeclaration>() {
-        @Override
-        public void apply(final MutableFieldDeclaration p) {
-          p.markAsInitializedBy(it);
-          String _simpleName = p.getSimpleName();
-          TypeReference _type = p.getType();
-          TypeReference _orObject = Util.this.orObject(_type);
-          final MutableParameterDeclaration param = it.addParameter(_simpleName, _orObject);
-          fieldToParameter.put(p, param);
+      for (final MutableFieldDeclaration p_1 : _finalFields) {
+        {
+          p_1.markAsInitializedBy(it);
+          String _simpleName_1 = p_1.getSimpleName();
+          TypeReference _type = p_1.getType();
+          TypeReference _orObject = this.orObject(_type);
+          final MutableParameterDeclaration param = it.addParameter(_simpleName_1, _orObject);
+          fieldToParameter.put(p_1, param);
         }
-      };
-      IterableExtensions.forEach(_finalFields, _function_1);
+      }
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
         protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
@@ -363,13 +357,9 @@ public class FinalFieldsConstructorProcessor implements TransformationParticipan
   
   @Override
   public void doTransform(final List<? extends MutableTypeParameterDeclarator> elements, @Extension final TransformationContext context) {
-    final Procedure1<MutableTypeParameterDeclarator> _function = new Procedure1<MutableTypeParameterDeclarator>() {
-      @Override
-      public void apply(final MutableTypeParameterDeclarator it) {
-        FinalFieldsConstructorProcessor.this.transform(it, context);
-      }
-    };
-    IterableExtensions.forEach(elements, _function);
+    for (final MutableTypeParameterDeclarator it : elements) {
+      this.transform(it, context);
+    }
   }
   
   protected void _transform(final MutableClassDeclaration it, @Extension final TransformationContext context) {

--- a/plugins/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/StandaloneBuilder.xtend
+++ b/plugins/org.eclipse.xtext.builder.standalone/src/org/eclipse/xtext/builder/standalone/StandaloneBuilder.xtend
@@ -238,9 +238,8 @@ class StandaloneBuilder {
 			encodingProvider.setDefaultEncoding(encoding)
 		commonFileAccess.setOutputPath(IFileSystemAccess.DEFAULT_OUTPUT, stubsDir.absolutePath)
 		val generateStubs = sourceResourceURIs.filter[languageAccess.linksAgainstJava]
-		generateStubs.forEach [
+		for (it : generateStubs)
 			languageAccess.stubGenerator.doGenerateStubs(commonFileAccess, data.getResourceDescription(it))
-		]
 		return stubsDir
 	}
 

--- a/plugins/org.eclipse.xtext.builder.standalone/xtend-gen/org/eclipse/xtext/builder/standalone/StandaloneBuilder.java
+++ b/plugins/org.eclipse.xtext.builder.standalone/xtend-gen/org/eclipse/xtext/builder/standalone/StandaloneBuilder.java
@@ -419,16 +419,12 @@ public class StandaloneBuilder {
       }
     };
     final Iterable<URI> generateStubs = IterableExtensions.<URI>filter(sourceResourceURIs, _function);
-    final Procedure1<URI> _function_1 = new Procedure1<URI>() {
-      @Override
-      public void apply(final URI it) {
-        LanguageAccess _languageAccess = StandaloneBuilder.this.languageAccess(it);
-        IStubGenerator _stubGenerator = _languageAccess.getStubGenerator();
-        IResourceDescription _resourceDescription = data.getResourceDescription(it);
-        _stubGenerator.doGenerateStubs(StandaloneBuilder.this.commonFileAccess, _resourceDescription);
-      }
-    };
-    IterableExtensions.<URI>forEach(generateStubs, _function_1);
+    for (final URI it : generateStubs) {
+      LanguageAccess _languageAccess = this.languageAccess(it);
+      IStubGenerator _stubGenerator = _languageAccess.getStubGenerator();
+      IResourceDescription _resourceDescription = data.getResourceDescription(it);
+      _stubGenerator.doGenerateStubs(this.commonFileAccess, _resourceDescription);
+    }
     return stubsDir;
   }
   

--- a/plugins/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.xtend
+++ b/plugins/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.xtend
@@ -163,10 +163,10 @@ class JavaBuilderState {
 			return new TypeNames(project) => [addTypeName(primaryTypeFqn, primaryTypeFqn)]
 		}
 		
-		typeNames.forEach [
-			val typeName =  getQualifedTypeName(packageName, new String(it))
+		for (it : typeNames) {
+			val typeName = getQualifedTypeName(packageName, new String(it))
 			qualifiedTypeNames.addTypeName(typeName, primaryTypeFqn)
-		]
+		}
 		qualifiedTypeNames
 	}
 

--- a/plugins/org.eclipse.xtext.common.types.ui/xtend-gen/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.java
+++ b/plugins/org.eclipse.xtext.common.types.ui/xtend-gen/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.java
@@ -31,9 +31,7 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.common.types.ui.notification.TypeNames;
 import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
@@ -276,15 +274,13 @@ public class JavaBuilderState {
         };
         return ObjectExtensions.<TypeNames>operator_doubleArrow(_typeNames, _function);
       }
-      final Procedure1<char[]> _function_1 = new Procedure1<char[]>() {
-        @Override
-        public void apply(final char[] it) {
+      for (final char[] it : typeNames) {
+        {
           String _string = new String(it);
-          final String typeName = JavaBuilderState.this.getQualifedTypeName(packageName, _string);
+          final String typeName = this.getQualifedTypeName(packageName, _string);
           qualifiedTypeNames.addTypeName(typeName, primaryTypeFqn);
         }
-      };
-      IterableExtensions.<char[]>forEach(((Iterable<char[]>)Conversions.doWrapArray(typeNames)), _function_1);
+      }
       _xblockexpression = qualifiedTypeNames;
     }
     return _xblockexpression;

--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/XtextAntlrGeneratorComparisonFragment.xtend
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/parser/antlr/XtextAntlrGeneratorComparisonFragment.xtend
@@ -234,9 +234,8 @@ class XtextAntlrGeneratorComparisonFragment extends FragmentAdapter {
 		
 		val context = createExecutionContext() as XpandExecutionContextImpl;
 		
-		advices.forEach[
+		for (it : advices)
 			context.registerAdvices(it);
-		];
 
 		val combined = grammar.isCombinedGrammar		
 		val helper = if (!combined) new AntlrFragmentHelperEx(naming, productionNaming, contentAssistNaming)

--- a/plugins/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/parser/antlr/XtextAntlrGeneratorComparisonFragment.java
+++ b/plugins/org.eclipse.xtext.generator/xtend-gen/org/eclipse/xtext/generator/parser/antlr/XtextAntlrGeneratorComparisonFragment.java
@@ -41,8 +41,6 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.FlattenedGrammarAccess;
 import org.eclipse.xtext.xtext.RuleFilter;
@@ -440,13 +438,9 @@ public class XtextAntlrGeneratorComparisonFragment extends FragmentAdapter {
     final Grammar flattened = _flattenedGrammarAccess.getFlattenedGrammar();
     XpandExecutionContext _createExecutionContext = this.createExecutionContext();
     final XpandExecutionContextImpl context = ((XpandExecutionContextImpl) _createExecutionContext);
-    final Procedure1<String> _function = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
-        context.registerAdvices(it);
-      }
-    };
-    IterableExtensions.<String>forEach(this.advices, _function);
+    for (final String it : this.advices) {
+      context.registerAdvices(it);
+    }
     Grammar _grammar_1 = this.getGrammar();
     final boolean combined = this.productionNaming.isCombinedGrammar(_grammar_1);
     XtextAntlrGeneratorComparisonFragment.AntlrFragmentHelperEx _xifexpression = null;

--- a/plugins/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaResourceDescriptionManager.xtend
+++ b/plugins/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaResourceDescriptionManager.xtend
@@ -32,7 +32,8 @@ class JavaResourceDescriptionManager implements IResourceDescription.Manager {
 				}
 				val result = new DefaultResourceDescription(resource, descriptionStrategy, cache)
 				if (!initialized) {
-					result.exportedObjects.forEach[EObjectURI]
+					for (it : result.exportedObjects)
+						EObjectURI
 				}
 				return result
 			} finally {

--- a/plugins/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/JavaResourceDescriptionManager.java
+++ b/plugins/org.eclipse.xtext.java/xtend-gen/org/eclipse/xtext/java/resource/JavaResourceDescriptionManager.java
@@ -14,7 +14,6 @@ import org.eclipse.xtext.resource.impl.DefaultResourceDescription;
 import org.eclipse.xtext.resource.impl.DefaultResourceDescriptionDelta;
 import org.eclipse.xtext.util.IResourceScopeCache;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 @SuppressWarnings("all")
 public class JavaResourceDescriptionManager implements IResourceDescription.Manager {
@@ -49,13 +48,9 @@ public class JavaResourceDescriptionManager implements IResourceDescription.Mana
         final DefaultResourceDescription result = new DefaultResourceDescription(resource, this.descriptionStrategy, this.cache);
         if ((!initialized)) {
           Iterable<IEObjectDescription> _exportedObjects = result.getExportedObjects();
-          final Procedure1<IEObjectDescription> _function = new Procedure1<IEObjectDescription>() {
-            @Override
-            public void apply(final IEObjectDescription it) {
-              it.getEObjectURI();
-            }
-          };
-          IterableExtensions.<IEObjectDescription>forEach(_exportedObjects, _function);
+          for (final IEObjectDescription it : _exportedObjects) {
+            it.getEObjectURI();
+          }
         }
         return result;
       } finally {

--- a/plugins/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/logging/LoggingTester.xtend
+++ b/plugins/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/logging/LoggingTester.xtend
@@ -92,7 +92,8 @@ import org.junit.Assert
 		val allAppenders = logger.appenderHierarchy
 		val filter = new SourceFilter(logger)
 		try {
-			allAppenders.forEach[addFilter(filter)]
+			for (it : allAppenders)
+				addFilter(filter)
 			logger.addAppender(appender)
 			logger.level = level
 			action.run
@@ -100,7 +101,8 @@ import org.junit.Assert
 			return new LogCapture(events)
 		} finally {
 			logger.removeAppender(appender)
-			allAppenders.forEach[removeFilter(filter)]
+			for (it : allAppenders)
+				removeFilter(filter)
 			logger.level = oldLevel
 		}
 	}

--- a/plugins/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/logging/LoggingTester.java
+++ b/plugins/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/logging/LoggingTester.java
@@ -32,7 +32,6 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 import org.junit.Assert;
@@ -379,13 +378,9 @@ public class LoggingTester {
     final ArrayList<Appender> allAppenders = LoggingTester.appenderHierarchy(logger);
     final LoggingTester.SourceFilter filter = new LoggingTester.SourceFilter(logger);
     try {
-      final Procedure1<Appender> _function = new Procedure1<Appender>() {
-        @Override
-        public void apply(final Appender it) {
-          it.addFilter(filter);
-        }
-      };
-      IterableExtensions.<Appender>forEach(allAppenders, _function);
+      for (final Appender it : allAppenders) {
+        it.addFilter(filter);
+      }
       logger.addAppender(appender);
       logger.setLevel(level);
       action.run();
@@ -394,13 +389,9 @@ public class LoggingTester {
       return new LoggingTester.LogCapture(events);
     } finally {
       logger.removeAppender(appender);
-      final Procedure1<Appender> _function_1 = new Procedure1<Appender>() {
-        @Override
-        public void apply(final Appender it) {
-          LoggingTester.removeFilter(it, filter);
-        }
-      };
-      IterableExtensions.<Appender>forEach(allAppenders, _function_1);
+      for (final Appender it_1 : allAppenders) {
+        LoggingTester.removeFilter(it_1, filter);
+      }
       logger.setLevel(oldLevel);
     }
   }

--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hyperlinking/SingleHoverShowingHyperlinkPresenter.xtend
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hyperlinking/SingleHoverShowingHyperlinkPresenter.xtend
@@ -75,13 +75,13 @@ class SingleHoverShowingHyperlinkPresenter implements InvocationHandler {
 	protected def IHyperlink[] makeNullsafe(IHyperlink[] arr) {
 		if (arr.exists[it === null || it.hyperlinkRegion === null]) {
 			val list = newArrayList
-			arr.forEach[
+			for (it : arr) {
 				if (it !== null && it.hyperlinkRegion !== null) {
 					list.add(it)
 				} else {
 					log.warn('Filtered invalid hyperlink: '+ it.getClass.name)
 				}
-			]
+			}
 			return list.toArray(newArrayOfSize(list.size))
 		}
 		return arr

--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/tasks/preferences/TaskTagPreferenceInitializer.xtend
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/tasks/preferences/TaskTagPreferenceInitializer.xtend
@@ -17,8 +17,7 @@ import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreInitializer
 class TaskTagPreferenceInitializer implements IPreferenceStoreInitializer {
 	override initialize(IPreferenceStoreAccess access) {
 		val store = access.writablePreferenceStore
-		PreferenceTaskTagProvider.KEYS.forEach [
+		for (it : PreferenceTaskTagProvider.KEYS)
 			store.setDefault(id, defaultValue)
-		]
 	}
 }

--- a/plugins/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/hyperlinking/SingleHoverShowingHyperlinkPresenter.java
+++ b/plugins/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/hyperlinking/SingleHoverShowingHyperlinkPresenter.java
@@ -25,7 +25,6 @@ import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.util.ReflectExtensions;
 
 /**
@@ -133,28 +132,24 @@ public class SingleHoverShowingHyperlinkPresenter implements InvocationHandler {
     boolean _exists = IterableExtensions.<IHyperlink>exists(((Iterable<IHyperlink>)Conversions.doWrapArray(arr)), _function);
     if (_exists) {
       final ArrayList<IHyperlink> list = CollectionLiterals.<IHyperlink>newArrayList();
-      final Procedure1<IHyperlink> _function_1 = new Procedure1<IHyperlink>() {
-        @Override
-        public void apply(final IHyperlink it) {
-          boolean _and = false;
-          if (!(it != null)) {
-            _and = false;
-          } else {
-            IRegion _hyperlinkRegion = it.getHyperlinkRegion();
-            boolean _tripleNotEquals = (_hyperlinkRegion != null);
-            _and = _tripleNotEquals;
-          }
-          if (_and) {
-            list.add(it);
-          } else {
-            Class<? extends IHyperlink> _class = it.getClass();
-            String _name = _class.getName();
-            String _plus = ("Filtered invalid hyperlink: " + _name);
-            SingleHoverShowingHyperlinkPresenter.log.warn(_plus);
-          }
+      for (final IHyperlink it : arr) {
+        boolean _and = false;
+        if (!(it != null)) {
+          _and = false;
+        } else {
+          IRegion _hyperlinkRegion = it.getHyperlinkRegion();
+          boolean _tripleNotEquals = (_hyperlinkRegion != null);
+          _and = _tripleNotEquals;
         }
-      };
-      IterableExtensions.<IHyperlink>forEach(((Iterable<IHyperlink>)Conversions.doWrapArray(arr)), _function_1);
+        if (_and) {
+          list.add(it);
+        } else {
+          Class<? extends IHyperlink> _class = it.getClass();
+          String _name = _class.getName();
+          String _plus = ("Filtered invalid hyperlink: " + _name);
+          SingleHoverShowingHyperlinkPresenter.log.warn(_plus);
+        }
+      }
       int _size = list.size();
       IHyperlink[] _newArrayOfSize = new IHyperlink[_size];
       return list.<IHyperlink>toArray(_newArrayOfSize);

--- a/plugins/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/tasks/preferences/TaskTagPreferenceInitializer.java
+++ b/plugins/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/tasks/preferences/TaskTagPreferenceInitializer.java
@@ -12,8 +12,6 @@ import org.eclipse.xtext.preferences.PreferenceKey;
 import org.eclipse.xtext.tasks.PreferenceTaskTagProvider;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreAccess;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreInitializer;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * @author Stefan Oehme - Initial contribution and API
@@ -23,14 +21,10 @@ public class TaskTagPreferenceInitializer implements IPreferenceStoreInitializer
   @Override
   public void initialize(final IPreferenceStoreAccess access) {
     final IPreferenceStore store = access.getWritablePreferenceStore();
-    final Procedure1<PreferenceKey> _function = new Procedure1<PreferenceKey>() {
-      @Override
-      public void apply(final PreferenceKey it) {
-        String _id = it.getId();
-        String _defaultValue = it.getDefaultValue();
-        store.setDefault(_id, _defaultValue);
-      }
-    };
-    IterableExtensions.<PreferenceKey>forEach(PreferenceTaskTagProvider.KEYS, _function);
+    for (final PreferenceKey it : PreferenceTaskTagProvider.KEYS) {
+      String _id = it.getId();
+      String _defaultValue = it.getDefaultValue();
+      store.setDefault(_id, _defaultValue);
+    }
   }
 }

--- a/plugins/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/Oven.xtend
+++ b/plugins/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/Oven.xtend
@@ -65,9 +65,9 @@ class Oven extends Assert {
 						}
 						XClosure: {
 							assertExpressionTypeIsResolved(content, resolvedTypes)
-							content.implicitFormalParameters.forEach [
+							for (it : content.implicitFormalParameters) {
 								assertIdentifiableTypeIsResolved(resolvedTypes)
-							]
+							}
 						}
 						XExpression: {
 							assertExpressionTypeIsResolved(content, resolvedTypes)

--- a/plugins/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/Oven.java
+++ b/plugins/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/Oven.java
@@ -23,9 +23,7 @@ import org.eclipse.xtext.xbase.XClosure;
 import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.IteratorExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.util.ReflectExtensions;
 import org.eclipse.xtext.xbase.typesystem.IBatchTypeResolver;
 import org.eclipse.xtext.xbase.typesystem.IResolvedTypes;
@@ -96,13 +94,9 @@ public class Oven extends Assert {
               _matched=true;
               this.assertExpressionTypeIsResolved(((XExpression)content), resolvedTypes);
               EList<JvmFormalParameter> _implicitFormalParameters = ((XClosure)content).getImplicitFormalParameters();
-              final Procedure1<JvmFormalParameter> _function = new Procedure1<JvmFormalParameter>() {
-                @Override
-                public void apply(final JvmFormalParameter it) {
-                  Oven.this.assertIdentifiableTypeIsResolved(it, resolvedTypes);
-                }
-              };
-              IterableExtensions.<JvmFormalParameter>forEach(_implicitFormalParameters, _function);
+              for (final JvmFormalParameter it : _implicitFormalParameters) {
+                this.assertIdentifiableTypeIsResolved(it, resolvedTypes);
+              }
             }
           }
           if (!_matched) {

--- a/plugins/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
+++ b/plugins/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
@@ -324,12 +324,37 @@ public class IterableExtensions {
 	/**
 	 * Applies {@code procedure} for each element of the given iterable.
 	 * 
+	 * This method has been deprecated because calls such as myIterable.forEach[] will call
+	 * org.eclipse.xtext.xbase.lib.IterableExtensions.forEach(Iterable<T>, Procedure1<? super T>) when using Java 7 (or older) and
+	 * java.lang.Iterable.forEach(Consumer<? super T>) when using Java 8 or newer.
+	 * 
+	 * Since this "magic" change in the Xtend-compilers output (the transpiled Java code) is undesirable, it is reommended to use
+	 * 
+	 * myIterable.forEach[] for java.lang.Iterable.forEach(Consumer<? super T>) and
+	 * 
+	 * myIterable.forach[] for org.eclipse.xtext.xbase.lib.IterableExtensions.foreach(Iterable<T>, Procedure1<? super T>)
+	 * 
+	 * @param iterable
+	 *            the iterable. May not be <code>null</code>.
+	 * @param procedure
+	 *            the procedure. May not be <code>null</code>.
+	 * 
+	 * @deprecated use java.lang.Iterable.forEach(Consumer<? super T>) from Java 8 or {@link #foreach(Iterable, Procedure1)} from this file.
+	 */
+	@Deprecated
+	public static <T> void forEach(Iterable<T> iterable, Procedure1<? super T> procedure) {
+		IteratorExtensions.forEach(iterable.iterator(), procedure);
+	}
+	
+	/**
+	 * Applies {@code procedure} for each element of the given iterable.
+	 * 
 	 * @param iterable
 	 *            the iterable. May not be <code>null</code>.
 	 * @param procedure
 	 *            the procedure. May not be <code>null</code>.
 	 */
-	public static <T> void forEach(Iterable<T> iterable, Procedure1<? super T> procedure) {
+	public static <T> void foreach(Iterable<T> iterable, Procedure1<? super T> procedure) {
 		IteratorExtensions.forEach(iterable.iterator(), procedure);
 	}
 	

--- a/plugins/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/util/ToStringBuilder.xtend
+++ b/plugins/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/util/ToStringBuilder.xtend
@@ -96,7 +96,8 @@ final class ToStringBuilder {
 	 */
 	@GwtIncompatible("Class.getDeclaredFields")
 	def addDeclaredFields() {
-		instance.class.declaredFields.forEach[addField]
+		for (it : instance.class.declaredFields)
+			addField
 		return this
 	}
 
@@ -106,7 +107,8 @@ final class ToStringBuilder {
 	 */
 	@GwtIncompatible("Class.getDeclaredFields")
 	def addAllFields() {
-		instance.class.allDeclaredFields.forEach[addField]
+		for (it : instance.class.allDeclaredFields)
+			addField
 		return this
 	}
 

--- a/plugins/org.eclipse.xtext.xbase.lib/xtend-gen/org/eclipse/xtext/xbase/lib/util/ToStringBuilder.java
+++ b/plugins/org.eclipse.xtext.xbase.lib/xtend-gen/org/eclipse/xtext/xbase/lib/util/ToStringBuilder.java
@@ -24,7 +24,6 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.util.ToStringContext;
 
 /**
@@ -168,13 +167,9 @@ public final class ToStringBuilder {
   public ToStringBuilder addDeclaredFields() {
     Class<?> _class = this.instance.getClass();
     Field[] _declaredFields = _class.getDeclaredFields();
-    final Procedure1<Field> _function = new Procedure1<Field>() {
-      @Override
-      public void apply(final Field it) {
-        ToStringBuilder.this.addField(it);
-      }
-    };
-    IterableExtensions.<Field>forEach(((Iterable<Field>)Conversions.doWrapArray(_declaredFields)), _function);
+    for (final Field it : _declaredFields) {
+      this.addField(it);
+    }
     return this;
   }
   
@@ -186,13 +181,9 @@ public final class ToStringBuilder {
   public ToStringBuilder addAllFields() {
     Class<?> _class = this.instance.getClass();
     ArrayList<Field> _allDeclaredFields = this.getAllDeclaredFields(_class);
-    final Procedure1<Field> _function = new Procedure1<Field>() {
-      @Override
-      public void apply(final Field it) {
-        ToStringBuilder.this.addField(it);
-      }
-    };
-    IterableExtensions.<Field>forEach(_allDeclaredFields, _function);
+    for (final Field it : _allDeclaredFields) {
+      this.addField(it);
+    }
     return this;
   }
   

--- a/plugins/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/FormattableDocument.xtend
+++ b/plugins/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/FormattableDocument.xtend
@@ -5,10 +5,10 @@ import java.util.TreeMap
 import org.apache.log4j.Logger
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend.lib.annotations.Data
-
-import static org.eclipse.xtext.xbase.formatting.BasicFormatterPreferenceKeys.*
 import org.eclipse.xtext.formatting2.IFormattableDocument
 import org.eclipse.xtext.formatting2.IHiddenRegionFormatter
+
+import static org.eclipse.xtext.xbase.formatting.BasicFormatterPreferenceKeys.*
 
 /**
  * @deprecated use {@link IFormattableDocument}
@@ -137,7 +137,8 @@ class FormattableDocument {
 	
 	def operator_add(Iterable<FormattingData> data) {
 		if(data != null)
-			data.forEach[addFormatting]
+			for (it : data)
+				addFormatting
 	}
 	
 	def operator_add((FormattableDocument) => Iterable<FormattingData> data) {

--- a/plugins/org.eclipse.xtext.xbase/org.eclipse.xtext.xbase.GenerateXbase.launch
+++ b/plugins/org.eclipse.xtext.xbase/org.eclipse.xtext.xbase.GenerateXbase.launch
@@ -8,7 +8,9 @@
 </listAttribute>
 <stringAttribute key="org.eclipse.debug.ui.ATTR_CONSOLE_ENCODING" value="ISO-8859-1"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.xtext.xbase.GenerateXbase"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.xtext.xbase"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx512m"/>
 </launchConfiguration>

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
@@ -566,7 +566,9 @@ class JvmModelGenerator implements IGenerator {
 	
 	def void generateThrowsClause(JvmExecutable it, ITreeAppendable appendable, GeneratorConfig config) {
 		val toBeGenerated = <JvmType, JvmTypeReference> newLinkedHashMap
-		exceptions.forEach[if(!toBeGenerated.containsKey(type)) toBeGenerated.put(type, it)]
+		for (it : exceptions)
+			if (!toBeGenerated.containsKey(type))
+				toBeGenerated.put(type, it)
 		appendable.forEachSafely(toBeGenerated.values, [
 				prefix = ' throws ' separator = ', '
 			], [
@@ -740,7 +742,9 @@ class JvmModelGenerator implements IGenerator {
 		appendable.append('{').increaseIndentation.newLine
 			.append('throw new Error("Unresolved compilation problems:"')
 		appendable.increaseIndentation
-		errors.forEach[appendable.newLine.append('+ "\\n').append(doConvertToJavaString(message)).append('"')]
+		for (it : errors) {
+			appendable.newLine.append('+ "\\n').append(doConvertToJavaString(message)).append('"')
+		}
 		appendable.append(');').decreaseIndentation.decreaseIndentation.newLine
 		    .append('}')
 	}

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/LoopExtensions.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/LoopExtensions.xtend
@@ -24,10 +24,10 @@ class LoopExtensions {
 		val params = new LoopParams => loopInitializer
 		params.appendPrefix(appendable)
 		elements.head => procedure
-		elements.tail.forEach[
+		for (it : elements.tail) {
 			params.appendSeparator(appendable)
 			it => procedure
-		]
+		}
 		params.appendSuffix(appendable)
 	}
 

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
@@ -340,14 +340,18 @@ class XbaseFormatter extends XtypeFormatter {
 	def dispatch void format(XBasicForLoopExpression expr, extension IFormattableDocument format) {
 		expr.regionFor.keyword("for").append[oneSpace]
 		expr.regionFor.keyword("(").append[noSpace]
-		expr.regionFor.keywords(";").forEach[prepend[noSpace].append[noSpace lowPriority]]
-		expr.regionFor.keywords(",").forEach[prepend[noSpace].append[oneSpace]]
+		for (it : expr.regionFor.keywords(";"))
+			prepend[noSpace].append[noSpace lowPriority]
+		for (it : expr.regionFor.keywords(","))
+			prepend[noSpace].append[oneSpace]
 		expr.regionFor.keyword(")").prepend[noSpace]
-		expr.initExpressions.forEach[it.format]
+		for (it : expr.initExpressions)
+			it.format
 		expr.expression.prepend[oneSpace]
 		expr.expression.format
 		expr.updateExpressions.head.prepend[oneSpace]
-		expr.updateExpressions.forEach[it.format]
+		for (it : expr.updateExpressions)
+			it.format
 		expr.eachExpression.formatBody(true, format)
 	}
 

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.xtend
@@ -59,17 +59,14 @@ import org.eclipse.xtext.xbase.jvmmodel.JvmModelAssociator
 		stream.nextEntry
 		val objIn = new ObjectInputStream(stream)
 		val logicalMap = objIn.readObject as Map<String,String>
-		logicalMap.entrySet.forEach [
+		for (it : logicalMap.entrySet)
 			adapter.logicalContainerMap.put(resource.getEObject(key), resource.getEObject(value) as JvmIdentifiableElement)
-		]
 		val sourceToTargetMap = objIn.readObject as Map<String,Set<String>>
-		sourceToTargetMap.entrySet.forEach [
+		for (it : sourceToTargetMap.entrySet)
 			adapter.sourceToTargetMap.put(resource.getEObject(key), Sets.newHashSet(value.map[resource.getEObject(it)]))
-		]
 		val targetToSourceMap = objIn.readObject as Map<String,Set<String>>
-		targetToSourceMap.entrySet.forEach [
+		for (it : targetToSourceMap.entrySet)
 			adapter.targetToSourceMap.put(resource.getEObject(key), Sets.newHashSet(value.map[resource.getEObject(it)]))
-		]
 	}
 	
 }

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/UniqueClassNameValidator.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/UniqueClassNameValidator.xtend
@@ -50,7 +50,8 @@ class UniqueClassNameValidator extends AbstractDeclarativeValidator {
 		if (root.eContainer == null) {
 			val resource = root.eResource
 			if (resource.contents.head == root) {
-				resource.contents.filter(JvmDeclaredType).forEach[ doCheckUniqueName ]
+				for (it : resource.contents.filter(JvmDeclaredType))
+					doCheckUniqueName 
 			}
 		}
 	}

--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/XbaseImplicitReturnFinder.xtend
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/XbaseImplicitReturnFinder.xtend
@@ -97,11 +97,13 @@ class XbaseImplicitReturnFinder implements ImplicitReturnFinder {
 
 	def dispatch void findImplicitReturns(XTryCatchFinallyExpression expression, ImplicitReturnFinder.Acceptor acceptor) {
 		findImplicitReturns(expression.expression, acceptor)
-		expression.catchClauses.forEach[findImplicitReturns(it.expression, acceptor)]
+		for (it : expression.catchClauses)
+			findImplicitReturns(it.expression, acceptor)
 	}
 
 	def dispatch void findImplicitReturns(XSwitchExpression expression, ImplicitReturnFinder.Acceptor acceptor) {
-		expression.cases.forEach[findImplicitReturns(it.then, acceptor)]
+		for (it : expression.cases)
+			findImplicitReturns(it.then, acceptor)
 		findImplicitReturns(expression.^default, acceptor)
 	}
 }

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
@@ -1147,28 +1147,24 @@ public class JvmModelGenerator implements IGenerator {
   public void generateThrowsClause(final JvmExecutable it, final ITreeAppendable appendable, final GeneratorConfig config) {
     final LinkedHashMap<JvmType, JvmTypeReference> toBeGenerated = CollectionLiterals.<JvmType, JvmTypeReference>newLinkedHashMap();
     EList<JvmTypeReference> _exceptions = it.getExceptions();
-    final Procedure1<JvmTypeReference> _function = new Procedure1<JvmTypeReference>() {
-      @Override
-      public void apply(final JvmTypeReference it) {
-        JvmType _type = it.getType();
-        boolean _containsKey = toBeGenerated.containsKey(_type);
-        boolean _not = (!_containsKey);
-        if (_not) {
-          JvmType _type_1 = it.getType();
-          toBeGenerated.put(_type_1, it);
-        }
+    for (final JvmTypeReference it_1 : _exceptions) {
+      JvmType _type = it_1.getType();
+      boolean _containsKey = toBeGenerated.containsKey(_type);
+      boolean _not = (!_containsKey);
+      if (_not) {
+        JvmType _type_1 = it_1.getType();
+        toBeGenerated.put(_type_1, it_1);
       }
-    };
-    IterableExtensions.<JvmTypeReference>forEach(_exceptions, _function);
+    }
     Collection<JvmTypeReference> _values = toBeGenerated.values();
-    final Procedure1<LoopParams> _function_1 = new Procedure1<LoopParams>() {
+    final Procedure1<LoopParams> _function = new Procedure1<LoopParams>() {
       @Override
       public void apply(final LoopParams it) {
         it.setPrefix(" throws ");
         it.setSeparator(", ");
       }
     };
-    final Procedure2<JvmTypeReference, ITreeAppendable> _function_2 = new Procedure2<JvmTypeReference, ITreeAppendable>() {
+    final Procedure2<JvmTypeReference, ITreeAppendable> _function_1 = new Procedure2<JvmTypeReference, ITreeAppendable>() {
       @Override
       public void apply(final JvmTypeReference it, final ITreeAppendable app) {
         ITreeAppendable _trace = app.trace(it);
@@ -1176,7 +1172,7 @@ public class JvmModelGenerator implements IGenerator {
         _trace.append(_type);
       }
     };
-    this._errorSafeExtensions.<JvmTypeReference>forEachSafely(appendable, _values, _function_1, _function_2);
+    this._errorSafeExtensions.<JvmTypeReference>forEachSafely(appendable, _values, _function, _function_1);
   }
   
   public void generateParameters(final JvmExecutable it, final ITreeAppendable appendable, final GeneratorConfig config) {
@@ -1483,23 +1479,19 @@ public class JvmModelGenerator implements IGenerator {
       ITreeAppendable _newLine = _increaseIndentation.newLine();
       _newLine.append("throw new Error(\"Unresolved compilation problems:\"");
       appendable.increaseIndentation();
-      final Procedure1<Issue> _function = new Procedure1<Issue>() {
-        @Override
-        public void apply(final Issue it) {
-          ITreeAppendable _newLine = appendable.newLine();
-          ITreeAppendable _append = _newLine.append("+ \"\\n");
-          String _message = it.getMessage();
-          String _doConvertToJavaString = JvmModelGenerator.this.doConvertToJavaString(_message);
-          ITreeAppendable _append_1 = _append.append(_doConvertToJavaString);
-          _append_1.append("\"");
-        }
-      };
-      IterableExtensions.<Issue>forEach(errors, _function);
-      ITreeAppendable _append_1 = appendable.append(");");
-      ITreeAppendable _decreaseIndentation = _append_1.decreaseIndentation();
+      for (final Issue it : errors) {
+        ITreeAppendable _newLine_1 = appendable.newLine();
+        ITreeAppendable _append_1 = _newLine_1.append("+ \"\\n");
+        String _message = it.getMessage();
+        String _doConvertToJavaString = this.doConvertToJavaString(_message);
+        ITreeAppendable _append_2 = _append_1.append(_doConvertToJavaString);
+        _append_2.append("\"");
+      }
+      ITreeAppendable _append_3 = appendable.append(");");
+      ITreeAppendable _decreaseIndentation = _append_3.decreaseIndentation();
       ITreeAppendable _decreaseIndentation_1 = _decreaseIndentation.decreaseIndentation();
-      ITreeAppendable _newLine_1 = _decreaseIndentation_1.newLine();
-      _xblockexpression = _newLine_1.append("}");
+      ITreeAppendable _newLine_2 = _decreaseIndentation_1.newLine();
+      _xblockexpression = _newLine_2.append("}");
     }
     return _xblockexpression;
   }

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/LoopExtensions.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/LoopExtensions.java
@@ -33,14 +33,12 @@ public class LoopExtensions {
     T _head = IterableExtensions.<T>head(elements);
     ObjectExtensions.<T>operator_doubleArrow(_head, procedure);
     Iterable<T> _tail = IterableExtensions.<T>tail(elements);
-    final Procedure1<T> _function = new Procedure1<T>() {
-      @Override
-      public void apply(final T it) {
+    for (final T it : _tail) {
+      {
         params.appendSeparator(appendable);
         ObjectExtensions.<T>operator_doubleArrow(it, procedure);
       }
-    };
-    IterableExtensions.<T>forEach(_tail, _function);
+    }
     params.appendSuffix(appendable);
   }
   

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/FormattableDocument.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/FormattableDocument.java
@@ -341,13 +341,9 @@ public class FormattableDocument {
   public void operator_add(final Iterable<FormattingData> data) {
     boolean _notEquals = (!Objects.equal(data, null));
     if (_notEquals) {
-      final Procedure1<FormattingData> _function = new Procedure1<FormattingData>() {
-        @Override
-        public void apply(final FormattingData it) {
-          FormattableDocument.this.addFormatting(it);
-        }
-      };
-      IterableExtensions.<FormattingData>forEach(data, _function);
+      for (final FormattingData it : data) {
+        this.addFormatting(it);
+      }
     }
   }
   

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
@@ -1039,93 +1039,77 @@ public class XbaseFormatter extends XtypeFormatter {
     format.append(_keyword_1, _function_1);
     ISemanticRegionsFinder _regionFor_2 = this.textRegionExtensions.regionFor(expr);
     List<ISemanticRegion> _keywords = _regionFor_2.keywords(";");
-    final Procedure1<ISemanticRegion> _function_2 = new Procedure1<ISemanticRegion>() {
-      @Override
-      public void apply(final ISemanticRegion it) {
-        final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.noSpace();
-          }
-        };
-        ISemanticRegion _prepend = format.prepend(it, _function);
-        final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.noSpace();
-            it.lowPriority();
-          }
-        };
-        format.append(_prepend, _function_1);
-      }
-    };
-    IterableExtensions.<ISemanticRegion>forEach(_keywords, _function_2);
+    for (final ISemanticRegion it : _keywords) {
+      final Procedure1<IHiddenRegionFormatter> _function_2 = new Procedure1<IHiddenRegionFormatter>() {
+        @Override
+        public void apply(final IHiddenRegionFormatter it) {
+          it.noSpace();
+        }
+      };
+      ISemanticRegion _prepend = format.prepend(it, _function_2);
+      final Procedure1<IHiddenRegionFormatter> _function_3 = new Procedure1<IHiddenRegionFormatter>() {
+        @Override
+        public void apply(final IHiddenRegionFormatter it) {
+          it.noSpace();
+          it.lowPriority();
+        }
+      };
+      format.append(_prepend, _function_3);
+    }
     ISemanticRegionsFinder _regionFor_3 = this.textRegionExtensions.regionFor(expr);
     List<ISemanticRegion> _keywords_1 = _regionFor_3.keywords(",");
-    final Procedure1<ISemanticRegion> _function_3 = new Procedure1<ISemanticRegion>() {
-      @Override
-      public void apply(final ISemanticRegion it) {
-        final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.noSpace();
-          }
-        };
-        ISemanticRegion _prepend = format.prepend(it, _function);
-        final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.oneSpace();
-          }
-        };
-        format.append(_prepend, _function_1);
-      }
-    };
-    IterableExtensions.<ISemanticRegion>forEach(_keywords_1, _function_3);
+    for (final ISemanticRegion it_1 : _keywords_1) {
+      final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {
+        @Override
+        public void apply(final IHiddenRegionFormatter it) {
+          it.noSpace();
+        }
+      };
+      ISemanticRegion _prepend_1 = format.prepend(it_1, _function_4);
+      final Procedure1<IHiddenRegionFormatter> _function_5 = new Procedure1<IHiddenRegionFormatter>() {
+        @Override
+        public void apply(final IHiddenRegionFormatter it) {
+          it.oneSpace();
+        }
+      };
+      format.append(_prepend_1, _function_5);
+    }
     ISemanticRegionsFinder _regionFor_4 = this.textRegionExtensions.regionFor(expr);
     ISemanticRegion _keyword_2 = _regionFor_4.keyword(")");
-    final Procedure1<IHiddenRegionFormatter> _function_4 = new Procedure1<IHiddenRegionFormatter>() {
+    final Procedure1<IHiddenRegionFormatter> _function_6 = new Procedure1<IHiddenRegionFormatter>() {
       @Override
       public void apply(final IHiddenRegionFormatter it) {
         it.noSpace();
       }
     };
-    format.prepend(_keyword_2, _function_4);
+    format.prepend(_keyword_2, _function_6);
     EList<XExpression> _initExpressions = expr.getInitExpressions();
-    final Procedure1<XExpression> _function_5 = new Procedure1<XExpression>() {
-      @Override
-      public void apply(final XExpression it) {
-        format.<XExpression>format(it);
-      }
-    };
-    IterableExtensions.<XExpression>forEach(_initExpressions, _function_5);
+    for (final XExpression it_2 : _initExpressions) {
+      format.<XExpression>format(it_2);
+    }
     XExpression _expression = expr.getExpression();
-    final Procedure1<IHiddenRegionFormatter> _function_6 = new Procedure1<IHiddenRegionFormatter>() {
-      @Override
-      public void apply(final IHiddenRegionFormatter it) {
-        it.oneSpace();
-      }
-    };
-    format.<XExpression>prepend(_expression, _function_6);
-    XExpression _expression_1 = expr.getExpression();
-    format.<XExpression>format(_expression_1);
-    EList<XExpression> _updateExpressions = expr.getUpdateExpressions();
-    XExpression _head = IterableExtensions.<XExpression>head(_updateExpressions);
     final Procedure1<IHiddenRegionFormatter> _function_7 = new Procedure1<IHiddenRegionFormatter>() {
       @Override
       public void apply(final IHiddenRegionFormatter it) {
         it.oneSpace();
       }
     };
-    format.<XExpression>prepend(_head, _function_7);
-    EList<XExpression> _updateExpressions_1 = expr.getUpdateExpressions();
-    final Procedure1<XExpression> _function_8 = new Procedure1<XExpression>() {
+    format.<XExpression>prepend(_expression, _function_7);
+    XExpression _expression_1 = expr.getExpression();
+    format.<XExpression>format(_expression_1);
+    EList<XExpression> _updateExpressions = expr.getUpdateExpressions();
+    XExpression _head = IterableExtensions.<XExpression>head(_updateExpressions);
+    final Procedure1<IHiddenRegionFormatter> _function_8 = new Procedure1<IHiddenRegionFormatter>() {
       @Override
-      public void apply(final XExpression it) {
-        format.<XExpression>format(it);
+      public void apply(final IHiddenRegionFormatter it) {
+        it.oneSpace();
       }
     };
-    IterableExtensions.<XExpression>forEach(_updateExpressions_1, _function_8);
+    format.<XExpression>prepend(_head, _function_8);
+    EList<XExpression> _updateExpressions_1 = expr.getUpdateExpressions();
+    for (final XExpression it_3 : _updateExpressions_1) {
+      format.<XExpression>format(it_3);
+    }
     XExpression _eachExpression = expr.getEachExpression();
     this.formatBody(_eachExpression, true, format);
   }

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/resource/BatchLinkableResourceStorageLoadable.java
@@ -115,59 +115,47 @@ public class BatchLinkableResourceStorageLoadable extends ResourceStorageLoadabl
       Object _readObject = objIn.readObject();
       final Map<String, String> logicalMap = ((Map<String, String>) _readObject);
       Set<Map.Entry<String, String>> _entrySet = logicalMap.entrySet();
-      final Procedure1<Map.Entry<String, String>> _function_1 = new Procedure1<Map.Entry<String, String>>() {
-        @Override
-        public void apply(final Map.Entry<String, String> it) {
-          String _key = it.getKey();
-          EObject _eObject = resource.getEObject(_key);
-          String _value = it.getValue();
-          EObject _eObject_1 = resource.getEObject(_value);
-          adapter.logicalContainerMap.put(_eObject, ((JvmIdentifiableElement) _eObject_1));
-        }
-      };
-      IterableExtensions.<Map.Entry<String, String>>forEach(_entrySet, _function_1);
+      for (final Map.Entry<String, String> it : _entrySet) {
+        String _key = it.getKey();
+        EObject _eObject = resource.getEObject(_key);
+        String _value = it.getValue();
+        EObject _eObject_1 = resource.getEObject(_value);
+        adapter.logicalContainerMap.put(_eObject, ((JvmIdentifiableElement) _eObject_1));
+      }
       Object _readObject_1 = objIn.readObject();
       final Map<String, Set<String>> sourceToTargetMap = ((Map<String, Set<String>>) _readObject_1);
       Set<Map.Entry<String, Set<String>>> _entrySet_1 = sourceToTargetMap.entrySet();
-      final Procedure1<Map.Entry<String, Set<String>>> _function_2 = new Procedure1<Map.Entry<String, Set<String>>>() {
-        @Override
-        public void apply(final Map.Entry<String, Set<String>> it) {
-          String _key = it.getKey();
-          EObject _eObject = resource.getEObject(_key);
-          Set<String> _value = it.getValue();
-          final Function1<String, EObject> _function = new Function1<String, EObject>() {
-            @Override
-            public EObject apply(final String it) {
-              return resource.getEObject(it);
-            }
-          };
-          Iterable<EObject> _map = IterableExtensions.<String, EObject>map(_value, _function);
-          HashSet<EObject> _newHashSet = Sets.<EObject>newHashSet(_map);
-          adapter.sourceToTargetMap.put(_eObject, _newHashSet);
-        }
-      };
-      IterableExtensions.<Map.Entry<String, Set<String>>>forEach(_entrySet_1, _function_2);
+      for (final Map.Entry<String, Set<String>> it_1 : _entrySet_1) {
+        String _key_1 = it_1.getKey();
+        EObject _eObject_2 = resource.getEObject(_key_1);
+        Set<String> _value_1 = it_1.getValue();
+        final Function1<String, EObject> _function_1 = new Function1<String, EObject>() {
+          @Override
+          public EObject apply(final String it) {
+            return resource.getEObject(it);
+          }
+        };
+        Iterable<EObject> _map = IterableExtensions.<String, EObject>map(_value_1, _function_1);
+        HashSet<EObject> _newHashSet = Sets.<EObject>newHashSet(_map);
+        adapter.sourceToTargetMap.put(_eObject_2, _newHashSet);
+      }
       Object _readObject_2 = objIn.readObject();
       final Map<String, Set<String>> targetToSourceMap = ((Map<String, Set<String>>) _readObject_2);
       Set<Map.Entry<String, Set<String>>> _entrySet_2 = targetToSourceMap.entrySet();
-      final Procedure1<Map.Entry<String, Set<String>>> _function_3 = new Procedure1<Map.Entry<String, Set<String>>>() {
-        @Override
-        public void apply(final Map.Entry<String, Set<String>> it) {
-          String _key = it.getKey();
-          EObject _eObject = resource.getEObject(_key);
-          Set<String> _value = it.getValue();
-          final Function1<String, EObject> _function = new Function1<String, EObject>() {
-            @Override
-            public EObject apply(final String it) {
-              return resource.getEObject(it);
-            }
-          };
-          Iterable<EObject> _map = IterableExtensions.<String, EObject>map(_value, _function);
-          HashSet<EObject> _newHashSet = Sets.<EObject>newHashSet(_map);
-          adapter.targetToSourceMap.put(_eObject, _newHashSet);
-        }
-      };
-      IterableExtensions.<Map.Entry<String, Set<String>>>forEach(_entrySet_2, _function_3);
+      for (final Map.Entry<String, Set<String>> it_2 : _entrySet_2) {
+        String _key_2 = it_2.getKey();
+        EObject _eObject_3 = resource.getEObject(_key_2);
+        Set<String> _value_2 = it_2.getValue();
+        final Function1<String, EObject> _function_2 = new Function1<String, EObject>() {
+          @Override
+          public EObject apply(final String it) {
+            return resource.getEObject(it);
+          }
+        };
+        Iterable<EObject> _map_1 = IterableExtensions.<String, EObject>map(_value_2, _function_2);
+        HashSet<EObject> _newHashSet_1 = Sets.<EObject>newHashSet(_map_1);
+        adapter.targetToSourceMap.put(_eObject_3, _newHashSet_1);
+      }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/validation/UniqueClassNameValidator.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/validation/UniqueClassNameValidator.java
@@ -38,7 +38,6 @@ import org.eclipse.xtext.validation.EValidatorRegistrar;
 import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociations;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.validation.IssueCodes;
 
 /**
@@ -84,13 +83,9 @@ public class UniqueClassNameValidator extends AbstractDeclarativeValidator {
       if (_equals_1) {
         EList<EObject> _contents_1 = resource.getContents();
         Iterable<JvmDeclaredType> _filter = Iterables.<JvmDeclaredType>filter(_contents_1, JvmDeclaredType.class);
-        final Procedure1<JvmDeclaredType> _function = new Procedure1<JvmDeclaredType>() {
-          @Override
-          public void apply(final JvmDeclaredType it) {
-            UniqueClassNameValidator.this.doCheckUniqueName(it);
-          }
-        };
-        IterableExtensions.<JvmDeclaredType>forEach(_filter, _function);
+        for (final JvmDeclaredType it : _filter) {
+          this.doCheckUniqueName(it);
+        }
       }
     }
   }

--- a/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/validation/XbaseImplicitReturnFinder.java
+++ b/plugins/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/validation/XbaseImplicitReturnFinder.java
@@ -29,7 +29,6 @@ import org.eclipse.xtext.xbase.XSynchronizedExpression;
 import org.eclipse.xtext.xbase.XTryCatchFinallyExpression;
 import org.eclipse.xtext.xbase.XTypeLiteral;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.validation.ImplicitReturnFinder;
 
 /**
@@ -109,26 +108,18 @@ public class XbaseImplicitReturnFinder implements ImplicitReturnFinder {
     XExpression _expression = expression.getExpression();
     this.findImplicitReturns(_expression, acceptor);
     EList<XCatchClause> _catchClauses = expression.getCatchClauses();
-    final Procedure1<XCatchClause> _function = new Procedure1<XCatchClause>() {
-      @Override
-      public void apply(final XCatchClause it) {
-        XExpression _expression = it.getExpression();
-        XbaseImplicitReturnFinder.this.findImplicitReturns(_expression, acceptor);
-      }
-    };
-    IterableExtensions.<XCatchClause>forEach(_catchClauses, _function);
+    for (final XCatchClause it : _catchClauses) {
+      XExpression _expression_1 = it.getExpression();
+      this.findImplicitReturns(_expression_1, acceptor);
+    }
   }
   
   protected void _findImplicitReturns(final XSwitchExpression expression, final ImplicitReturnFinder.Acceptor acceptor) {
     EList<XCasePart> _cases = expression.getCases();
-    final Procedure1<XCasePart> _function = new Procedure1<XCasePart>() {
-      @Override
-      public void apply(final XCasePart it) {
-        XExpression _then = it.getThen();
-        XbaseImplicitReturnFinder.this.findImplicitReturns(_then, acceptor);
-      }
-    };
-    IterableExtensions.<XCasePart>forEach(_cases, _function);
+    for (final XCasePart it : _cases) {
+      XExpression _then = it.getThen();
+      this.findImplicitReturns(_then, acceptor);
+    }
     XExpression _default = expression.getDefault();
     this.findImplicitReturns(_default, acceptor);
   }

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextDirectoryCleaner.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextDirectoryCleaner.xtend
@@ -47,9 +47,11 @@ class XtextDirectoryCleaner implements IGuiceAwareGeneratorComponent {
 		
 		val delegate = new DirectoryCleaner
 		delegate.useDefaultExcludes = useDefaultExcludes
-		excludes.forEach[delegate.addExclude(it)]
+		for (it : excludes)
+			delegate.addExclude(it)
 
-		directories.forEach[delegate.cleanFolder(it)]
+		for (it : directories)
+			delegate.cleanFolder(it)
 	}
 	
 	override initialize(Injector injector) {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.xtend
@@ -146,7 +146,8 @@ class XtextGenerator extends AbstractWorkflowComponent2 {
 	
 	private def void handleException(Exception ex, Issues issues) {
 		if (ex instanceof CompositeGeneratorException) {
-			ex.exceptions.forEach[handleException(issues)]
+			for (it : ex.exceptions)
+				handleException(issues)
 		} else {
 			issues.addError(this, "GeneratorException: ", null, ex, null)
 		}

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorResourceSetInitializer.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorResourceSetInitializer.xtend
@@ -32,9 +32,8 @@ class XtextGeneratorResourceSetInitializer {
 		val delegate = new StandaloneSetup
 		delegate.resourceSet = resourceSet
 		resourceSet.packageRegistry.put(EcorePackage.eNS_URI, EcorePackage.eINSTANCE)
-		referencedResources.forEach[
+		for (it : referencedResources)
 			loadResource(resourceSet)
-		]
 		registerGenModels(resourceSet)
 		registerEPackages(resourceSet)
 	}
@@ -116,7 +115,8 @@ class XtextGeneratorResourceSetInitializer {
 		// don't use forEach loop since the given strategy may trigger additional resource loading
 		for(var i = 0; i < resourceSet.resources.size; i++) {
 			val resource = resourceSet.resources.get(i)
-			resource.contents.filter(type).forEach[ strategy.apply(it) ]
+			for (it : resource.contents.filter(type))
+				strategy.apply(it) 
 		}
 	}
 }

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.xtend
@@ -32,12 +32,12 @@ class XtextGeneratorStandaloneSetup implements IGuiceAwareGeneratorComponent {
 	private def void setup() {
 		val delegate = new StandaloneSetup
 		delegate.scanClassPath = scanClasspath
-		projectMappings.forEach [ mapping |
+		for (mapping : projectMappings) {
 			delegate.addProjectMapping(new ProjectMapping => [
 				projectName = mapping.key
 				path = mapping.value
 			])
-		]
+		}
 	}
 
 	private def getProjectMappings() {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/idea/IdeaPluginGenerator.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/idea/IdeaPluginGenerator.xtend
@@ -120,18 +120,18 @@ class IdeaPluginGenerator extends AbstractStubGeneratingFragment {
 
 		bindFactory.contributeTo(language.ideaGenModule)
 
-		#[
+		val toSrc = #[
 			grammar.compileStandaloneSetup,
 			grammar.compileIdeaSetup,
 			grammar.compileCompletionContributor,
 			grammar.compileFileType,
 			grammar.compileFacetConfiguration,
 			grammar.compileColorSettingsPage
-		].forEach[
-			writeTo(projectConfig.ideaPlugin.src)
 		]
+		for (it : toSrc)
+			writeTo(projectConfig.ideaPlugin.src)
 
-		#[
+		val toSrcGen = #[
 			grammar.compileServicesISetup,
 			grammar.compileAbstractCompletionContributor,
 			grammar.compileLanguage,
@@ -150,9 +150,9 @@ class IdeaPluginGenerator extends AbstractStubGeneratingFragment {
 			grammar.compilePomDeclarationSearcher,
 			grammar.compileFacetType,
 			grammar.compileBaseColorSettingsPage
-		].forEach[
-			writeTo(projectConfig.ideaPlugin.srcGen)
 		]
+		for (it : toSrcGen)
+			writeTo(projectConfig.ideaPlugin.srcGen)
 
 		if (deployable) {
 			val pluginXml = grammar.compilePluginXml

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.xtend
@@ -38,10 +38,7 @@ class Junit4Fragment2 extends AbstractStubGeneratingFragment {
 			projectConfig.eclipsePlugin.manifest.exportedPackages.add(eclipsePluginActivator.packageName)
 		}
 		
-		#[
-			projectConfig.runtimeTest.manifest,
-			projectConfig.eclipsePluginTest.manifest
-		].filterNull.forEach [
+		for (it : #[projectConfig.runtimeTest.manifest, projectConfig.eclipsePluginTest.manifest].filterNull) {
 			importedPackages.addAll(
 				"org.junit;version=\"4.5.0\"",
 				"org.junit.runner;version=\"4.5.0\"",
@@ -51,7 +48,7 @@ class Junit4Fragment2 extends AbstractStubGeneratingFragment {
 				"org.junit.runners.model;version=\"4.5.0\"",
 				"org.hamcrest.core"
 			)
-		]
+		}
 		generateInjectorProvider.writeTo(projectConfig.runtimeTest.srcGen)
 		if (isGenerateStub)
 			generateExampleRuntimeTest.writeTo(projectConfig.runtimeTest.src)

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.xtend
@@ -39,9 +39,8 @@ class GeneratedJavaFileAccess extends JavaFileAccess {
 	 * any optionally required imports are already processed and tracked in {@link #imports}.
 	 */
 	override getContent() {
-		classAnnotations.forEach[
+		for (it : classAnnotations)
 			importType(annotationImport)
-		]
 		super.getContent()
 	}
 	

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/StandardProjectConfig.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/StandardProjectConfig.xtend
@@ -43,7 +43,7 @@ class StandardProjectConfig extends XtextProjectConfig {
 
 	override setDefaults() {
 		super.setDefaults
-		enabledProjects.forEach [
+		for (it : enabledProjects) {
 			if (name === null)
 				name = computeName
 			if (it.rootPath === null)
@@ -70,7 +70,7 @@ class StandardProjectConfig extends XtextProjectConfig {
 				if (assetsPath === null)
 					assets = computeAssets
 			}
-		]
+		}
 	}
 
 	protected def computeName(SubProjectConfig project) {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.xtend
@@ -29,7 +29,8 @@ class XtextProjectConfig implements IXtextProjectConfig {
 	WebProjectConfig web = new WebProjectConfig
 	
 	def void checkConfiguration(Issues issues) {
-		enabledProjects.forEach[checkConfiguration(issues)]
+		for (it : enabledProjects)
+			checkConfiguration(issues)
 	}
 
 	def List<? extends SubProjectConfig> getAllProjects() {
@@ -64,7 +65,8 @@ class XtextProjectConfig implements IXtextProjectConfig {
 	override initialize(Injector injector) {
 		setDefaults
 		injector.injectMembers(this)
-		enabledProjects.forEach[initialize(injector)]
+		for (it : enabledProjects)
+			initialize(injector)
 	}
 	
 	def setDefaults() {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGeneratorFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGeneratorFragment2.xtend
@@ -134,7 +134,8 @@ abstract class AbstractAntlrGeneratorFragment2 extends AbstractXtextGeneratorFra
 		fsa.generateFile(type.javaPath, newContent)
 	}
 	def protected void suppressWarnings(IXtextGeneratorFileSystemAccess fsa, TypeReference... types) {
-		types.forEach[suppressWarnings(fsa, it)]
+		for (it : types)
+			suppressWarnings(fsa, it)
 	}
 
 	def protected void normalizeLineDelimiters(IXtextGeneratorFileSystemAccess fsa, TypeReference type) {
@@ -149,7 +150,8 @@ abstract class AbstractAntlrGeneratorFragment2 extends AbstractXtextGeneratorFra
 	}
 	
 	def protected void normalizeLineDelimiters(IXtextGeneratorFileSystemAccess fsa, TypeReference... types) {
-		types.forEach[normalizeLineDelimiters(fsa, it)]
+		for (it : types)
+			normalizeLineDelimiters(fsa, it)
 	}
 
 	def protected void normalizeTokens(IXtextGeneratorFileSystemAccess fsa, String tokenFile) {

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.xtend
@@ -311,9 +311,8 @@ import org.eclipse.xtext.util.internal.Log
 	private def StringConcatenationClient genCondition(List<ISerializationContext> contexts, IConstraint constraint, Multimap<EObject, IConstraint> ctx2ctr) {
 		val sorted = contexts.sort
 		val index = LinkedHashMultimap.create
-		sorted.forEach [
+		for (it : sorted)
 			index.put(contextObject, it)
-		]
 		'''«FOR obj : index.keySet SEPARATOR "\n\t\t|| "»«obj.genObjectSelector»«IF ctx2ctr.get(obj).size > 1»«obj.genParameterSelector(index.get(obj), constraint)»«ENDIF»«ENDFOR»'''
 	}
 	

--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.xtend
@@ -267,12 +267,12 @@ class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
 		val nonWordKeywords = newArrayList
 		val keywordsFilterPattern = Pattern.compile(keywordsFilter)
 		val wordKeywordPattern = Pattern.compile('\\w(.*\\w)?')
-		allKeywords.filter[keywordsFilterPattern.matcher(it).matches].forEach[
+		for (it : allKeywords.filter[keywordsFilterPattern.matcher(it).matches]) {
 			if (wordKeywordPattern.matcher(it).matches)
 				wordKeywords += it
 			else
 				nonWordKeywords += it
-		]
+		}
 		Collections.sort(wordKeywords)
 		Collections.sort(nonWordKeywords)
 		val jsFile = fileAccessFactory.createTextFile()

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextDirectoryCleaner.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextDirectoryCleaner.java
@@ -22,7 +22,6 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xtext.generator.IGuiceAwareGeneratorComponent;
 import org.eclipse.xtext.xtext.generator.model.IXtextGeneratorFileSystemAccess;
 import org.eclipse.xtext.xtext.generator.model.project.IRuntimeProjectConfig;
@@ -56,59 +55,51 @@ public class XtextDirectoryCleaner implements IGuiceAwareGeneratorComponent {
   }
   
   public void clean() {
-    if ((!this.enabled)) {
-      return;
-    }
-    final ArrayList<String> directories = CollectionLiterals.<String>newArrayList();
-    List<? extends ISubProjectConfig> _enabledProjects = this.config.getEnabledProjects();
-    final Function1<ISubProjectConfig, IXtextGeneratorFileSystemAccess> _function = new Function1<ISubProjectConfig, IXtextGeneratorFileSystemAccess>() {
-      @Override
-      public IXtextGeneratorFileSystemAccess apply(final ISubProjectConfig it) {
-        return it.getSrcGen();
+    try {
+      if ((!this.enabled)) {
+        return;
       }
-    };
-    List<IXtextGeneratorFileSystemAccess> _map = ListExtensions.map(_enabledProjects, _function);
-    IRuntimeProjectConfig _runtime = this.config.getRuntime();
-    IXtextGeneratorFileSystemAccess _ecoreModel = _runtime.getEcoreModel();
-    Iterable<IXtextGeneratorFileSystemAccess> _plus = Iterables.<IXtextGeneratorFileSystemAccess>concat(_map, Collections.<IXtextGeneratorFileSystemAccess>unmodifiableList(CollectionLiterals.<IXtextGeneratorFileSystemAccess>newArrayList(_ecoreModel)));
-    Iterable<IXtextGeneratorFileSystemAccess> _filterNull = IterableExtensions.<IXtextGeneratorFileSystemAccess>filterNull(_plus);
-    final Function1<IXtextGeneratorFileSystemAccess, String> _function_1 = new Function1<IXtextGeneratorFileSystemAccess, String>() {
-      @Override
-      public String apply(final IXtextGeneratorFileSystemAccess it) {
-        return it.getPath();
-      }
-    };
-    Iterable<String> _map_1 = IterableExtensions.<IXtextGeneratorFileSystemAccess, String>map(_filterNull, _function_1);
-    final Function1<String, Boolean> _function_2 = new Function1<String, Boolean>() {
-      @Override
-      public Boolean apply(final String it) {
-        File _file = new File(it);
-        return Boolean.valueOf(_file.isDirectory());
-      }
-    };
-    Iterable<String> _filter = IterableExtensions.<String>filter(_map_1, _function_2);
-    Iterables.<String>addAll(directories, _filter);
-    Iterables.<String>addAll(directories, this.extraDirectories);
-    final DirectoryCleaner delegate = new DirectoryCleaner();
-    delegate.setUseDefaultExcludes(this.useDefaultExcludes);
-    final Procedure1<String> _function_3 = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
+      final ArrayList<String> directories = CollectionLiterals.<String>newArrayList();
+      List<? extends ISubProjectConfig> _enabledProjects = this.config.getEnabledProjects();
+      final Function1<ISubProjectConfig, IXtextGeneratorFileSystemAccess> _function = new Function1<ISubProjectConfig, IXtextGeneratorFileSystemAccess>() {
+        @Override
+        public IXtextGeneratorFileSystemAccess apply(final ISubProjectConfig it) {
+          return it.getSrcGen();
+        }
+      };
+      List<IXtextGeneratorFileSystemAccess> _map = ListExtensions.map(_enabledProjects, _function);
+      IRuntimeProjectConfig _runtime = this.config.getRuntime();
+      IXtextGeneratorFileSystemAccess _ecoreModel = _runtime.getEcoreModel();
+      Iterable<IXtextGeneratorFileSystemAccess> _plus = Iterables.<IXtextGeneratorFileSystemAccess>concat(_map, Collections.<IXtextGeneratorFileSystemAccess>unmodifiableList(CollectionLiterals.<IXtextGeneratorFileSystemAccess>newArrayList(_ecoreModel)));
+      Iterable<IXtextGeneratorFileSystemAccess> _filterNull = IterableExtensions.<IXtextGeneratorFileSystemAccess>filterNull(_plus);
+      final Function1<IXtextGeneratorFileSystemAccess, String> _function_1 = new Function1<IXtextGeneratorFileSystemAccess, String>() {
+        @Override
+        public String apply(final IXtextGeneratorFileSystemAccess it) {
+          return it.getPath();
+        }
+      };
+      Iterable<String> _map_1 = IterableExtensions.<IXtextGeneratorFileSystemAccess, String>map(_filterNull, _function_1);
+      final Function1<String, Boolean> _function_2 = new Function1<String, Boolean>() {
+        @Override
+        public Boolean apply(final String it) {
+          File _file = new File(it);
+          return Boolean.valueOf(_file.isDirectory());
+        }
+      };
+      Iterable<String> _filter = IterableExtensions.<String>filter(_map_1, _function_2);
+      Iterables.<String>addAll(directories, _filter);
+      Iterables.<String>addAll(directories, this.extraDirectories);
+      final DirectoryCleaner delegate = new DirectoryCleaner();
+      delegate.setUseDefaultExcludes(this.useDefaultExcludes);
+      for (final String it : this.excludes) {
         delegate.addExclude(it);
       }
-    };
-    IterableExtensions.<String>forEach(this.excludes, _function_3);
-    final Procedure1<String> _function_4 = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
-        try {
-          delegate.cleanFolder(it);
-        } catch (Throwable _e) {
-          throw Exceptions.sneakyThrow(_e);
-        }
+      for (final String it_1 : directories) {
+        delegate.cleanFolder(it_1);
       }
-    };
-    IterableExtensions.<String>forEach(directories, _function_4);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
   }
   
   @Override

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGenerator.java
@@ -229,13 +229,9 @@ public class XtextGenerator extends AbstractWorkflowComponent2 {
   private void handleException(final Exception ex, final Issues issues) {
     if ((ex instanceof CompositeGeneratorException)) {
       List<Exception> _exceptions = ((CompositeGeneratorException)ex).getExceptions();
-      final Procedure1<Exception> _function = new Procedure1<Exception>() {
-        @Override
-        public void apply(final Exception it) {
-          XtextGenerator.this.handleException(it, issues);
-        }
-      };
-      IterableExtensions.<Exception>forEach(_exceptions, _function);
+      for (final Exception it : _exceptions) {
+        this.handleException(it, issues);
+      }
     } else {
       issues.addError(this, "GeneratorException: ", null, ex, null);
     }

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorResourceSetInitializer.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorResourceSetInitializer.java
@@ -28,7 +28,6 @@ import org.eclipse.xtext.ecore.EcoreSupportStandaloneSetup;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
 import org.eclipse.xtext.util.internal.Log;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
@@ -43,13 +42,9 @@ public class XtextGeneratorResourceSetInitializer {
     delegate.setResourceSet(resourceSet);
     EPackage.Registry _packageRegistry = resourceSet.getPackageRegistry();
     _packageRegistry.put(EcorePackage.eNS_URI, EcorePackage.eINSTANCE);
-    final Procedure1<String> _function = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
-        XtextGeneratorResourceSetInitializer.this.loadResource(it, resourceSet);
-      }
-    };
-    IterableExtensions.<String>forEach(referencedResources, _function);
+    for (final String it : referencedResources) {
+      this.loadResource(it, resourceSet);
+    }
     this.registerGenModels(resourceSet);
     this.registerEPackages(resourceSet);
   }
@@ -183,13 +178,9 @@ public class XtextGeneratorResourceSetInitializer {
         final Resource resource = _resources.get(i);
         EList<EObject> _contents = resource.getContents();
         Iterable<Type> _filter = Iterables.<Type>filter(_contents, type);
-        final Procedure1<Type> _function = new Procedure1<Type>() {
-          @Override
-          public void apply(final Type it) {
-            strategy.apply(it);
-          }
-        };
-        IterableExtensions.<Type>forEach(_filter, _function);
+        for (final Type it : _filter) {
+          strategy.apply(it);
+        }
       }
     }
   }

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorStandaloneSetup.java
@@ -49,24 +49,20 @@ public class XtextGeneratorStandaloneSetup implements IGuiceAwareGeneratorCompon
     final StandaloneSetup delegate = new StandaloneSetup();
     delegate.setScanClassPath(this.scanClasspath);
     Iterable<Pair<String, String>> _projectMappings = this.getProjectMappings();
-    final Procedure1<Pair<String, String>> _function = new Procedure1<Pair<String, String>>() {
-      @Override
-      public void apply(final Pair<String, String> mapping) {
-        ProjectMapping _projectMapping = new ProjectMapping();
-        final Procedure1<ProjectMapping> _function = new Procedure1<ProjectMapping>() {
-          @Override
-          public void apply(final ProjectMapping it) {
-            String _key = mapping.getKey();
-            it.setProjectName(_key);
-            String _value = mapping.getValue();
-            it.setPath(_value);
-          }
-        };
-        ProjectMapping _doubleArrow = ObjectExtensions.<ProjectMapping>operator_doubleArrow(_projectMapping, _function);
-        delegate.addProjectMapping(_doubleArrow);
-      }
-    };
-    IterableExtensions.<Pair<String, String>>forEach(_projectMappings, _function);
+    for (final Pair<String, String> mapping : _projectMappings) {
+      ProjectMapping _projectMapping = new ProjectMapping();
+      final Procedure1<ProjectMapping> _function = new Procedure1<ProjectMapping>() {
+        @Override
+        public void apply(final ProjectMapping it) {
+          String _key = mapping.getKey();
+          it.setProjectName(_key);
+          String _value = mapping.getValue();
+          it.setPath(_value);
+        }
+      };
+      ProjectMapping _doubleArrow = ObjectExtensions.<ProjectMapping>operator_doubleArrow(_projectMapping, _function);
+      delegate.addProjectMapping(_doubleArrow);
+    }
   }
   
   private Iterable<Pair<String, String>> getProjectMappings() {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/idea/IdeaPluginGenerator.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/idea/IdeaPluginGenerator.java
@@ -59,7 +59,6 @@ import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.IteratorExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment;
@@ -267,16 +266,13 @@ public class IdeaPluginGenerator extends AbstractStubGeneratingFragment {
     JavaFileAccess _compileFileType = this.compileFileType(grammar);
     JavaFileAccess _compileFacetConfiguration = this.compileFacetConfiguration(grammar);
     JavaFileAccess _compileColorSettingsPage = this.compileColorSettingsPage(grammar);
-    final Procedure1<JavaFileAccess> _function = new Procedure1<JavaFileAccess>() {
-      @Override
-      public void apply(final JavaFileAccess it) {
-        IXtextProjectConfig _projectConfig = IdeaPluginGenerator.this.getProjectConfig();
-        ISubProjectConfig _ideaPlugin = _projectConfig.getIdeaPlugin();
-        IXtextGeneratorFileSystemAccess _src = _ideaPlugin.getSrc();
-        it.writeTo(_src);
-      }
-    };
-    IterableExtensions.<JavaFileAccess>forEach(Collections.<JavaFileAccess>unmodifiableList(CollectionLiterals.<JavaFileAccess>newArrayList(_compileStandaloneSetup, _compileIdeaSetup, _compileCompletionContributor, _compileFileType, _compileFacetConfiguration, _compileColorSettingsPage)), _function);
+    final List<JavaFileAccess> toSrc = Collections.<JavaFileAccess>unmodifiableList(CollectionLiterals.<JavaFileAccess>newArrayList(_compileStandaloneSetup, _compileIdeaSetup, _compileCompletionContributor, _compileFileType, _compileFacetConfiguration, _compileColorSettingsPage));
+    for (final JavaFileAccess it : toSrc) {
+      IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
+      ISubProjectConfig _ideaPlugin_1 = _projectConfig_1.getIdeaPlugin();
+      IXtextGeneratorFileSystemAccess _src = _ideaPlugin_1.getSrc();
+      it.writeTo(_src);
+    }
     TextFileAccess _compileServicesISetup = this.compileServicesISetup(grammar);
     JavaFileAccess _compileAbstractCompletionContributor = this.compileAbstractCompletionContributor(grammar);
     JavaFileAccess _compileLanguage = this.compileLanguage(grammar);
@@ -295,34 +291,31 @@ public class IdeaPluginGenerator extends AbstractStubGeneratingFragment {
     JavaFileAccess _compilePomDeclarationSearcher = this.compilePomDeclarationSearcher(grammar);
     JavaFileAccess _compileFacetType = this.compileFacetType(grammar);
     JavaFileAccess _compileBaseColorSettingsPage = this.compileBaseColorSettingsPage(grammar);
-    final Procedure1<TextFileAccess> _function_1 = new Procedure1<TextFileAccess>() {
-      @Override
-      public void apply(final TextFileAccess it) {
-        IXtextProjectConfig _projectConfig = IdeaPluginGenerator.this.getProjectConfig();
-        ISubProjectConfig _ideaPlugin = _projectConfig.getIdeaPlugin();
-        IXtextGeneratorFileSystemAccess _srcGen = _ideaPlugin.getSrcGen();
-        it.writeTo(_srcGen);
-      }
-    };
-    IterableExtensions.forEach(Collections.<TextFileAccess>unmodifiableList(CollectionLiterals.<TextFileAccess>newArrayList(_compileServicesISetup, _compileAbstractCompletionContributor, _compileLanguage, _compileAbstractFileType, _compileFileTypeFactory, _compileFileImpl, _compileTokenTypeProvider, _compileElementTypeProvider, _compileParserDefinition, _compileSyntaxHighlighterFactory, _compileSemanticHighlightVisitor, _compileExtensionFactory, _compileCodeBlockModificationListener, _compilePsiParser, _compileAntlrTokenFileProvider, _compilePomDeclarationSearcher, _compileFacetType, _compileBaseColorSettingsPage)), _function_1);
+    final List<? extends TextFileAccess> toSrcGen = Collections.<TextFileAccess>unmodifiableList(CollectionLiterals.<TextFileAccess>newArrayList(_compileServicesISetup, _compileAbstractCompletionContributor, _compileLanguage, _compileAbstractFileType, _compileFileTypeFactory, _compileFileImpl, _compileTokenTypeProvider, _compileElementTypeProvider, _compileParserDefinition, _compileSyntaxHighlighterFactory, _compileSemanticHighlightVisitor, _compileExtensionFactory, _compileCodeBlockModificationListener, _compilePsiParser, _compileAntlrTokenFileProvider, _compilePomDeclarationSearcher, _compileFacetType, _compileBaseColorSettingsPage));
+    for (final TextFileAccess it_1 : toSrcGen) {
+      IXtextProjectConfig _projectConfig_2 = this.getProjectConfig();
+      ISubProjectConfig _ideaPlugin_2 = _projectConfig_2.getIdeaPlugin();
+      IXtextGeneratorFileSystemAccess _srcGen = _ideaPlugin_2.getSrcGen();
+      it_1.writeTo(_srcGen);
+    }
     if (this.deployable) {
       final TextFileAccess pluginXml = this.compilePluginXml(grammar);
-      IXtextProjectConfig _projectConfig_1 = this.getProjectConfig();
-      ISubProjectConfig _ideaPlugin_1 = _projectConfig_1.getIdeaPlugin();
-      IXtextGeneratorFileSystemAccess _metaInf = _ideaPlugin_1.getMetaInf();
+      IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();
+      ISubProjectConfig _ideaPlugin_3 = _projectConfig_3.getIdeaPlugin();
+      IXtextGeneratorFileSystemAccess _metaInf = _ideaPlugin_3.getMetaInf();
       String _path = pluginXml.getPath();
       boolean _isFile = _metaInf.isFile(_path);
       boolean _not_1 = (!_isFile);
       if (_not_1) {
-        IXtextProjectConfig _projectConfig_2 = this.getProjectConfig();
-        ISubProjectConfig _ideaPlugin_2 = _projectConfig_2.getIdeaPlugin();
-        IXtextGeneratorFileSystemAccess _metaInf_1 = _ideaPlugin_2.getMetaInf();
+        IXtextProjectConfig _projectConfig_4 = this.getProjectConfig();
+        ISubProjectConfig _ideaPlugin_4 = _projectConfig_4.getIdeaPlugin();
+        IXtextGeneratorFileSystemAccess _metaInf_1 = _ideaPlugin_4.getMetaInf();
         pluginXml.writeTo(_metaInf_1);
       }
       TextFileAccess _compilePluginGenXml = this.compilePluginGenXml(grammar);
-      IXtextProjectConfig _projectConfig_3 = this.getProjectConfig();
-      ISubProjectConfig _ideaPlugin_3 = _projectConfig_3.getIdeaPlugin();
-      IXtextGeneratorFileSystemAccess _metaInf_2 = _ideaPlugin_3.getMetaInf();
+      IXtextProjectConfig _projectConfig_5 = this.getProjectConfig();
+      ISubProjectConfig _ideaPlugin_5 = _projectConfig_5.getIdeaPlugin();
+      IXtextGeneratorFileSystemAccess _metaInf_2 = _ideaPlugin_5.getMetaInf();
       _compilePluginGenXml.writeTo(_metaInf_2);
     }
   }

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/junit/Junit4Fragment2.java
@@ -108,21 +108,17 @@ public class Junit4Fragment2 extends AbstractStubGeneratingFragment {
     IBundleProjectConfig _eclipsePluginTest_2 = _projectConfig_7.getEclipsePluginTest();
     ManifestAccess _manifest_7 = _eclipsePluginTest_2.getManifest();
     Iterable<ManifestAccess> _filterNull = IterableExtensions.<ManifestAccess>filterNull(Collections.<ManifestAccess>unmodifiableList(CollectionLiterals.<ManifestAccess>newArrayList(_manifest_6, _manifest_7)));
-    final Procedure1<ManifestAccess> _function_2 = new Procedure1<ManifestAccess>() {
-      @Override
-      public void apply(final ManifestAccess it) {
-        Set<String> _importedPackages = it.getImportedPackages();
-        CollectionExtensions.<String>addAll(_importedPackages, 
-          "org.junit;version=\"4.5.0\"", 
-          "org.junit.runner;version=\"4.5.0\"", 
-          "org.junit.runner.manipulation;version=\"4.5.0\"", 
-          "org.junit.runner.notification;version=\"4.5.0\"", 
-          "org.junit.runners;version=\"4.5.0\"", 
-          "org.junit.runners.model;version=\"4.5.0\"", 
-          "org.hamcrest.core");
-      }
-    };
-    IterableExtensions.<ManifestAccess>forEach(_filterNull, _function_2);
+    for (final ManifestAccess it : _filterNull) {
+      Set<String> _importedPackages = it.getImportedPackages();
+      CollectionExtensions.<String>addAll(_importedPackages, 
+        "org.junit;version=\"4.5.0\"", 
+        "org.junit.runner;version=\"4.5.0\"", 
+        "org.junit.runner.manipulation;version=\"4.5.0\"", 
+        "org.junit.runner.notification;version=\"4.5.0\"", 
+        "org.junit.runners;version=\"4.5.0\"", 
+        "org.junit.runners.model;version=\"4.5.0\"", 
+        "org.hamcrest.core");
+    }
     JavaFileAccess _generateInjectorProvider = this.generateInjectorProvider();
     IXtextProjectConfig _projectConfig_8 = this.getProjectConfig();
     IBundleProjectConfig _runtimeTest_3 = _projectConfig_8.getRuntimeTest();

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/GeneratedJavaFileAccess.java
@@ -8,7 +8,6 @@ import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.CodeConfig;
 import org.eclipse.xtext.xtext.generator.model.JavaFileAccess;
@@ -54,14 +53,10 @@ public class GeneratedJavaFileAccess extends JavaFileAccess {
     CharSequence _xblockexpression = null;
     {
       Iterable<IClassAnnotation> _classAnnotations = this.getClassAnnotations();
-      final Procedure1<IClassAnnotation> _function = new Procedure1<IClassAnnotation>() {
-        @Override
-        public void apply(final IClassAnnotation it) {
-          TypeReference _annotationImport = it.getAnnotationImport();
-          GeneratedJavaFileAccess.this.importType(_annotationImport);
-        }
-      };
-      IterableExtensions.<IClassAnnotation>forEach(_classAnnotations, _function);
+      for (final IClassAnnotation it : _classAnnotations) {
+        TypeReference _annotationImport = it.getAnnotationImport();
+        this.importType(_annotationImport);
+      }
       _xblockexpression = super.getContent();
     }
     return _xblockexpression;

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/StandardProjectConfig.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/StandardProjectConfig.java
@@ -11,8 +11,6 @@ import com.google.common.base.Objects;
 import java.util.List;
 import org.eclipse.emf.mwe2.runtime.Mandatory;
 import org.eclipse.xtend.lib.annotations.Accessors;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.Issues;
 import org.eclipse.xtext.xtext.generator.model.ManifestAccess;
@@ -65,51 +63,50 @@ public class StandardProjectConfig extends XtextProjectConfig {
   public void setDefaults() {
     super.setDefaults();
     List<? extends SubProjectConfig> _enabledProjects = this.getEnabledProjects();
-    final Procedure1<SubProjectConfig> _function = new Procedure1<SubProjectConfig>() {
-      @Override
-      public void apply(final SubProjectConfig it) {
+    for (final SubProjectConfig it : _enabledProjects) {
+      {
         String _name = it.getName();
         boolean _tripleEquals = (_name == null);
         if (_tripleEquals) {
-          String _computeName = StandardProjectConfig.this.computeName(it);
+          String _computeName = this.computeName(it);
           it.setName(_computeName);
         }
         String _rootPath = it.getRootPath();
         boolean _tripleEquals_1 = (_rootPath == null);
         if (_tripleEquals_1) {
-          String _computeRoot = StandardProjectConfig.this.computeRoot(it);
+          String _computeRoot = this.computeRoot(it);
           it.setRoot(_computeRoot);
         }
         String _metaInfPath = it.getMetaInfPath();
         boolean _tripleEquals_2 = (_metaInfPath == null);
         if (_tripleEquals_2) {
-          String _computeMetaInf = StandardProjectConfig.this.computeMetaInf(it);
+          String _computeMetaInf = this.computeMetaInf(it);
           it.setMetaInf(_computeMetaInf);
         }
         String _srcPath = it.getSrcPath();
         boolean _tripleEquals_3 = (_srcPath == null);
         if (_tripleEquals_3) {
-          String _computeSrc = StandardProjectConfig.this.computeSrc(it);
+          String _computeSrc = this.computeSrc(it);
           it.setSrc(_computeSrc);
         }
         String _srcGenPath = it.getSrcGenPath();
         boolean _tripleEquals_4 = (_srcGenPath == null);
         if (_tripleEquals_4) {
-          String _computeSrcGen = StandardProjectConfig.this.computeSrcGen(it);
+          String _computeSrcGen = this.computeSrcGen(it);
           it.setSrcGen(_computeSrcGen);
         }
         if ((it instanceof BundleProjectConfig)) {
-          if (StandardProjectConfig.this.createEclipseMetaData) {
+          if (this.createEclipseMetaData) {
             ManifestAccess _manifest = ((BundleProjectConfig)it).getManifest();
             boolean _tripleEquals_5 = (_manifest == null);
             if (_tripleEquals_5) {
-              ManifestAccess _newManifestAccess = StandardProjectConfig.this.newManifestAccess();
+              ManifestAccess _newManifestAccess = this.newManifestAccess();
               ((BundleProjectConfig)it).setManifest(_newManifestAccess);
             }
             PluginXmlAccess _pluginXml = ((BundleProjectConfig)it).getPluginXml();
             boolean _tripleEquals_6 = (_pluginXml == null);
             if (_tripleEquals_6) {
-              PluginXmlAccess _newPluginXmlAccess = StandardProjectConfig.this.newPluginXmlAccess();
+              PluginXmlAccess _newPluginXmlAccess = this.newPluginXmlAccess();
               ((BundleProjectConfig)it).setPluginXml(_newPluginXmlAccess);
             }
           }
@@ -118,7 +115,7 @@ public class StandardProjectConfig extends XtextProjectConfig {
           String _ecoreModelPath = ((RuntimeProjectConfig)it).getEcoreModelPath();
           boolean _tripleEquals_7 = (_ecoreModelPath == null);
           if (_tripleEquals_7) {
-            String _computeEcoreModel = StandardProjectConfig.this.computeEcoreModel(((RuntimeProjectConfig)it));
+            String _computeEcoreModel = this.computeEcoreModel(((RuntimeProjectConfig)it));
             ((RuntimeProjectConfig)it).setEcoreModel(_computeEcoreModel);
           }
         }
@@ -126,13 +123,12 @@ public class StandardProjectConfig extends XtextProjectConfig {
           String _assetsPath = ((WebProjectConfig)it).getAssetsPath();
           boolean _tripleEquals_8 = (_assetsPath == null);
           if (_tripleEquals_8) {
-            String _computeAssets = StandardProjectConfig.this.computeAssets(((WebProjectConfig)it));
+            String _computeAssets = this.computeAssets(((WebProjectConfig)it));
             ((WebProjectConfig)it).setAssets(_computeAssets);
           }
         }
       }
-    };
-    IterableExtensions.forEach(_enabledProjects, _function);
+    }
   }
   
   protected String computeName(final SubProjectConfig project) {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/model/project/XtextProjectConfig.java
@@ -16,7 +16,6 @@ import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.Issues;
 import org.eclipse.xtext.xtext.generator.model.ManifestAccess;
@@ -50,13 +49,9 @@ public class XtextProjectConfig implements IXtextProjectConfig {
   
   public void checkConfiguration(final Issues issues) {
     List<? extends SubProjectConfig> _enabledProjects = this.getEnabledProjects();
-    final Procedure1<SubProjectConfig> _function = new Procedure1<SubProjectConfig>() {
-      @Override
-      public void apply(final SubProjectConfig it) {
-        it.checkConfiguration(issues);
-      }
-    };
-    IterableExtensions.forEach(_enabledProjects, _function);
+    for (final SubProjectConfig it : _enabledProjects) {
+      it.checkConfiguration(issues);
+    }
   }
   
   public List<? extends SubProjectConfig> getAllProjects() {
@@ -104,13 +99,9 @@ public class XtextProjectConfig implements IXtextProjectConfig {
     this.setDefaults();
     injector.injectMembers(this);
     List<? extends SubProjectConfig> _enabledProjects = this.getEnabledProjects();
-    final Procedure1<SubProjectConfig> _function = new Procedure1<SubProjectConfig>() {
-      @Override
-      public void apply(final SubProjectConfig it) {
-        it.initialize(injector);
-      }
-    };
-    IterableExtensions.forEach(_enabledProjects, _function);
+    for (final SubProjectConfig it : _enabledProjects) {
+      it.initialize(injector);
+    }
   }
   
   public void setDefaults() {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGeneratorFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/parser/antlr/AbstractAntlrGeneratorFragment2.java
@@ -39,8 +39,6 @@ import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment;
 import org.eclipse.xtext.xtext.generator.CodeConfig;
@@ -223,13 +221,9 @@ public abstract class AbstractAntlrGeneratorFragment2 extends AbstractXtextGener
   }
   
   protected void suppressWarnings(final IXtextGeneratorFileSystemAccess fsa, final TypeReference... types) {
-    final Procedure1<TypeReference> _function = new Procedure1<TypeReference>() {
-      @Override
-      public void apply(final TypeReference it) {
-        AbstractAntlrGeneratorFragment2.this.suppressWarnings(fsa, it);
-      }
-    };
-    IterableExtensions.<TypeReference>forEach(((Iterable<TypeReference>)Conversions.doWrapArray(types)), _function);
+    for (final TypeReference it : types) {
+      this.suppressWarnings(fsa, it);
+    }
   }
   
   protected void normalizeLineDelimiters(final IXtextGeneratorFileSystemAccess fsa, final TypeReference type) {
@@ -248,13 +242,9 @@ public abstract class AbstractAntlrGeneratorFragment2 extends AbstractXtextGener
   }
   
   protected void normalizeLineDelimiters(final IXtextGeneratorFileSystemAccess fsa, final TypeReference... types) {
-    final Procedure1<TypeReference> _function = new Procedure1<TypeReference>() {
-      @Override
-      public void apply(final TypeReference it) {
-        AbstractAntlrGeneratorFragment2.this.normalizeLineDelimiters(fsa, it);
-      }
-    };
-    IterableExtensions.<TypeReference>forEach(((Iterable<TypeReference>)Conversions.doWrapArray(types)), _function);
+    for (final TypeReference it : types) {
+      this.normalizeLineDelimiters(fsa, it);
+    }
   }
   
   protected void normalizeTokens(final IXtextGeneratorFileSystemAccess fsa, final String tokenFile) {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/serializer/SerializerFragment2.java
@@ -72,7 +72,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.eclipse.xtext.xbase.lib.Pair;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.generator.AbstractStubGeneratingFragment;
 import org.eclipse.xtext.xtext.generator.IXtextGeneratorLanguage;
@@ -954,14 +953,10 @@ public class SerializerFragment2 extends AbstractStubGeneratingFragment {
     {
       final List<ISerializationContext> sorted = IterableExtensions.<ISerializationContext>sort(contexts);
       final LinkedHashMultimap<EObject, ISerializationContext> index = LinkedHashMultimap.<EObject, ISerializationContext>create();
-      final Procedure1<ISerializationContext> _function = new Procedure1<ISerializationContext>() {
-        @Override
-        public void apply(final ISerializationContext it) {
-          EObject _contextObject = SerializerFragment2.this.getContextObject(it);
-          index.put(_contextObject, it);
-        }
-      };
-      IterableExtensions.<ISerializationContext>forEach(sorted, _function);
+      for (final ISerializationContext it : sorted) {
+        EObject _contextObject = this.getContextObject(it);
+        index.put(_contextObject, it);
+      }
       StringConcatenationClient _client = new StringConcatenationClient() {
         @Override
         protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/web/WebIntegrationFragment.java
@@ -36,7 +36,6 @@ import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function0;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment;
@@ -451,19 +450,15 @@ public class WebIntegrationFragment extends AbstractXtextGeneratorFragment {
       }
     };
     Iterable<String> _filter = IterableExtensions.<String>filter(allKeywords, _function);
-    final Procedure1<String> _function_1 = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
-        Matcher _matcher = wordKeywordPattern.matcher(it);
-        boolean _matches = _matcher.matches();
-        if (_matches) {
-          wordKeywords.add(it);
-        } else {
-          nonWordKeywords.add(it);
-        }
+    for (final String it : _filter) {
+      Matcher _matcher = wordKeywordPattern.matcher(it);
+      boolean _matches = _matcher.matches();
+      if (_matches) {
+        wordKeywords.add(it);
+      } else {
+        nonWordKeywords.add(it);
       }
-    };
-    IterableExtensions.<String>forEach(_filter, _function_1);
+    }
     Collections.<String>sort(wordKeywords);
     Collections.<String>sort(nonWordKeywords);
     final TextFileAccess jsFile = this.fileAccessFactory.createTextFile();

--- a/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
+++ b/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
@@ -192,7 +192,8 @@ class AdvancedNewProjectPage extends WizardPage {
 				reportIssue(ERROR, '''
 				Frontend projects like '«affectedProjects»' depends on '«createIdeProject.text»' project.
 				Please <a>deselect</a> these.''', [
-					dependend.forEach[selection = false]
+					for (it : dependend)
+						selection = false
 				])
 			} else {
 				reportIssue(ERROR, '''

--- a/plugins/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
+++ b/plugins/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
@@ -469,13 +469,9 @@ public class AdvancedNewProjectPage extends WizardPage {
             final Procedure0 _function_9 = new Procedure0() {
               @Override
               public void apply() {
-                final Procedure1<Button> _function = new Procedure1<Button>() {
-                  @Override
-                  public void apply(final Button it) {
-                    it.setSelection(false);
-                  }
-                };
-                IterableExtensions.<Button>forEach(dependend, _function);
+                for (final Button it : dependend) {
+                  it.setSelection(false);
+                }
               }
             };
             _xifexpression_1 = this.<Control>reportIssue(IMessageProvider.ERROR, _builder_6.toString(), _function_9);

--- a/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/cli/CliProjectsCreator.xtend
+++ b/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/cli/CliProjectsCreator.xtend
@@ -23,15 +23,14 @@ class CliProjectsCreator implements ProjectsCreator {
 	@Accessors String lineDelimiter
 
 	override createProjects(WizardConfiguration config) {
-		config.enabledProjects.forEach [
+		for (it : config.enabledProjects)
 			createProject
-		]
 	}
 
 	def createProject(ProjectDescriptor project) {
 		val projectRoot = new File(project.location)
 		projectRoot.mkdirs
-		project.files.forEach [
+		for (it : project.files) {
 			val projectRelativePath = project.config.sourceLayout.getPathFor(outlet) + "/" + relativePath
 			val file = new File(projectRoot, projectRelativePath)
 			file.parentFile.mkdirs
@@ -47,10 +46,9 @@ class CliProjectsCreator implements ProjectsCreator {
 			if(executable) {
 				file.executable = true
 			}
-		]
-		project.sourceFolders.forEach [
+		}
+		for (it : project.sourceFolders)
 			new File(projectRoot, it).mkdirs
-		]
 	}
 
 }

--- a/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextExtensions.xtend
+++ b/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextExtensions.xtend
@@ -71,7 +71,8 @@ class Ecore2XtextExtensions {
 			return
 		else {
 			acceptor += classifiers
-			classifiers.filter(EClass).forEach([c|allAssignedClassifiers(c, acceptor)])
+			for (c : classifiers.filter(EClass))
+				allAssignedClassifiers(c, acceptor)
 		}
 	}
 

--- a/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/cli/CliProjectsCreator.java
+++ b/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/cli/CliProjectsCreator.java
@@ -16,8 +16,6 @@ import java.util.Set;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.wizard.AbstractFile;
 import org.eclipse.xtext.xtext.wizard.BinaryFile;
@@ -36,24 +34,19 @@ public class CliProjectsCreator implements ProjectsCreator {
   @Override
   public void createProjects(final WizardConfiguration config) {
     Set<ProjectDescriptor> _enabledProjects = config.getEnabledProjects();
-    final Procedure1<ProjectDescriptor> _function = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
-        CliProjectsCreator.this.createProject(it);
-      }
-    };
-    IterableExtensions.<ProjectDescriptor>forEach(_enabledProjects, _function);
+    for (final ProjectDescriptor it : _enabledProjects) {
+      this.createProject(it);
+    }
   }
   
   public void createProject(final ProjectDescriptor project) {
-    String _location = project.getLocation();
-    final File projectRoot = new File(_location);
-    projectRoot.mkdirs();
-    Iterable<? extends AbstractFile> _files = project.getFiles();
-    final Procedure1<AbstractFile> _function = new Procedure1<AbstractFile>() {
-      @Override
-      public void apply(final AbstractFile it) {
-        try {
+    try {
+      String _location = project.getLocation();
+      final File projectRoot = new File(_location);
+      projectRoot.mkdirs();
+      Iterable<? extends AbstractFile> _files = project.getFiles();
+      for (final AbstractFile it : _files) {
+        {
           WizardConfiguration _config = project.getConfig();
           SourceLayout _sourceLayout = _config.getSourceLayout();
           Outlet _outlet = it.getOutlet();
@@ -70,7 +63,7 @@ public class CliProjectsCreator implements ProjectsCreator {
               _matched=true;
               String _content = ((TextFile)it).getContent();
               String _newLine = Strings.newLine();
-              final String normalizedContent = _content.replace(_newLine, CliProjectsCreator.this.lineDelimiter);
+              final String normalizedContent = _content.replace(_newLine, this.lineDelimiter);
               WizardConfiguration _config_1 = project.getConfig();
               Charset _encoding = _config_1.getEncoding();
               Files.write(normalizedContent, file, _encoding);
@@ -88,21 +81,16 @@ public class CliProjectsCreator implements ProjectsCreator {
           if (_isExecutable) {
             file.setExecutable(true);
           }
-        } catch (Throwable _e) {
-          throw Exceptions.sneakyThrow(_e);
         }
       }
-    };
-    IterableExtensions.forEach(_files, _function);
-    Set<String> _sourceFolders = project.getSourceFolders();
-    final Procedure1<String> _function_1 = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
-        File _file = new File(projectRoot, it);
+      Set<String> _sourceFolders = project.getSourceFolders();
+      for (final String it_1 : _sourceFolders) {
+        File _file = new File(projectRoot, it_1);
         _file.mkdirs();
       }
-    };
-    IterableExtensions.<String>forEach(_sourceFolders, _function_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
   }
   
   @Pure

--- a/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextExtensions.java
+++ b/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextExtensions.java
@@ -24,7 +24,6 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xtext.wizard.EPackageInfo;
 import org.eclipse.xtext.xtext.wizard.Ecore2XtextConfiguration;
 import org.eclipse.xtext.xtext.wizard.ecore2xtext.UniqueNameUtil;
@@ -233,13 +232,9 @@ public class Ecore2XtextExtensions {
     } else {
       Iterables.<EClassifier>addAll(acceptor, classifiers);
       Iterable<EClass> _filter_1 = Iterables.<EClass>filter(classifiers, EClass.class);
-      final Procedure1<EClass> _function_2 = new Procedure1<EClass>() {
-        @Override
-        public void apply(final EClass c) {
-          Ecore2XtextExtensions.allAssignedClassifiers(c, acceptor);
-        }
-      };
-      IterableExtensions.<EClass>forEach(_filter_1, _function_2);
+      for (final EClass c : _filter_1) {
+        Ecore2XtextExtensions.allAssignedClassifiers(c, acceptor);
+      }
     }
   }
   

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/build/IncrementalBuilder.xtend
@@ -58,8 +58,8 @@ import org.eclipse.xtext.generator.GeneratorContext
 		
 		def Result launch() {
 			val newSource2GeneratedMapping = request.state.fileMappings
-			request.deletedFiles.forEach [ source |
-				newSource2GeneratedMapping.deleteSource(source).forEach [ generated |
+			for (source : request.deletedFiles) {
+				for (generated : newSource2GeneratedMapping.deleteSource(source)) {
 					if (LOG.isInfoEnabled)
 						LOG.info("Deleting " + generated)
 					val serviceProvider = context.getResourceServiceProvider(source)
@@ -70,8 +70,8 @@ import org.eclipse.xtext.generator.GeneratorContext
 						context.resourceSet.getURIConverter.delete(generated, emptyMap)
 						request.afterDeleteFile.apply(generated)
 					}
-				]
-			]
+				}
+			}
 			val result = indexer.computeAndIndexAffected(request, context)
 			request.cancelIndicator.checkCanceled
 			val resolvedDeltas = newArrayList
@@ -146,11 +146,11 @@ import org.eclipse.xtext.generator.GeneratorContext
 			generatorContext.cancelIndicator = request.cancelIndicator
 			generator.generate(resource, fileSystemAccess, generatorContext)
 			// delete everything that was previously generated, but not this time
-			previous.forEach[
+			for (it : previous) {
 				LOG.info('Deleting stale generated file ' + it)
 				context.resourceSet.getURIConverter.delete(it, emptyMap)
 				request.getAfterDeleteFile.apply(it)
-			]
+			}
 		}
 	
 		protected def createFileSystemAccess(IResourceServiceProvider serviceProvider, Resource resource) {

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/build/Indexer.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/build/Indexer.xtend
@@ -88,14 +88,14 @@ import org.eclipse.xtext.service.OperationCanceledManager
 	protected def List<Delta> getDeltasForDeletedResources(BuildRequest request, ResourceDescriptionsData oldIndex,
 		extension BuildContext context) {
 		val deltas = <Delta>newArrayList()
-		request.deletedFiles.filter[context.getResourceServiceProvider(it) != null].forEach [
+		for (it : request.deletedFiles.filter[context.getResourceServiceProvider(it) != null]) {
 			context.cancelIndicator.checkCanceled
 			val IResourceDescription oldDescription = oldIndex?.getResourceDescription(it)
 			if (oldDescription != null) {
 				val delta = new DefaultResourceDescriptionDelta(oldDescription, null)
 				deltas += delta
 			}
-		]
+		}
 		return deltas
 	}
 

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/build/Source2GeneratedMapping.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/build/Source2GeneratedMapping.xtend
@@ -57,16 +57,14 @@ import org.eclipse.xtext.generator.IFileSystemAccess
 	
 	def Set<URI> deleteSource(URI source) {
 		val generated = new HashSet<URI>(source2generated.removeAll(source))
-		generated.forEach[
+		for (it : generated)
 			generated2source.remove(it, source)
-		]
 		return generated
 	}
 
 	def void deleteGenerated(URI generated) {
-		generated2source.removeAll(generated).forEach[
+		for (it : generated2source.removeAll(generated))
 			source2generated.remove(it, generated)
-		]
 		generated2OutputConfigName.remove(generated)
 	}
 	
@@ -102,13 +100,13 @@ import org.eclipse.xtext.generator.IFileSystemAccess
 	override writeExternal(ObjectOutput out) throws IOException {
 		val entries = source2generated.asMap.entrySet
 		out.writeInt(entries.size)
-		entries.forEach [
+		for (it : entries) {
 			out.writeUTF(key.toString)
 			out.writeInt(value.size)
-			value.forEach[
+			for (it : value) {
 				out.writeUTF(toString)
-				out.writeUTF(generated2OutputConfigName.get(it)?:IFileSystemAccess.DEFAULT_OUTPUT)
-			]
-		]		
+				out.writeUTF(generated2OutputConfigName.get(it) ?: IFileSystemAccess.DEFAULT_OUTPUT)
+			}
+		}
 	}
 }

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/ChunkedResourceDescriptions.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/resource/impl/ChunkedResourceDescriptions.xtend
@@ -130,19 +130,18 @@ import org.eclipse.xtext.util.internal.EmfAdaptable
 	override writeExternal(ObjectOutput out) throws IOException {
 		val copy = new HashMap(chunk2resourceDescriptions)
 		out.writeInt(copy.entrySet.size)
-		copy.entrySet.forEach[
+		for (it : copy.entrySet) {
 			out.writeUTF(key)
-			val descriptions = value.allResourceDescriptions.map[
-				if(it instanceof Serializable)
+			val descriptions = value.allResourceDescriptions.map [
+				if (it instanceof Serializable)
 					it
-				else 
+				else
 					SerializableResourceDescription.createCopy(it)
-			] 
-			out.writeInt(descriptions.size)
-			descriptions.forEach[
-				out.writeObject(it)
 			]
-		]
+			out.writeInt(descriptions.size)
+			for (it : descriptions)
+				out.writeObject(it)
+		}
 	}
 }
 	

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/tasks/DefaultTaskFinder.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/tasks/DefaultTaskFinder.xtend
@@ -46,10 +46,10 @@ class DefaultTaskFinder implements ITaskFinder {
 		if (node.canContainTaskTags) {
 			//TODO strip comment characters before parsing, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=380449#c13
 			val tasks = parser.parseTasks(node.text, taskTags)
-			tasks.forEach [
+			for (it : tasks) {
 				offset = offset + node.offset
 				lineNumber = lineNumber + node.startLine - 1
-			]
+			}
 			return tasks
 		}
 		return #[]

--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/FlattenedGrammarAccess.xtend
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/xtext/FlattenedGrammarAccess.xtend
@@ -89,15 +89,15 @@ class FlattenedGrammarAccess {
 	}
 
 	def private void markAsFragment(Multimap<TerminalRule, AbstractRule> calledFrom) {
-		calledFrom.keySet.filter [
+		val terminals = calledFrom.keySet.filter [
 			!isFragment
 		].filter [
 			allAreTerminalRules(calledFrom.get(it))
 		].filter [
 			!(it.eContainer as Grammar).hiddenTokens.contains(it)
-		].forEach [
-			fragment = true
 		]
+		for (it : terminals)
+			fragment = true
 	}
 
 	def private Multimap<TerminalRule, AbstractRule> copyRuleBodies(

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/IncrementalBuilder.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/IncrementalBuilder.java
@@ -159,141 +159,135 @@ public class IncrementalBuilder {
     private OperationCanceledManager _operationCanceledManager;
     
     public IncrementalBuilder.Result launch() {
-      IndexState _state = this.request.getState();
-      final Source2GeneratedMapping newSource2GeneratedMapping = _state.getFileMappings();
-      List<URI> _deletedFiles = this.request.getDeletedFiles();
-      final Procedure1<URI> _function = new Procedure1<URI>() {
-        @Override
-        public void apply(final URI source) {
+      try {
+        IndexState _state = this.request.getState();
+        final Source2GeneratedMapping newSource2GeneratedMapping = _state.getFileMappings();
+        List<URI> _deletedFiles = this.request.getDeletedFiles();
+        for (final URI source : _deletedFiles) {
           Set<URI> _deleteSource = newSource2GeneratedMapping.deleteSource(source);
-          final Procedure1<URI> _function = new Procedure1<URI>() {
-            @Override
-            public void apply(final URI generated) {
-              try {
-                boolean _isInfoEnabled = IncrementalBuilder.InternalStatefulIncrementalBuilder.LOG.isInfoEnabled();
-                if (_isInfoEnabled) {
-                  IncrementalBuilder.InternalStatefulIncrementalBuilder.LOG.info(("Deleting " + generated));
+          for (final URI generated : _deleteSource) {
+            {
+              boolean _isInfoEnabled = IncrementalBuilder.InternalStatefulIncrementalBuilder.LOG.isInfoEnabled();
+              if (_isInfoEnabled) {
+                IncrementalBuilder.InternalStatefulIncrementalBuilder.LOG.info(("Deleting " + generated));
+              }
+              final IResourceServiceProvider serviceProvider = this.context.getResourceServiceProvider(source);
+              IContextualOutputConfigurationProvider2 _get = serviceProvider.<IContextualOutputConfigurationProvider2>get(IContextualOutputConfigurationProvider2.class);
+              XtextResourceSet _resourceSet = this.request.getResourceSet();
+              final Set<OutputConfiguration> configs = _get.getOutputConfigurations(_resourceSet);
+              final String configName = newSource2GeneratedMapping.getOutputConfigName(generated);
+              final Function1<OutputConfiguration, Boolean> _function = new Function1<OutputConfiguration, Boolean>() {
+                @Override
+                public Boolean apply(final OutputConfiguration it) {
+                  String _name = it.getName();
+                  return Boolean.valueOf(Objects.equal(_name, configName));
                 }
-                final IResourceServiceProvider serviceProvider = InternalStatefulIncrementalBuilder.this.context.getResourceServiceProvider(source);
-                IContextualOutputConfigurationProvider2 _get = serviceProvider.<IContextualOutputConfigurationProvider2>get(IContextualOutputConfigurationProvider2.class);
-                XtextResourceSet _resourceSet = InternalStatefulIncrementalBuilder.this.request.getResourceSet();
-                final Set<OutputConfiguration> configs = _get.getOutputConfigurations(_resourceSet);
-                final String configName = newSource2GeneratedMapping.getOutputConfigName(generated);
-                final Function1<OutputConfiguration, Boolean> _function = new Function1<OutputConfiguration, Boolean>() {
-                  @Override
-                  public Boolean apply(final OutputConfiguration it) {
-                    String _name = it.getName();
-                    return Boolean.valueOf(Objects.equal(_name, configName));
-                  }
-                };
-                final OutputConfiguration config = IterableExtensions.<OutputConfiguration>findFirst(configs, _function);
-                boolean _and = false;
-                boolean _notEquals = (!Objects.equal(config, null));
-                if (!_notEquals) {
-                  _and = false;
-                } else {
-                  boolean _isCleanUpDerivedResources = config.isCleanUpDerivedResources();
-                  _and = _isCleanUpDerivedResources;
-                }
-                if (_and) {
-                  XtextResourceSet _resourceSet_1 = InternalStatefulIncrementalBuilder.this.context.getResourceSet();
-                  URIConverter _uRIConverter = _resourceSet_1.getURIConverter();
-                  Map<Object, Object> _emptyMap = CollectionLiterals.<Object, Object>emptyMap();
-                  _uRIConverter.delete(generated, _emptyMap);
-                  Procedure1<? super URI> _afterDeleteFile = InternalStatefulIncrementalBuilder.this.request.getAfterDeleteFile();
-                  _afterDeleteFile.apply(generated);
-                }
-              } catch (Throwable _e) {
-                throw Exceptions.sneakyThrow(_e);
+              };
+              final OutputConfiguration config = IterableExtensions.<OutputConfiguration>findFirst(configs, _function);
+              boolean _and = false;
+              boolean _notEquals = (!Objects.equal(config, null));
+              if (!_notEquals) {
+                _and = false;
+              } else {
+                boolean _isCleanUpDerivedResources = config.isCleanUpDerivedResources();
+                _and = _isCleanUpDerivedResources;
+              }
+              if (_and) {
+                XtextResourceSet _resourceSet_1 = this.context.getResourceSet();
+                URIConverter _uRIConverter = _resourceSet_1.getURIConverter();
+                Map<Object, Object> _emptyMap = CollectionLiterals.<Object, Object>emptyMap();
+                _uRIConverter.delete(generated, _emptyMap);
+                Procedure1<? super URI> _afterDeleteFile = this.request.getAfterDeleteFile();
+                _afterDeleteFile.apply(generated);
               }
             }
-          };
-          IterableExtensions.<URI>forEach(_deleteSource, _function);
-        }
-      };
-      IterableExtensions.<URI>forEach(_deletedFiles, _function);
-      final Indexer.IndexResult result = this.indexer.computeAndIndexAffected(this.request, this.context);
-      CancelIndicator _cancelIndicator = this.request.getCancelIndicator();
-      this._operationCanceledManager.checkCanceled(_cancelIndicator);
-      final ArrayList<IResourceDescription.Delta> resolvedDeltas = CollectionLiterals.<IResourceDescription.Delta>newArrayList();
-      List<IResourceDescription.Delta> _resourceDeltas = result.getResourceDeltas();
-      final Function1<IResourceDescription.Delta, Boolean> _function_1 = new Function1<IResourceDescription.Delta, Boolean>() {
-        @Override
-        public Boolean apply(final IResourceDescription.Delta it) {
-          IResourceDescription _new = it.getNew();
-          return Boolean.valueOf(Objects.equal(_new, null));
-        }
-      };
-      Iterable<IResourceDescription.Delta> _filter = IterableExtensions.<IResourceDescription.Delta>filter(_resourceDeltas, _function_1);
-      Iterables.<IResourceDescription.Delta>addAll(resolvedDeltas, _filter);
-      List<IResourceDescription.Delta> _resourceDeltas_1 = result.getResourceDeltas();
-      final Function1<IResourceDescription.Delta, Boolean> _function_2 = new Function1<IResourceDescription.Delta, Boolean>() {
-        @Override
-        public Boolean apply(final IResourceDescription.Delta it) {
-          IResourceDescription _new = it.getNew();
-          return Boolean.valueOf((!Objects.equal(_new, null)));
-        }
-      };
-      Iterable<IResourceDescription.Delta> _filter_1 = IterableExtensions.<IResourceDescription.Delta>filter(_resourceDeltas_1, _function_2);
-      final Function1<IResourceDescription.Delta, URI> _function_3 = new Function1<IResourceDescription.Delta, URI>() {
-        @Override
-        public URI apply(final IResourceDescription.Delta it) {
-          return it.getUri();
-        }
-      };
-      Iterable<URI> _map = IterableExtensions.<IResourceDescription.Delta, URI>map(_filter_1, _function_3);
-      final Function1<Resource, IResourceDescription.Delta> _function_4 = new Function1<Resource, IResourceDescription.Delta>() {
-        @Override
-        public IResourceDescription.Delta apply(final Resource resource) {
-          CancelIndicator _cancelIndicator = InternalStatefulIncrementalBuilder.this.request.getCancelIndicator();
-          InternalStatefulIncrementalBuilder.this._operationCanceledManager.checkCanceled(_cancelIndicator);
-          resource.getContents();
-          EcoreUtil2.resolveLazyCrossReferences(resource, CancelIndicator.NullImpl);
-          CancelIndicator _cancelIndicator_1 = InternalStatefulIncrementalBuilder.this.request.getCancelIndicator();
-          InternalStatefulIncrementalBuilder.this._operationCanceledManager.checkCanceled(_cancelIndicator_1);
-          URI _uRI = resource.getURI();
-          final IResourceServiceProvider serviceProvider = InternalStatefulIncrementalBuilder.this.context.getResourceServiceProvider(_uRI);
-          final IResourceDescription.Manager manager = serviceProvider.getResourceDescriptionManager();
-          final IResourceDescription description = manager.getResourceDescription(resource);
-          final SerializableResourceDescription copiedDescription = SerializableResourceDescription.createCopy(description);
-          ResourceDescriptionsData _newIndex = result.getNewIndex();
-          URI _uRI_1 = resource.getURI();
-          _newIndex.addDescription(_uRI_1, copiedDescription);
-          CancelIndicator _cancelIndicator_2 = InternalStatefulIncrementalBuilder.this.request.getCancelIndicator();
-          InternalStatefulIncrementalBuilder.this._operationCanceledManager.checkCanceled(_cancelIndicator_2);
-          boolean _and = false;
-          boolean _and_1 = false;
-          boolean _isIndexOnly = InternalStatefulIncrementalBuilder.this.request.isIndexOnly();
-          boolean _not = (!_isIndexOnly);
-          if (!_not) {
-            _and_1 = false;
-          } else {
-            boolean _validate = InternalStatefulIncrementalBuilder.this.validate(resource);
-            _and_1 = _validate;
           }
-          if (!_and_1) {
-            _and = false;
-          } else {
-            IShouldGenerate _get = serviceProvider.<IShouldGenerate>get(IShouldGenerate.class);
-            boolean _shouldGenerate = _get.shouldGenerate(resource, CancelIndicator.NullImpl);
-            _and = _shouldGenerate;
-          }
-          if (_and) {
-            CancelIndicator _cancelIndicator_3 = InternalStatefulIncrementalBuilder.this.request.getCancelIndicator();
-            InternalStatefulIncrementalBuilder.this._operationCanceledManager.checkCanceled(_cancelIndicator_3);
-            InternalStatefulIncrementalBuilder.this.generate(resource, InternalStatefulIncrementalBuilder.this.request, newSource2GeneratedMapping);
-          }
-          IndexState _oldState = InternalStatefulIncrementalBuilder.this.context.getOldState();
-          ResourceDescriptionsData _resourceDescriptions = _oldState.getResourceDescriptions();
-          URI _uRI_2 = resource.getURI();
-          final IResourceDescription old = _resourceDescriptions.getResourceDescription(_uRI_2);
-          return manager.createDelta(old, copiedDescription);
         }
-      };
-      Iterable<IResourceDescription.Delta> _executeClustered = this.context.<IResourceDescription.Delta>executeClustered(_map, _function_4);
-      Iterables.<IResourceDescription.Delta>addAll(resolvedDeltas, _executeClustered);
-      IndexState _state_1 = this.request.getState();
-      return new IncrementalBuilder.Result(_state_1, resolvedDeltas);
+        final Indexer.IndexResult result = this.indexer.computeAndIndexAffected(this.request, this.context);
+        CancelIndicator _cancelIndicator = this.request.getCancelIndicator();
+        this._operationCanceledManager.checkCanceled(_cancelIndicator);
+        final ArrayList<IResourceDescription.Delta> resolvedDeltas = CollectionLiterals.<IResourceDescription.Delta>newArrayList();
+        List<IResourceDescription.Delta> _resourceDeltas = result.getResourceDeltas();
+        final Function1<IResourceDescription.Delta, Boolean> _function = new Function1<IResourceDescription.Delta, Boolean>() {
+          @Override
+          public Boolean apply(final IResourceDescription.Delta it) {
+            IResourceDescription _new = it.getNew();
+            return Boolean.valueOf(Objects.equal(_new, null));
+          }
+        };
+        Iterable<IResourceDescription.Delta> _filter = IterableExtensions.<IResourceDescription.Delta>filter(_resourceDeltas, _function);
+        Iterables.<IResourceDescription.Delta>addAll(resolvedDeltas, _filter);
+        List<IResourceDescription.Delta> _resourceDeltas_1 = result.getResourceDeltas();
+        final Function1<IResourceDescription.Delta, Boolean> _function_1 = new Function1<IResourceDescription.Delta, Boolean>() {
+          @Override
+          public Boolean apply(final IResourceDescription.Delta it) {
+            IResourceDescription _new = it.getNew();
+            return Boolean.valueOf((!Objects.equal(_new, null)));
+          }
+        };
+        Iterable<IResourceDescription.Delta> _filter_1 = IterableExtensions.<IResourceDescription.Delta>filter(_resourceDeltas_1, _function_1);
+        final Function1<IResourceDescription.Delta, URI> _function_2 = new Function1<IResourceDescription.Delta, URI>() {
+          @Override
+          public URI apply(final IResourceDescription.Delta it) {
+            return it.getUri();
+          }
+        };
+        Iterable<URI> _map = IterableExtensions.<IResourceDescription.Delta, URI>map(_filter_1, _function_2);
+        final Function1<Resource, IResourceDescription.Delta> _function_3 = new Function1<Resource, IResourceDescription.Delta>() {
+          @Override
+          public IResourceDescription.Delta apply(final Resource resource) {
+            CancelIndicator _cancelIndicator = InternalStatefulIncrementalBuilder.this.request.getCancelIndicator();
+            InternalStatefulIncrementalBuilder.this._operationCanceledManager.checkCanceled(_cancelIndicator);
+            resource.getContents();
+            EcoreUtil2.resolveLazyCrossReferences(resource, CancelIndicator.NullImpl);
+            CancelIndicator _cancelIndicator_1 = InternalStatefulIncrementalBuilder.this.request.getCancelIndicator();
+            InternalStatefulIncrementalBuilder.this._operationCanceledManager.checkCanceled(_cancelIndicator_1);
+            URI _uRI = resource.getURI();
+            final IResourceServiceProvider serviceProvider = InternalStatefulIncrementalBuilder.this.context.getResourceServiceProvider(_uRI);
+            final IResourceDescription.Manager manager = serviceProvider.getResourceDescriptionManager();
+            final IResourceDescription description = manager.getResourceDescription(resource);
+            final SerializableResourceDescription copiedDescription = SerializableResourceDescription.createCopy(description);
+            ResourceDescriptionsData _newIndex = result.getNewIndex();
+            URI _uRI_1 = resource.getURI();
+            _newIndex.addDescription(_uRI_1, copiedDescription);
+            CancelIndicator _cancelIndicator_2 = InternalStatefulIncrementalBuilder.this.request.getCancelIndicator();
+            InternalStatefulIncrementalBuilder.this._operationCanceledManager.checkCanceled(_cancelIndicator_2);
+            boolean _and = false;
+            boolean _and_1 = false;
+            boolean _isIndexOnly = InternalStatefulIncrementalBuilder.this.request.isIndexOnly();
+            boolean _not = (!_isIndexOnly);
+            if (!_not) {
+              _and_1 = false;
+            } else {
+              boolean _validate = InternalStatefulIncrementalBuilder.this.validate(resource);
+              _and_1 = _validate;
+            }
+            if (!_and_1) {
+              _and = false;
+            } else {
+              IShouldGenerate _get = serviceProvider.<IShouldGenerate>get(IShouldGenerate.class);
+              boolean _shouldGenerate = _get.shouldGenerate(resource, CancelIndicator.NullImpl);
+              _and = _shouldGenerate;
+            }
+            if (_and) {
+              CancelIndicator _cancelIndicator_3 = InternalStatefulIncrementalBuilder.this.request.getCancelIndicator();
+              InternalStatefulIncrementalBuilder.this._operationCanceledManager.checkCanceled(_cancelIndicator_3);
+              InternalStatefulIncrementalBuilder.this.generate(resource, InternalStatefulIncrementalBuilder.this.request, newSource2GeneratedMapping);
+            }
+            IndexState _oldState = InternalStatefulIncrementalBuilder.this.context.getOldState();
+            ResourceDescriptionsData _resourceDescriptions = _oldState.getResourceDescriptions();
+            URI _uRI_2 = resource.getURI();
+            final IResourceDescription old = _resourceDescriptions.getResourceDescription(_uRI_2);
+            return manager.createDelta(old, copiedDescription);
+          }
+        };
+        Iterable<IResourceDescription.Delta> _executeClustered = this.context.<IResourceDescription.Delta>executeClustered(_map, _function_3);
+        Iterables.<IResourceDescription.Delta>addAll(resolvedDeltas, _executeClustered);
+        IndexState _state_1 = this.request.getState();
+        return new IncrementalBuilder.Result(_state_1, resolvedDeltas);
+      } catch (Throwable _e) {
+        throw Exceptions.sneakyThrow(_e);
+      }
     }
     
     protected boolean validate(final Resource resource) {
@@ -316,82 +310,80 @@ public class IncrementalBuilder {
     }
     
     protected void generate(final Resource resource, final BuildRequest request, final Source2GeneratedMapping newMappings) {
-      URI _uRI = resource.getURI();
-      final IResourceServiceProvider serviceProvider = this.context.getResourceServiceProvider(_uRI);
-      final GeneratorDelegate generator = serviceProvider.<GeneratorDelegate>get(GeneratorDelegate.class);
-      boolean _equals = Objects.equal(generator, null);
-      if (_equals) {
-        return;
-      }
-      URI _uRI_1 = resource.getURI();
-      final Set<URI> previous = newMappings.deleteSource(_uRI_1);
-      URIBasedFileSystemAccess _createFileSystemAccess = this.createFileSystemAccess(serviceProvider, resource);
-      final Procedure1<URIBasedFileSystemAccess> _function = new Procedure1<URIBasedFileSystemAccess>() {
-        @Override
-        public void apply(final URIBasedFileSystemAccess it) {
-          final URIBasedFileSystemAccess.BeforeWrite _function = new URIBasedFileSystemAccess.BeforeWrite() {
-            @Override
-            public InputStream beforeWrite(final URI uri, final String outputCfgName, final InputStream contents) {
-              URI _uRI = resource.getURI();
-              newMappings.addSource2Generated(_uRI, uri, outputCfgName);
-              previous.remove(uri);
-              Procedure2<? super URI, ? super URI> _afterGenerateFile = request.getAfterGenerateFile();
-              URI _uRI_1 = resource.getURI();
-              _afterGenerateFile.apply(_uRI_1, uri);
-              return contents;
-            }
-          };
-          it.setBeforeWrite(_function);
-          final URIBasedFileSystemAccess.BeforeDelete _function_1 = new URIBasedFileSystemAccess.BeforeDelete() {
-            @Override
-            public boolean beforeDelete(final URI uri) {
-              newMappings.deleteGenerated(uri);
-              Procedure1<? super URI> _afterDeleteFile = request.getAfterDeleteFile();
-              _afterDeleteFile.apply(uri);
-              return true;
-            }
-          };
-          it.setBeforeDelete(_function_1);
+      try {
+        URI _uRI = resource.getURI();
+        final IResourceServiceProvider serviceProvider = this.context.getResourceServiceProvider(_uRI);
+        final GeneratorDelegate generator = serviceProvider.<GeneratorDelegate>get(GeneratorDelegate.class);
+        boolean _equals = Objects.equal(generator, null);
+        if (_equals) {
+          return;
         }
-      };
-      final URIBasedFileSystemAccess fileSystemAccess = ObjectExtensions.<URIBasedFileSystemAccess>operator_doubleArrow(_createFileSystemAccess, _function);
-      fileSystemAccess.setContext(resource);
-      boolean _isWriteStorageResources = request.isWriteStorageResources();
-      if (_isWriteStorageResources) {
-        boolean _matched = false;
-        if (!_matched) {
-          if (resource instanceof StorageAwareResource) {
-            IResourceStorageFacade _resourceStorageFacade = ((StorageAwareResource)resource).getResourceStorageFacade();
-            boolean _notEquals = (!Objects.equal(_resourceStorageFacade, null));
-            if (_notEquals) {
-              _matched=true;
-              IResourceStorageFacade _resourceStorageFacade_1 = ((StorageAwareResource)resource).getResourceStorageFacade();
-              _resourceStorageFacade_1.saveResource(((StorageAwareResource)resource), fileSystemAccess);
+        URI _uRI_1 = resource.getURI();
+        final Set<URI> previous = newMappings.deleteSource(_uRI_1);
+        URIBasedFileSystemAccess _createFileSystemAccess = this.createFileSystemAccess(serviceProvider, resource);
+        final Procedure1<URIBasedFileSystemAccess> _function = new Procedure1<URIBasedFileSystemAccess>() {
+          @Override
+          public void apply(final URIBasedFileSystemAccess it) {
+            final URIBasedFileSystemAccess.BeforeWrite _function = new URIBasedFileSystemAccess.BeforeWrite() {
+              @Override
+              public InputStream beforeWrite(final URI uri, final String outputCfgName, final InputStream contents) {
+                URI _uRI = resource.getURI();
+                newMappings.addSource2Generated(_uRI, uri, outputCfgName);
+                previous.remove(uri);
+                Procedure2<? super URI, ? super URI> _afterGenerateFile = request.getAfterGenerateFile();
+                URI _uRI_1 = resource.getURI();
+                _afterGenerateFile.apply(_uRI_1, uri);
+                return contents;
+              }
+            };
+            it.setBeforeWrite(_function);
+            final URIBasedFileSystemAccess.BeforeDelete _function_1 = new URIBasedFileSystemAccess.BeforeDelete() {
+              @Override
+              public boolean beforeDelete(final URI uri) {
+                newMappings.deleteGenerated(uri);
+                Procedure1<? super URI> _afterDeleteFile = request.getAfterDeleteFile();
+                _afterDeleteFile.apply(uri);
+                return true;
+              }
+            };
+            it.setBeforeDelete(_function_1);
+          }
+        };
+        final URIBasedFileSystemAccess fileSystemAccess = ObjectExtensions.<URIBasedFileSystemAccess>operator_doubleArrow(_createFileSystemAccess, _function);
+        fileSystemAccess.setContext(resource);
+        boolean _isWriteStorageResources = request.isWriteStorageResources();
+        if (_isWriteStorageResources) {
+          boolean _matched = false;
+          if (!_matched) {
+            if (resource instanceof StorageAwareResource) {
+              IResourceStorageFacade _resourceStorageFacade = ((StorageAwareResource)resource).getResourceStorageFacade();
+              boolean _notEquals = (!Objects.equal(_resourceStorageFacade, null));
+              if (_notEquals) {
+                _matched=true;
+                IResourceStorageFacade _resourceStorageFacade_1 = ((StorageAwareResource)resource).getResourceStorageFacade();
+                _resourceStorageFacade_1.saveResource(((StorageAwareResource)resource), fileSystemAccess);
+              }
             }
           }
         }
-      }
-      final GeneratorContext generatorContext = new GeneratorContext();
-      CancelIndicator _cancelIndicator = request.getCancelIndicator();
-      generatorContext.setCancelIndicator(_cancelIndicator);
-      generator.generate(resource, fileSystemAccess, generatorContext);
-      final Procedure1<URI> _function_1 = new Procedure1<URI>() {
-        @Override
-        public void apply(final URI it) {
-          try {
+        final GeneratorContext generatorContext = new GeneratorContext();
+        CancelIndicator _cancelIndicator = request.getCancelIndicator();
+        generatorContext.setCancelIndicator(_cancelIndicator);
+        generator.generate(resource, fileSystemAccess, generatorContext);
+        for (final URI it : previous) {
+          {
             IncrementalBuilder.InternalStatefulIncrementalBuilder.LOG.info(("Deleting stale generated file " + it));
-            XtextResourceSet _resourceSet = InternalStatefulIncrementalBuilder.this.context.getResourceSet();
+            XtextResourceSet _resourceSet = this.context.getResourceSet();
             URIConverter _uRIConverter = _resourceSet.getURIConverter();
             Map<Object, Object> _emptyMap = CollectionLiterals.<Object, Object>emptyMap();
             _uRIConverter.delete(it, _emptyMap);
             Procedure1<? super URI> _afterDeleteFile = request.getAfterDeleteFile();
             _afterDeleteFile.apply(it);
-          } catch (Throwable _e) {
-            throw Exceptions.sneakyThrow(_e);
           }
         }
-      };
-      IterableExtensions.<URI>forEach(previous, _function_1);
+      } catch (Throwable _e) {
+        throw Exceptions.sneakyThrow(_e);
+      }
     }
     
     protected URIBasedFileSystemAccess createFileSystemAccess(final IResourceServiceProvider serviceProvider, final Resource resource) {

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/Indexer.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/Indexer.java
@@ -52,7 +52,6 @@ import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -308,11 +307,10 @@ public class Indexer {
       }
     };
     Iterable<URI> _filter = IterableExtensions.<URI>filter(_deletedFiles, _function);
-    final Procedure1<URI> _function_1 = new Procedure1<URI>() {
-      @Override
-      public void apply(final URI it) {
+    for (final URI it : _filter) {
+      {
         CancelIndicator _cancelIndicator = context.getCancelIndicator();
-        Indexer.this._operationCanceledManager.checkCanceled(_cancelIndicator);
+        this._operationCanceledManager.checkCanceled(_cancelIndicator);
         IResourceDescription _resourceDescription = null;
         if (oldIndex!=null) {
           _resourceDescription=oldIndex.getResourceDescription(it);
@@ -324,8 +322,7 @@ public class Indexer {
           deltas.add(delta);
         }
       }
-    };
-    IterableExtensions.<URI>forEach(_filter, _function_1);
+    }
     return deltas;
   }
   

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/Source2GeneratedMapping.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/build/Source2GeneratedMapping.java
@@ -24,10 +24,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor;
 import org.eclipse.xtext.generator.IFileSystemAccess;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.ExclusiveRange;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * @author Jan Koehnlein - Initial contribution and API
@@ -70,25 +67,17 @@ public class Source2GeneratedMapping implements Externalizable {
   public Set<URI> deleteSource(final URI source) {
     Collection<URI> _removeAll = this.source2generated.removeAll(source);
     final HashSet<URI> generated = new HashSet<URI>(_removeAll);
-    final Procedure1<URI> _function = new Procedure1<URI>() {
-      @Override
-      public void apply(final URI it) {
-        Source2GeneratedMapping.this.generated2source.remove(it, source);
-      }
-    };
-    IterableExtensions.<URI>forEach(generated, _function);
+    for (final URI it : generated) {
+      this.generated2source.remove(it, source);
+    }
     return generated;
   }
   
   public void deleteGenerated(final URI generated) {
     Collection<URI> _removeAll = this.generated2source.removeAll(generated);
-    final Procedure1<URI> _function = new Procedure1<URI>() {
-      @Override
-      public void apply(final URI it) {
-        Source2GeneratedMapping.this.source2generated.remove(it, generated);
-      }
-    };
-    IterableExtensions.<URI>forEach(_removeAll, _function);
+    for (final URI it : _removeAll) {
+      this.source2generated.remove(it, generated);
+    }
     this.generated2OutputConfigName.remove(generated);
   }
   
@@ -139,43 +128,31 @@ public class Source2GeneratedMapping implements Externalizable {
     final Set<Map.Entry<URI, Collection<URI>>> entries = _asMap.entrySet();
     int _size = entries.size();
     out.writeInt(_size);
-    final Procedure1<Map.Entry<URI, Collection<URI>>> _function = new Procedure1<Map.Entry<URI, Collection<URI>>>() {
-      @Override
-      public void apply(final Map.Entry<URI, Collection<URI>> it) {
-        try {
-          URI _key = it.getKey();
-          String _string = _key.toString();
-          out.writeUTF(_string);
-          Collection<URI> _value = it.getValue();
-          int _size = _value.size();
-          out.writeInt(_size);
-          Collection<URI> _value_1 = it.getValue();
-          final Procedure1<URI> _function = new Procedure1<URI>() {
-            @Override
-            public void apply(final URI it) {
-              try {
-                String _string = it.toString();
-                out.writeUTF(_string);
-                String _elvis = null;
-                String _get = Source2GeneratedMapping.this.generated2OutputConfigName.get(it);
-                if (_get != null) {
-                  _elvis = _get;
-                } else {
-                  _elvis = IFileSystemAccess.DEFAULT_OUTPUT;
-                }
-                out.writeUTF(_elvis);
-              } catch (Throwable _e) {
-                throw Exceptions.sneakyThrow(_e);
-              }
+    for (final Map.Entry<URI, Collection<URI>> it : entries) {
+      {
+        URI _key = it.getKey();
+        String _string = _key.toString();
+        out.writeUTF(_string);
+        Collection<URI> _value = it.getValue();
+        int _size_1 = _value.size();
+        out.writeInt(_size_1);
+        Collection<URI> _value_1 = it.getValue();
+        for (final URI it_1 : _value_1) {
+          {
+            String _string_1 = it_1.toString();
+            out.writeUTF(_string_1);
+            String _elvis = null;
+            String _get = this.generated2OutputConfigName.get(it_1);
+            if (_get != null) {
+              _elvis = _get;
+            } else {
+              _elvis = IFileSystemAccess.DEFAULT_OUTPUT;
             }
-          };
-          IterableExtensions.<URI>forEach(_value_1, _function);
-        } catch (Throwable _e) {
-          throw Exceptions.sneakyThrow(_e);
+            out.writeUTF(_elvis);
+          }
         }
       }
-    };
-    IterableExtensions.<Map.Entry<URI, Collection<URI>>>forEach(entries, _function);
+    }
   }
   
   public Source2GeneratedMapping(final Multimap<URI, URI> source2generated, final Multimap<URI, URI> generated2source, final Map<URI, String> generated2OutputConfigName) {

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/resource/impl/ChunkedResourceDescriptions.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/resource/impl/ChunkedResourceDescriptions.java
@@ -35,11 +35,9 @@ import org.eclipse.xtext.resource.impl.AbstractCompoundSelectable;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsData;
 import org.eclipse.xtext.resource.persistence.SerializableResourceDescription;
 import org.eclipse.xtext.util.internal.EmfAdaptable;
-import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.ExclusiveRange;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * A IResourceDescriptions implementation that holds its resource description in chunks, each identified by a string.
@@ -209,46 +207,32 @@ public class ChunkedResourceDescriptions extends AbstractCompoundSelectable impl
     int _size = _entrySet.size();
     out.writeInt(_size);
     Set<Map.Entry<String, ResourceDescriptionsData>> _entrySet_1 = copy.entrySet();
-    final Procedure1<Map.Entry<String, ResourceDescriptionsData>> _function = new Procedure1<Map.Entry<String, ResourceDescriptionsData>>() {
-      @Override
-      public void apply(final Map.Entry<String, ResourceDescriptionsData> it) {
-        try {
-          String _key = it.getKey();
-          out.writeUTF(_key);
-          ResourceDescriptionsData _value = it.getValue();
-          Iterable<IResourceDescription> _allResourceDescriptions = _value.getAllResourceDescriptions();
-          final Function1<IResourceDescription, Object> _function = new Function1<IResourceDescription, Object>() {
-            @Override
-            public Object apply(final IResourceDescription it) {
-              Object _xifexpression = null;
-              if ((it instanceof Serializable)) {
-                _xifexpression = ((Object)it);
-              } else {
-                _xifexpression = SerializableResourceDescription.createCopy(it);
-              }
-              return ((Object)_xifexpression);
+    for (final Map.Entry<String, ResourceDescriptionsData> it : _entrySet_1) {
+      {
+        String _key = it.getKey();
+        out.writeUTF(_key);
+        ResourceDescriptionsData _value = it.getValue();
+        Iterable<IResourceDescription> _allResourceDescriptions = _value.getAllResourceDescriptions();
+        final Function1<IResourceDescription, Object> _function = new Function1<IResourceDescription, Object>() {
+          @Override
+          public Object apply(final IResourceDescription it) {
+            Object _xifexpression = null;
+            if ((it instanceof Serializable)) {
+              _xifexpression = ((Object)it);
+            } else {
+              _xifexpression = SerializableResourceDescription.createCopy(it);
             }
-          };
-          final Iterable<Object> descriptions = IterableExtensions.<IResourceDescription, Object>map(_allResourceDescriptions, _function);
-          int _size = IterableExtensions.size(descriptions);
-          out.writeInt(_size);
-          final Procedure1<Object> _function_1 = new Procedure1<Object>() {
-            @Override
-            public void apply(final Object it) {
-              try {
-                out.writeObject(it);
-              } catch (Throwable _e) {
-                throw Exceptions.sneakyThrow(_e);
-              }
-            }
-          };
-          IterableExtensions.<Object>forEach(descriptions, _function_1);
-        } catch (Throwable _e) {
-          throw Exceptions.sneakyThrow(_e);
+            return ((Object)_xifexpression);
+          }
+        };
+        final Iterable<Object> descriptions = IterableExtensions.<IResourceDescription, Object>map(_allResourceDescriptions, _function);
+        int _size_1 = IterableExtensions.size(descriptions);
+        out.writeInt(_size_1);
+        for (final Object it_1 : descriptions) {
+          out.writeObject(it_1);
         }
       }
-    };
-    IterableExtensions.<Map.Entry<String, ResourceDescriptionsData>>forEach(_entrySet_1, _function);
+    }
   }
   
   public static ChunkedResourceDescriptions findInEmfObject(final Notifier emfObject) {

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinder.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/tasks/DefaultTaskFinder.java
@@ -27,7 +27,6 @@ import org.eclipse.xtext.tasks.TaskTags;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * @author Stefan Oehme - Initial contribution and API
@@ -97,9 +96,8 @@ public class DefaultTaskFinder implements ITaskFinder {
     if (_canContainTaskTags) {
       String _text = node.getText();
       final List<Task> tasks = this.parser.parseTasks(_text, taskTags);
-      final Procedure1<Task> _function = new Procedure1<Task>() {
-        @Override
-        public void apply(final Task it) {
+      for (final Task it : tasks) {
+        {
           int _offset = it.getOffset();
           int _offset_1 = node.getOffset();
           int _plus = (_offset + _offset_1);
@@ -110,8 +108,7 @@ public class DefaultTaskFinder implements ITaskFinder {
           int _minus = (_plus_1 - 1);
           it.setLineNumber(_minus);
         }
-      };
-      IterableExtensions.<Task>forEach(tasks, _function);
+      }
       return tasks;
     }
     return Collections.<Task>unmodifiableList(CollectionLiterals.<Task>newArrayList());

--- a/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/xtext/FlattenedGrammarAccess.java
+++ b/plugins/org.eclipse.xtext/xtend-gen/org/eclipse/xtext/xtext/FlattenedGrammarAccess.java
@@ -51,7 +51,6 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure2;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xtext.ConditionEvaluator;
@@ -175,14 +174,10 @@ public class FlattenedGrammarAccess {
         return Boolean.valueOf((!_contains));
       }
     };
-    Iterable<TerminalRule> _filter_2 = IterableExtensions.<TerminalRule>filter(_filter_1, _function_2);
-    final Procedure1<TerminalRule> _function_3 = new Procedure1<TerminalRule>() {
-      @Override
-      public void apply(final TerminalRule it) {
-        it.setFragment(true);
-      }
-    };
-    IterableExtensions.<TerminalRule>forEach(_filter_2, _function_3);
+    final Iterable<TerminalRule> terminals = IterableExtensions.<TerminalRule>filter(_filter_1, _function_2);
+    for (final TerminalRule it : terminals) {
+      it.setFragment(true);
+    }
   }
   
   private Multimap<TerminalRule, AbstractRule> copyRuleBodies(final List<AbstractRule> copies, final Map<RuleWithParameterValues, AbstractRule> origToCopy) {

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/EmfModelsTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/EmfModelsTest.xtend
@@ -56,11 +56,11 @@ class EmfModelsTest {
 
 	def void check(EPackage ePack) {
 		info("Checking EPackage '" + ePack.getName() + "'");
-		ePack.getEClassifiers().forEach [
+		for (it : ePack.getEClassifiers()) {
 			if (it instanceof EClass) {
 				check(it)
 			}
-		]
+		}
 		info("EPackage '" + ePack.getName() + "' passed.");
 	}
 

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.xtend
@@ -83,7 +83,11 @@ class TestBatchCompiler {
 	@AfterClass
 	def static void afterClass() {
 		try {
-			abfalleimer.forEach[if(exists) delete]
+			for (it : abfalleimer) {
+				if (exists) {
+					delete
+				}
+			}
 		} catch (Exception e) {
 		} finally {
 			abfalleimer.clear

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.xtend
@@ -794,10 +794,10 @@ abstract class AbstractReusableActiveAnnotationTests {
 			val annotationsValue = annotation.getAnnotationArrayValue('annotations')
 			assertNotNull(annotationsValue)
 			assertEquals(2, annotationsValue.size)
-			annotationsValue.forEach[
+			for (it : annotationsValue) {
 				assertEquals(someAnnotationType, annotationValue.annotationTypeDeclaration)
 				assertFalse(annotationValue.getBooleanValue('value'))
-			]
+			}
 		]
 	}
 	
@@ -3140,7 +3140,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 			val resource = it.xtendFile.eResource
 			val jvmTypes = resource.contents.tail
 			
-			jvmTypes.forEach [
+			for (it : jvmTypes) {
 				if (it instanceof JvmDeclaredType) {
 					val generated = String.valueOf(generator.generateType(it, generatorConfigProvider.get(it)))
 					if (!clientFilesAsSet.remove(generated)) {
@@ -3149,7 +3149,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				} else {
 					throw new IllegalArgumentException(String.valueOf(it))
 				}
-			]
+			}
 			if (!clientFilesAsSet.empty) {
 				fail('Missing compiled code. Expected :\n' + clientFilesAsSet.join('\n'))
 			}

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AccessObjectProcessor.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AccessObjectProcessor.xtend
@@ -60,15 +60,15 @@ class AccessObjectProcessor implements TransformationParticipant<MutableClassDec
 	override doTransform(List<? extends MutableClassDeclaration> annotatedSourceClasses, 
 		extension TransformationContext ctx
 	) {
-		annotatedSourceClasses.forEach [
-			it.declaredFields.forEach [field |
+		for (it : annotatedSourceClasses) {
+			for (field : it.declaredFields) {
 				field.declaringType.addMethod('get'+field.simpleName.toFirstUpper) [
 					returnType = field.type 
 					body = ['''
 						return this.«field.simpleName»;
 					''']
 				]
-			]
+			}
 			
 			val pkg = it.qualifiedName.substring(0, it.qualifiedName.length-it.simpleName.length)
 			
@@ -95,18 +95,18 @@ class AccessObjectProcessor implements TransformationParticipant<MutableClassDec
 				gIfcs.add(ser)
 				g.setImplementedInterfaces(gIfcs)
 			}
-		]
+		}
 	}
 	
 	override doRegisterGlobals(List<? extends ClassDeclaration> annotatedSourceElements, 
 		extension RegisterGlobalsContext ctx
 	) {
-		annotatedSourceElements.forEach [
+		for (it : annotatedSourceElements) {
 			val pkg = it.qualifiedName.substring(0, it.qualifiedName.length-it.simpleName.length)
 			val PVersionName = pkg+"P"+it.simpleName;
 			val GVersionName = pkg+"G"+it.simpleName;
 			ctx.registerClass(PVersionName)
 			ctx.registerClass(GVersionName)
-		]
+		}
 	}
 }

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/Bug446364Test.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/Bug446364Test.xtend
@@ -117,14 +117,14 @@ class Bug446364Processor extends AbstractClassProcessor {
 	override doTransform(MutableClassDeclaration annotatedClass, extension TransformationContext context) {
 		switch (annotatedClass.annotations.head.getStringValue('value')) {
 			case 'rename': {
-				annotatedClass.declaredMethods.forEach[
+				for (it : annotatedClass.declaredMethods) {
 					simpleName = 'prefix_' + simpleName
-				]
+				}
 			}
 			case 'changeBody': {
-				annotatedClass.declaredMethods.forEach[
+				for (it : annotatedClass.declaredMethods) {
 					body = '''return null;'''
-				]
+				}
 			}
 		}
 	}

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.xtend
@@ -164,7 +164,9 @@ class DeclarationsTest extends AbstractXtendTestCase {
 		''').asCompilationUnit [ 
 			val c = sourceTypeDeclarations.head as ClassDeclaration
 			val mutable = typeLookup.findClass(c.qualifiedName)
-			mutable.declaredMembers.forEach[ remove ]
+			for (it : mutable.declaredMembers) {
+				remove
+			}
 			assertTrue(mutable.declaredMembers.empty)
 		]
 	}

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.xtend
@@ -48,9 +48,9 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 		}
 		if (computedSuperType != null) {
 			computedSuperType => [ superType |
-				typeReferences.forEach [
+				for (it : typeReferences) {
 					assertEquals(superTypeAndParam.key, conformanceComputer.getCommonSuperType(#[it, superType], superType.owner)?.simpleName)
-				]
+				}
 			]
 		}
 		if (computedSuperType != null) {

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/DeferredTypeParameterHintCollectorTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/DeferredTypeParameterHintCollectorTest.xtend
@@ -74,7 +74,9 @@ class DeferredTypeParameterHintCollectorTest extends AbstractTestingTypeReferenc
 		for(key: allKeys) {
 			if (key.simpleName == typeParamName) {
 				val unbound = mapping.get(key).typeReference as UnboundTypeReference
-				unbound.getAllHints.forEach [ assertEquals( BoundTypeArgumentSource::INFERRED_LATER, source ) ]
+				for (it : unbound.getAllHints) {
+					assertEquals(BoundTypeArgumentSource::INFERRED_LATER, source)
+				}
 				return unbound.getAllHints
 			}
 		}

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ReorderedFeatureCallArgumentsTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ReorderedFeatureCallArgumentsTest.xtend
@@ -171,26 +171,26 @@ class ReorderedFeatureCallArgumentsTest extends AbstractTestingTypeReferenceOwne
 	}
 	
 	protected def void withIndizes(IFeatureCallArguments arguments, int... indexes) {
-		indexes.forEach [
+		for (it : indexes) {
 			assertTrue(arguments.hasUnprocessedArguments)
 			val slot = arguments.nextUnprocessedArgumentSlot
 			val expression = slot.argumentExpression
 			val featureCall = expression.eContainer as XFeatureCall
 			assertEquals(it, featureCall.featureCallArguments.indexOf(expression))
 			slot.markProcessed
-		]
+		}
 		assertFalse(arguments.hasUnprocessedArguments)
 	}
 	
 	protected def void withTypes(IFeatureCallArguments arguments, String... types) {
-		types.forEach [
+		for (it : types) {
 			assertTrue(arguments.hasUnprocessedArguments)
 			val slot = arguments.nextUnprocessedArgumentSlot
 			assertEquals(it === null, slot.superfluous)
 			if (it !== null)
 				assertEquals(it, slot.declaredType.simpleName)
 			slot.markProcessed
-		]
+		}
 		assertFalse(arguments.hasUnprocessedArguments)
 	}
 	

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ReorderedVarArgFeatureCallArgumentsTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ReorderedVarArgFeatureCallArgumentsTest.xtend
@@ -195,26 +195,26 @@ class ReorderedVarArgFeatureCallArgumentsTest extends AbstractTestingTypeReferen
 	}
 	
 	protected def void withIndizes(IFeatureCallArguments arguments, int... indexes) {
-		indexes.forEach [
+		for (it : indexes) {
 			assertTrue(arguments.hasUnprocessedArguments)
 			val slot = arguments.nextUnprocessedArgumentSlot
 			val expression = slot.argumentExpressions.head
 			val featureCall = expression.eContainer as XFeatureCall
 			assertEquals(it, featureCall.featureCallArguments.indexOf(expression))
 			slot.markProcessed
-		]
+		}
 		assertFalse(arguments.hasUnprocessedArguments)
 	}
 	
 	protected def void withTypes(IFeatureCallArguments arguments, String... types) {
-		types.forEach [
+		for (it : types) {
 			assertTrue(arguments.hasUnprocessedArguments)
 			val slot = arguments.nextUnprocessedArgumentSlot
 			assertEquals(it === null, slot.superfluous)
 			if (it !== null)
 				assertEquals(it, slot.declaredType.simpleName)
 			slot.markProcessed
-		]
+		}
 		assertFalse(arguments.hasUnprocessedArguments)
 	}
 	

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/AmbiguityValidationTests.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/AmbiguityValidationTests.xtend
@@ -38,12 +38,12 @@ abstract class AmbiguityValidationTest extends AbstractXtendTestCase {
 		assertEquals(errors.toString, 1, errors.size)
 		val singleError = errors.head as AbstractDiagnostic
 		assertEquals(singleError.message, IssueCodes.AMBIGUOUS_FEATURE_CALL, singleError.code)
-		messageParts.map[LineDelimiters.toUnix(it)].forEach [
+		for (it : messageParts.map[LineDelimiters.toUnix(it)]) {
 			val message = singleError.message
 			if (!message.contains(it)) {
 				assertEquals(it, message)
 			}
-		]
+		}
 		val firstType = file.xtendTypes.head
 		val firstMember = firstType.members.head as XtendFunction
 		val block = firstMember.expression as XBlockExpression

--- a/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/SuspiciousOverloadValidationTest.xtend
+++ b/tests/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/SuspiciousOverloadValidationTest.xtend
@@ -41,12 +41,12 @@ class SuspiciousOverloadValidationTest extends AbstractXtendTestCase {
 		assertEquals(errors.toString, 1, errors.size)
 		val singleError = errors.head as AbstractDiagnostic
 		assertEquals(singleError.message, IssueCodes.SUSPICIOUSLY_OVERLOADED_FEATURE, singleError.code)
-		messageParts.map[LineDelimiters.toUnix(it)].forEach [
+		for (it : messageParts.map[LineDelimiters.toUnix(it)]) {
 			val message = singleError.message
 			if (!message.contains(it)) {
 				assertEquals(it, message)
 			}
-		]
+		}
 		val firstType = file.xtendTypes.head
 		val firstMember = firstType.members.head as XtendFunction
 		val block = firstMember.expression as XBlockExpression
@@ -64,12 +64,12 @@ class SuspiciousOverloadValidationTest extends AbstractXtendTestCase {
 		assertEquals(errors.toString, 1, errors.size)
 		val singleError = errors.head as AbstractDiagnostic
 		assertEquals(singleError.message, IssueCodes.SUSPICIOUSLY_OVERLOADED_FEATURE, singleError.code)
-		messageParts.map[LineDelimiters.toUnix(it)].forEach [
+		for (it : messageParts.map[LineDelimiters.toUnix(it)]) {
 			val message = singleError.message
 			if (!message.contains(it)) {
 				assertEquals(it, message)
 			}
-		]
+		}
 		val firstType = file.xtendTypes.head
 		val innerType = firstType.members.head as XtendClass
 		val firstMember = innerType.members.head as XtendFunction

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/EmfModelsTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/EmfModelsTest.java
@@ -32,8 +32,6 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -71,15 +69,11 @@ public class EmfModelsTest {
     String _plus_1 = (_plus + "\'");
     EmfModelsTest.LOGGER.info(_plus_1);
     EList<EClassifier> _eClassifiers = ePack.getEClassifiers();
-    final Procedure1<EClassifier> _function = new Procedure1<EClassifier>() {
-      @Override
-      public void apply(final EClassifier it) {
-        if ((it instanceof EClass)) {
-          EmfModelsTest.this.check(((EClass)it));
-        }
+    for (final EClassifier it : _eClassifiers) {
+      if ((it instanceof EClass)) {
+        this.check(((EClass)it));
       }
-    };
-    IterableExtensions.<EClassifier>forEach(_eClassifiers, _function);
+    }
     String _name_1 = ePack.getName();
     String _plus_2 = ("EPackage \'" + _name_1);
     String _plus_3 = (_plus_2 + "\' passed.");

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.java
@@ -130,16 +130,12 @@ public class TestBatchCompiler {
   @AfterClass
   public static void afterClass() {
     try {
-      final Procedure1<File> _function = new Procedure1<File>() {
-        @Override
-        public void apply(final File it) {
-          boolean _exists = it.exists();
-          if (_exists) {
-            it.delete();
-          }
+      for (final File it : TestBatchCompiler.abfalleimer) {
+        boolean _exists = it.exists();
+        if (_exists) {
+          it.delete();
         }
-      };
-      IterableExtensions.<File>forEach(TestBatchCompiler.abfalleimer, _function);
+      }
     } catch (final Throwable _t) {
       if (_t instanceof Exception) {
         final Exception e = (Exception)_t;

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.java
@@ -1686,16 +1686,14 @@ public abstract class AbstractReusableActiveAnnotationTests {
         Assert.assertNotNull(annotationsValue);
         int _size = ((List<AnnotationReference>)Conversions.doWrapArray(annotationsValue)).size();
         Assert.assertEquals(2, _size);
-        final Procedure1<AnnotationReference> _function = new Procedure1<AnnotationReference>() {
-          @Override
-          public void apply(final AnnotationReference it) {
-            AnnotationTypeDeclaration _annotationTypeDeclaration = annotationValue.getAnnotationTypeDeclaration();
-            Assert.assertEquals(someAnnotationType, _annotationTypeDeclaration);
-            boolean _booleanValue = annotationValue.getBooleanValue("value");
-            Assert.assertFalse(_booleanValue);
+        for (final AnnotationReference it_1 : annotationsValue) {
+          {
+            AnnotationTypeDeclaration _annotationTypeDeclaration_1 = annotationValue.getAnnotationTypeDeclaration();
+            Assert.assertEquals(someAnnotationType, _annotationTypeDeclaration_1);
+            boolean _booleanValue_1 = annotationValue.getBooleanValue("value");
+            Assert.assertFalse(_booleanValue_1);
           }
-        };
-        IterableExtensions.<AnnotationReference>forEach(((Iterable<AnnotationReference>)Conversions.doWrapArray(annotationsValue)), _function);
+        }
       }
     };
     this.assertProcessing(_mappedTo, _mappedTo_1, _function);
@@ -6256,33 +6254,29 @@ public abstract class AbstractReusableActiveAnnotationTests {
         final Resource resource = _xtendFile.eResource();
         EList<EObject> _contents = resource.getContents();
         final Iterable<EObject> jvmTypes = IterableExtensions.<EObject>tail(_contents);
-        final Procedure1<EObject> _function_1 = new Procedure1<EObject>() {
-          @Override
-          public void apply(final EObject it) {
-            if ((it instanceof JvmDeclaredType)) {
-              GeneratorConfig _get = AbstractReusableActiveAnnotationTests.this.generatorConfigProvider.get(it);
-              CharSequence _generateType = AbstractReusableActiveAnnotationTests.this.generator.generateType(((JvmDeclaredType)it), _get);
-              final String generated = String.valueOf(_generateType);
-              boolean _remove = clientFilesAsSet.remove(generated);
-              boolean _not = (!_remove);
-              if (_not) {
-                String _join = IterableExtensions.join(clientFilesAsSet, "\n");
-                String _plus = ((("Unexpected compiled code:\n" + generated) + "\nExpected :\n") + _join);
-                Assert.assertEquals("", _plus);
-              }
-            } else {
-              String _valueOf = String.valueOf(it);
-              throw new IllegalArgumentException(_valueOf);
+        for (final EObject it_1 : jvmTypes) {
+          if ((it_1 instanceof JvmDeclaredType)) {
+            GeneratorConfig _get = AbstractReusableActiveAnnotationTests.this.generatorConfigProvider.get(it_1);
+            CharSequence _generateType = AbstractReusableActiveAnnotationTests.this.generator.generateType(((JvmDeclaredType)it_1), _get);
+            final String generated = String.valueOf(_generateType);
+            boolean _remove = clientFilesAsSet.remove(generated);
+            boolean _not = (!_remove);
+            if (_not) {
+              String _join = IterableExtensions.join(clientFilesAsSet, "\n");
+              String _plus = ((("Unexpected compiled code:\n" + generated) + "\nExpected :\n") + _join);
+              Assert.assertEquals("", _plus);
             }
+          } else {
+            String _valueOf = String.valueOf(it_1);
+            throw new IllegalArgumentException(_valueOf);
           }
-        };
-        IterableExtensions.<EObject>forEach(jvmTypes, _function_1);
+        }
         boolean _isEmpty = clientFilesAsSet.isEmpty();
-        boolean _not = (!_isEmpty);
-        if (_not) {
-          String _join = IterableExtensions.join(clientFilesAsSet, "\n");
-          String _plus = ("Missing compiled code. Expected :\n" + _join);
-          Assert.fail(_plus);
+        boolean _not_1 = (!_isEmpty);
+        if (_not_1) {
+          String _join_1 = IterableExtensions.join(clientFilesAsSet, "\n");
+          String _plus_1 = ("Missing compiled code. Expected :\n" + _join_1);
+          Assert.fail(_plus_1);
         }
       }
     };

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AccessObjectProcessor.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AccessObjectProcessor.java
@@ -17,7 +17,6 @@ import org.eclipse.xtend.lib.macro.declaration.MutableTypeDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.TypeReference;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
@@ -25,54 +24,49 @@ import org.eclipse.xtext.xbase.lib.StringExtensions;
 public class AccessObjectProcessor implements TransformationParticipant<MutableClassDeclaration>, RegisterGlobalsParticipant<ClassDeclaration> {
   @Override
   public void doTransform(final List<? extends MutableClassDeclaration> annotatedSourceClasses, @Extension final TransformationContext ctx) {
-    final Procedure1<MutableClassDeclaration> _function = new Procedure1<MutableClassDeclaration>() {
-      @Override
-      public void apply(final MutableClassDeclaration it) {
+    for (final MutableClassDeclaration it : annotatedSourceClasses) {
+      {
         Iterable<? extends MutableFieldDeclaration> _declaredFields = it.getDeclaredFields();
-        final Procedure1<MutableFieldDeclaration> _function = new Procedure1<MutableFieldDeclaration>() {
-          @Override
-          public void apply(final MutableFieldDeclaration field) {
-            MutableTypeDeclaration _declaringType = field.getDeclaringType();
-            String _simpleName = field.getSimpleName();
-            String _firstUpper = StringExtensions.toFirstUpper(_simpleName);
-            String _plus = ("get" + _firstUpper);
-            final Procedure1<MutableMethodDeclaration> _function = new Procedure1<MutableMethodDeclaration>() {
-              @Override
-              public void apply(final MutableMethodDeclaration it) {
-                TypeReference _type = field.getType();
-                it.setReturnType(_type);
-                final CompilationStrategy _function = new CompilationStrategy() {
-                  @Override
-                  public CharSequence compile(final CompilationStrategy.CompilationContext it) {
-                    StringConcatenation _builder = new StringConcatenation();
-                    _builder.append("return this.");
-                    String _simpleName = field.getSimpleName();
-                    _builder.append(_simpleName, "");
-                    _builder.append(";");
-                    _builder.newLineIfNotEmpty();
-                    return _builder;
-                  }
-                };
-                it.setBody(_function);
-              }
-            };
-            _declaringType.addMethod(_plus, _function);
-          }
-        };
-        IterableExtensions.forEach(_declaredFields, _function);
+        for (final MutableFieldDeclaration field : _declaredFields) {
+          MutableTypeDeclaration _declaringType = field.getDeclaringType();
+          String _simpleName = field.getSimpleName();
+          String _firstUpper = StringExtensions.toFirstUpper(_simpleName);
+          String _plus = ("get" + _firstUpper);
+          final Procedure1<MutableMethodDeclaration> _function = new Procedure1<MutableMethodDeclaration>() {
+            @Override
+            public void apply(final MutableMethodDeclaration it) {
+              TypeReference _type = field.getType();
+              it.setReturnType(_type);
+              final CompilationStrategy _function = new CompilationStrategy() {
+                @Override
+                public CharSequence compile(final CompilationStrategy.CompilationContext it) {
+                  StringConcatenation _builder = new StringConcatenation();
+                  _builder.append("return this.");
+                  String _simpleName = field.getSimpleName();
+                  _builder.append(_simpleName, "");
+                  _builder.append(";");
+                  _builder.newLineIfNotEmpty();
+                  return _builder;
+                }
+              };
+              it.setBody(_function);
+            }
+          };
+          _declaringType.addMethod(_plus, _function);
+        }
         String _qualifiedName = it.getQualifiedName();
         String _qualifiedName_1 = it.getQualifiedName();
         int _length = _qualifiedName_1.length();
-        String _simpleName = it.getSimpleName();
-        int _length_1 = _simpleName.length();
+        String _simpleName_1 = it.getSimpleName();
+        int _length_1 = _simpleName_1.length();
         int _minus = (_length - _length_1);
         final String pkg = _qualifiedName.substring(0, _minus);
         final TypeReference ser = ctx.newTypeReference(Serializable.class);
         if ((ser == null)) {
           ctx.addError(it, "Cannot find Serializable");
         }
-        String _simpleName_1 = it.getSimpleName();
-        final String PVersionName = ((pkg + "P") + _simpleName_1);
+        String _simpleName_2 = it.getSimpleName();
+        final String PVersionName = ((pkg + "P") + _simpleName_2);
         final MutableClassDeclaration p = ctx.findClass(PVersionName);
         boolean _equals = Objects.equal(p, null);
         if (_equals) {
@@ -91,8 +85,8 @@ public class AccessObjectProcessor implements TransformationParticipant<MutableC
           pIfcs.add(ser);
           p.setImplementedInterfaces(pIfcs);
         }
-        String _simpleName_2 = it.getSimpleName();
-        final String GVersionName = ((pkg + "G") + _simpleName_2);
+        String _simpleName_3 = it.getSimpleName();
+        final String GVersionName = ((pkg + "G") + _simpleName_3);
         final MutableClassDeclaration g = ctx.findClass(GVersionName);
         boolean _equals_1 = Objects.equal(g, null);
         if (_equals_1) {
@@ -112,15 +106,13 @@ public class AccessObjectProcessor implements TransformationParticipant<MutableC
           g.setImplementedInterfaces(gIfcs);
         }
       }
-    };
-    IterableExtensions.forEach(annotatedSourceClasses, _function);
+    }
   }
   
   @Override
   public void doRegisterGlobals(final List<? extends ClassDeclaration> annotatedSourceElements, @Extension final RegisterGlobalsContext ctx) {
-    final Procedure1<ClassDeclaration> _function = new Procedure1<ClassDeclaration>() {
-      @Override
-      public void apply(final ClassDeclaration it) {
+    for (final ClassDeclaration it : annotatedSourceElements) {
+      {
         String _qualifiedName = it.getQualifiedName();
         String _qualifiedName_1 = it.getQualifiedName();
         int _length = _qualifiedName_1.length();
@@ -135,7 +127,6 @@ public class AccessObjectProcessor implements TransformationParticipant<MutableC
         ctx.registerClass(PVersionName);
         ctx.registerClass(GVersionName);
       }
-    };
-    IterableExtensions.forEach(annotatedSourceElements, _function);
+    }
   }
 }

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/Bug446364Processor.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/Bug446364Processor.java
@@ -16,7 +16,6 @@ import org.eclipse.xtend.lib.macro.declaration.MutableMethodDeclaration;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 @SuppressWarnings("all")
 public class Bug446364Processor extends AbstractClassProcessor {
@@ -30,34 +29,26 @@ public class Bug446364Processor extends AbstractClassProcessor {
       if (Objects.equal(_stringValue, "rename")) {
         _matched=true;
         Iterable<? extends MutableMethodDeclaration> _declaredMethods = annotatedClass.getDeclaredMethods();
-        final Procedure1<MutableMethodDeclaration> _function = new Procedure1<MutableMethodDeclaration>() {
-          @Override
-          public void apply(final MutableMethodDeclaration it) {
-            String _simpleName = it.getSimpleName();
-            String _plus = ("prefix_" + _simpleName);
-            it.setSimpleName(_plus);
-          }
-        };
-        IterableExtensions.forEach(_declaredMethods, _function);
+        for (final MutableMethodDeclaration it : _declaredMethods) {
+          String _simpleName = it.getSimpleName();
+          String _plus = ("prefix_" + _simpleName);
+          it.setSimpleName(_plus);
+        }
       }
     }
     if (!_matched) {
       if (Objects.equal(_stringValue, "changeBody")) {
         _matched=true;
         Iterable<? extends MutableMethodDeclaration> _declaredMethods_1 = annotatedClass.getDeclaredMethods();
-        final Procedure1<MutableMethodDeclaration> _function_1 = new Procedure1<MutableMethodDeclaration>() {
-          @Override
-          public void apply(final MutableMethodDeclaration it) {
-            StringConcatenationClient _client = new StringConcatenationClient() {
-              @Override
-              protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-                _builder.append("return null;");
-              }
-            };
-            it.setBody(_client);
-          }
-        };
-        IterableExtensions.forEach(_declaredMethods_1, _function_1);
+        for (final MutableMethodDeclaration it_1 : _declaredMethods_1) {
+          StringConcatenationClient _client = new StringConcatenationClient() {
+            @Override
+            protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
+              _builder.append("return null;");
+            }
+          };
+          it_1.setBody(_client);
+        }
       }
     }
   }

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.java
@@ -386,13 +386,9 @@ public class DeclarationsTest extends AbstractXtendTestCase {
         String _qualifiedName = c.getQualifiedName();
         final MutableClassDeclaration mutable = _typeLookup.findClass(_qualifiedName);
         Iterable<? extends MutableMemberDeclaration> _declaredMembers = mutable.getDeclaredMembers();
-        final Procedure1<MutableMemberDeclaration> _function = new Procedure1<MutableMemberDeclaration>() {
-          @Override
-          public void apply(final MutableMemberDeclaration it) {
-            it.remove();
-          }
-        };
-        IterableExtensions.forEach(_declaredMembers, _function);
+        for (final MutableMemberDeclaration it_1 : _declaredMembers) {
+          it_1.remove();
+        }
         Iterable<? extends MutableMemberDeclaration> _declaredMembers_1 = mutable.getDeclaredMembers();
         boolean _isEmpty = IterableExtensions.isEmpty(_declaredMembers_1);
         Assert.assertTrue(_isEmpty);

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.java
@@ -162,20 +162,16 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
         final Procedure1<LightweightTypeReference> _function_1 = new Procedure1<LightweightTypeReference>() {
           @Override
           public void apply(final LightweightTypeReference superType) {
-            final Procedure1<LightweightTypeReference> _function = new Procedure1<LightweightTypeReference>() {
-              @Override
-              public void apply(final LightweightTypeReference it) {
-                String _key = superTypeAndParam.getKey();
-                ITypeReferenceOwner _owner = superType.getOwner();
-                LightweightTypeReference _commonSuperType = conformanceComputer.getCommonSuperType(Collections.<LightweightTypeReference>unmodifiableList(CollectionLiterals.<LightweightTypeReference>newArrayList(it, superType)), _owner);
-                String _simpleName = null;
-                if (_commonSuperType!=null) {
-                  _simpleName=_commonSuperType.getSimpleName();
-                }
-                Assert.assertEquals(_key, _simpleName);
+            for (final LightweightTypeReference it : typeReferences) {
+              String _key = superTypeAndParam.getKey();
+              ITypeReferenceOwner _owner = superType.getOwner();
+              LightweightTypeReference _commonSuperType = conformanceComputer.getCommonSuperType(Collections.<LightweightTypeReference>unmodifiableList(CollectionLiterals.<LightweightTypeReference>newArrayList(it, superType)), _owner);
+              String _simpleName = null;
+              if (_commonSuperType!=null) {
+                _simpleName=_commonSuperType.getSimpleName();
               }
-            };
-            IterableExtensions.<LightweightTypeReference>forEach(typeReferences, _function);
+              Assert.assertEquals(_key, _simpleName);
+            }
           }
         };
         ObjectExtensions.<LightweightTypeReference>operator_doubleArrow(computedSuperType, _function_1);

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/DeferredTypeParameterHintCollectorTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/DeferredTypeParameterHintCollectorTest.java
@@ -37,7 +37,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.eclipse.xtext.xbase.lib.Pair;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.typesystem.internal.DefaultReentrantTypeResolver;
 import org.eclipse.xtext.xbase.typesystem.references.ITypeReferenceOwner;
 import org.eclipse.xtext.xbase.typesystem.references.LightweightBoundTypeArgument;
@@ -120,14 +119,10 @@ public class DeferredTypeParameterHintCollectorTest extends AbstractTestingTypeR
         LightweightTypeReference _typeReference = _get.getTypeReference();
         final UnboundTypeReference unbound = ((UnboundTypeReference) _typeReference);
         List<LightweightBoundTypeArgument> _allHints = unbound.getAllHints();
-        final Procedure1<LightweightBoundTypeArgument> _function = new Procedure1<LightweightBoundTypeArgument>() {
-          @Override
-          public void apply(final LightweightBoundTypeArgument it) {
-            BoundTypeArgumentSource _source = it.getSource();
-            Assert.assertEquals(BoundTypeArgumentSource.INFERRED_LATER, _source);
-          }
-        };
-        IterableExtensions.<LightweightBoundTypeArgument>forEach(_allHints, _function);
+        for (final LightweightBoundTypeArgument it : _allHints) {
+          BoundTypeArgumentSource _source = it.getSource();
+          Assert.assertEquals(BoundTypeArgumentSource.INFERRED_LATER, _source);
+        }
         return unbound.getAllHints();
       }
     }
@@ -136,13 +131,13 @@ public class DeferredTypeParameterHintCollectorTest extends AbstractTestingTypeR
     _builder.append(typeParamName, "");
     _builder.append(" in ");
     Set<JvmTypeParameter> _keySet = mapping.keySet();
-    final Function1<JvmTypeParameter, String> _function_1 = new Function1<JvmTypeParameter, String>() {
+    final Function1<JvmTypeParameter, String> _function = new Function1<JvmTypeParameter, String>() {
       @Override
       public String apply(final JvmTypeParameter it) {
         return it.getSimpleName();
       }
     };
-    Iterable<String> _map = IterableExtensions.<JvmTypeParameter, String>map(_keySet, _function_1);
+    Iterable<String> _map = IterableExtensions.<JvmTypeParameter, String>map(_keySet, _function);
     _builder.append(_map, "");
     String _string = _builder.toString();
     Assert.fail(_string);

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ReorderedFeatureCallArgumentsTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ReorderedFeatureCallArgumentsTest.java
@@ -23,11 +23,9 @@ import org.eclipse.xtext.xbase.XClosure;
 import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.XFeatureCall;
 import org.eclipse.xtext.xbase.XNumberLiteral;
-import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.typesystem.arguments.IFeatureCallArgumentSlot;
 import org.eclipse.xtext.xbase.typesystem.arguments.IFeatureCallArguments;
 import org.eclipse.xtext.xbase.typesystem.arguments.ReorderedFeatureCallArguments;
@@ -253,9 +251,8 @@ public class ReorderedFeatureCallArgumentsTest extends AbstractTestingTypeRefere
   }
   
   protected void withIndizes(final IFeatureCallArguments arguments, final int... indexes) {
-    final Procedure1<Integer> _function = new Procedure1<Integer>() {
-      @Override
-      public void apply(final Integer it) {
+    for (final int it : indexes) {
+      {
         boolean _hasUnprocessedArguments = arguments.hasUnprocessedArguments();
         Assert.assertTrue(_hasUnprocessedArguments);
         final IFeatureCallArgumentSlot slot = arguments.getNextUnprocessedArgumentSlot();
@@ -264,19 +261,17 @@ public class ReorderedFeatureCallArgumentsTest extends AbstractTestingTypeRefere
         final XFeatureCall featureCall = ((XFeatureCall) _eContainer);
         EList<XExpression> _featureCallArguments = featureCall.getFeatureCallArguments();
         int _indexOf = _featureCallArguments.indexOf(expression);
-        Assert.assertEquals((it).intValue(), _indexOf);
+        Assert.assertEquals(it, _indexOf);
         slot.markProcessed();
       }
-    };
-    IterableExtensions.<Integer>forEach(((Iterable<Integer>)Conversions.doWrapArray(indexes)), _function);
+    }
     boolean _hasUnprocessedArguments = arguments.hasUnprocessedArguments();
     Assert.assertFalse(_hasUnprocessedArguments);
   }
   
   protected void withTypes(final IFeatureCallArguments arguments, final String... types) {
-    final Procedure1<String> _function = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
+    for (final String it : types) {
+      {
         boolean _hasUnprocessedArguments = arguments.hasUnprocessedArguments();
         Assert.assertTrue(_hasUnprocessedArguments);
         final IFeatureCallArgumentSlot slot = arguments.getNextUnprocessedArgumentSlot();
@@ -289,8 +284,7 @@ public class ReorderedFeatureCallArgumentsTest extends AbstractTestingTypeRefere
         }
         slot.markProcessed();
       }
-    };
-    IterableExtensions.<String>forEach(((Iterable<String>)Conversions.doWrapArray(types)), _function);
+    }
     boolean _hasUnprocessedArguments = arguments.hasUnprocessedArguments();
     Assert.assertFalse(_hasUnprocessedArguments);
   }

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ReorderedVarArgFeatureCallArgumentsTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ReorderedVarArgFeatureCallArgumentsTest.java
@@ -25,11 +25,9 @@ import org.eclipse.xtext.xbase.XClosure;
 import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.XFeatureCall;
 import org.eclipse.xtext.xbase.XNumberLiteral;
-import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.typesystem.arguments.IFeatureCallArgumentSlot;
 import org.eclipse.xtext.xbase.typesystem.arguments.IFeatureCallArguments;
 import org.eclipse.xtext.xbase.typesystem.arguments.ReorderedVarArgFeatureCallArguments;
@@ -287,9 +285,8 @@ public class ReorderedVarArgFeatureCallArgumentsTest extends AbstractTestingType
   }
   
   protected void withIndizes(final IFeatureCallArguments arguments, final int... indexes) {
-    final Procedure1<Integer> _function = new Procedure1<Integer>() {
-      @Override
-      public void apply(final Integer it) {
+    for (final int it : indexes) {
+      {
         boolean _hasUnprocessedArguments = arguments.hasUnprocessedArguments();
         Assert.assertTrue(_hasUnprocessedArguments);
         final IFeatureCallArgumentSlot slot = arguments.getNextUnprocessedArgumentSlot();
@@ -299,19 +296,17 @@ public class ReorderedVarArgFeatureCallArgumentsTest extends AbstractTestingType
         final XFeatureCall featureCall = ((XFeatureCall) _eContainer);
         EList<XExpression> _featureCallArguments = featureCall.getFeatureCallArguments();
         int _indexOf = _featureCallArguments.indexOf(expression);
-        Assert.assertEquals((it).intValue(), _indexOf);
+        Assert.assertEquals(it, _indexOf);
         slot.markProcessed();
       }
-    };
-    IterableExtensions.<Integer>forEach(((Iterable<Integer>)Conversions.doWrapArray(indexes)), _function);
+    }
     boolean _hasUnprocessedArguments = arguments.hasUnprocessedArguments();
     Assert.assertFalse(_hasUnprocessedArguments);
   }
   
   protected void withTypes(final IFeatureCallArguments arguments, final String... types) {
-    final Procedure1<String> _function = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
+    for (final String it : types) {
+      {
         boolean _hasUnprocessedArguments = arguments.hasUnprocessedArguments();
         Assert.assertTrue(_hasUnprocessedArguments);
         final IFeatureCallArgumentSlot slot = arguments.getNextUnprocessedArgumentSlot();
@@ -324,8 +319,7 @@ public class ReorderedVarArgFeatureCallArgumentsTest extends AbstractTestingType
         }
         slot.markProcessed();
       }
-    };
-    IterableExtensions.<String>forEach(((Iterable<String>)Conversions.doWrapArray(types)), _function);
+    }
     boolean _hasUnprocessedArguments = arguments.hasUnprocessedArguments();
     Assert.assertFalse(_hasUnprocessedArguments);
   }

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/AmbiguityValidationTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/AmbiguityValidationTest.java
@@ -30,7 +30,6 @@ import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.typesystem.IBatchTypeResolver;
 import org.eclipse.xtext.xbase.typesystem.IResolvedTypes;
 import org.eclipse.xtext.xbase.typesystem.computation.IAmbiguousLinkingCandidate;
@@ -74,9 +73,8 @@ public abstract class AmbiguityValidationTest extends AbstractXtendTestCase {
       }
     };
     List<String> _map = ListExtensions.<String, String>map(((List<String>)Conversions.doWrapArray(messageParts)), _function);
-    final Procedure1<String> _function_1 = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
+    for (final String it : _map) {
+      {
         final String message = singleError.getMessage();
         boolean _contains = message.contains(it);
         boolean _not = (!_contains);
@@ -84,8 +82,7 @@ public abstract class AmbiguityValidationTest extends AbstractXtendTestCase {
           Assert.assertEquals(it, message);
         }
       }
-    };
-    IterableExtensions.<String>forEach(_map, _function_1);
+    }
     EList<XtendTypeDeclaration> _xtendTypes = file.getXtendTypes();
     final XtendTypeDeclaration firstType = IterableExtensions.<XtendTypeDeclaration>head(_xtendTypes);
     EList<XtendMember> _members = firstType.getMembers();

--- a/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/SuspiciousOverloadValidationTest.java
+++ b/tests/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/SuspiciousOverloadValidationTest.java
@@ -42,7 +42,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.IteratorExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.typesystem.IBatchTypeResolver;
 import org.eclipse.xtext.xbase.typesystem.IResolvedTypes;
 import org.eclipse.xtext.xbase.typesystem.computation.IFeatureLinkingCandidate;
@@ -87,9 +86,8 @@ public class SuspiciousOverloadValidationTest extends AbstractXtendTestCase {
       }
     };
     List<String> _map = ListExtensions.<String, String>map(((List<String>)Conversions.doWrapArray(messageParts)), _function);
-    final Procedure1<String> _function_1 = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
+    for (final String it : _map) {
+      {
         final String message = singleError.getMessage();
         boolean _contains = message.contains(it);
         boolean _not = (!_contains);
@@ -97,8 +95,7 @@ public class SuspiciousOverloadValidationTest extends AbstractXtendTestCase {
           Assert.assertEquals(it, message);
         }
       }
-    };
-    IterableExtensions.<String>forEach(_map, _function_1);
+    }
     EList<XtendTypeDeclaration> _xtendTypes = file.getXtendTypes();
     final XtendTypeDeclaration firstType = IterableExtensions.<XtendTypeDeclaration>head(_xtendTypes);
     EList<XtendMember> _members = firstType.getMembers();
@@ -108,7 +105,7 @@ public class SuspiciousOverloadValidationTest extends AbstractXtendTestCase {
     final XBlockExpression block = ((XBlockExpression) _expression);
     TreeIterator<EObject> _eAllContents = block.eAllContents();
     Iterator<XAbstractFeatureCall> _filter = Iterators.<XAbstractFeatureCall>filter(_eAllContents, XAbstractFeatureCall.class);
-    final Function1<XAbstractFeatureCall, Boolean> _function_2 = new Function1<XAbstractFeatureCall, Boolean>() {
+    final Function1<XAbstractFeatureCall, Boolean> _function_1 = new Function1<XAbstractFeatureCall, Boolean>() {
       @Override
       public Boolean apply(final XAbstractFeatureCall it) {
         boolean _and = false;
@@ -123,7 +120,7 @@ public class SuspiciousOverloadValidationTest extends AbstractXtendTestCase {
         return Boolean.valueOf(_and);
       }
     };
-    final XAbstractFeatureCall featureCall = IteratorExtensions.<XAbstractFeatureCall>findLast(_filter, _function_2);
+    final XAbstractFeatureCall featureCall = IteratorExtensions.<XAbstractFeatureCall>findLast(_filter, _function_1);
     IResolvedTypes _resolveTypes = this._iBatchTypeResolver.resolveTypes(file);
     final IFeatureLinkingCandidate linkingCandidate = _resolveTypes.getLinkingCandidate(featureCall);
     Assert.assertTrue((linkingCandidate instanceof ISuspiciouslyOverloadedCandidate));
@@ -148,9 +145,8 @@ public class SuspiciousOverloadValidationTest extends AbstractXtendTestCase {
       }
     };
     List<String> _map = ListExtensions.<String, String>map(((List<String>)Conversions.doWrapArray(messageParts)), _function);
-    final Procedure1<String> _function_1 = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
+    for (final String it : _map) {
+      {
         final String message = singleError.getMessage();
         boolean _contains = message.contains(it);
         boolean _not = (!_contains);
@@ -158,8 +154,7 @@ public class SuspiciousOverloadValidationTest extends AbstractXtendTestCase {
           Assert.assertEquals(it, message);
         }
       }
-    };
-    IterableExtensions.<String>forEach(_map, _function_1);
+    }
     EList<XtendTypeDeclaration> _xtendTypes = file.getXtendTypes();
     final XtendTypeDeclaration firstType = IterableExtensions.<XtendTypeDeclaration>head(_xtendTypes);
     EList<XtendMember> _members = firstType.getMembers();
@@ -172,7 +167,7 @@ public class SuspiciousOverloadValidationTest extends AbstractXtendTestCase {
     final XBlockExpression block = ((XBlockExpression) _expression);
     TreeIterator<EObject> _eAllContents = block.eAllContents();
     Iterator<XAbstractFeatureCall> _filter = Iterators.<XAbstractFeatureCall>filter(_eAllContents, XAbstractFeatureCall.class);
-    final Function1<XAbstractFeatureCall, Boolean> _function_2 = new Function1<XAbstractFeatureCall, Boolean>() {
+    final Function1<XAbstractFeatureCall, Boolean> _function_1 = new Function1<XAbstractFeatureCall, Boolean>() {
       @Override
       public Boolean apply(final XAbstractFeatureCall it) {
         boolean _and = false;
@@ -187,7 +182,7 @@ public class SuspiciousOverloadValidationTest extends AbstractXtendTestCase {
         return Boolean.valueOf(_and);
       }
     };
-    final XAbstractFeatureCall featureCall = IteratorExtensions.<XAbstractFeatureCall>findLast(_filter, _function_2);
+    final XAbstractFeatureCall featureCall = IteratorExtensions.<XAbstractFeatureCall>findLast(_filter, _function_1);
     IResolvedTypes _resolveTypes = this._iBatchTypeResolver.resolveTypes(file);
     final IFeatureLinkingCandidate linkingCandidate = _resolveTypes.getLinkingCandidate(featureCall);
     Assert.assertTrue((linkingCandidate instanceof ISuspiciouslyOverloadedCandidate));

--- a/tests/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/tests/SwtBotProjectHelper.xtend
+++ b/tests/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/tests/SwtBotProjectHelper.xtend
@@ -81,7 +81,9 @@ class SwtBotProjectHelper {
 		try {
 			menu('File').menu('New').menu('Xtend Class').click
 		} catch (WidgetNotFoundException e) {
-			it.shells.forEach[println('''Shell: '«text»', active: «active»''')]
+			for (it : it.shells) {
+				println('''Shell: '«text»', active: «active»''')
+			}
 			SWTUtils.captureScreenshot('''«SWTBotPreferences.SCREENSHOTS_DIR»/MenuFileNotFound«System.currentTimeMillis».«SWTBotPreferences.SCREENSHOT_FORMAT»''',
 				it.shells.filter[active].head.widget)
 			throw e
@@ -95,7 +97,9 @@ class SwtBotProjectHelper {
 	}
 	
 	static def closeAllEditors(SWTWorkbenchBot it) {
-		editors.forEach[close]
+		for (it : editors) {
+			close
+		}
 	}
 	
 	static def setContent(SWTBotEclipseEditor it, CharSequence content) {
@@ -160,7 +164,9 @@ class SwtBotProjectHelper {
 				}
 			}
 		} catch(WidgetNotFoundException exc) {
-			ResourcesPlugin.workspace.root.getProject(project).getFolder('src').members.forEach[delete(true,null)]
+			for (it : ResourcesPlugin.workspace.root.getProject(project).getFolder('src').members) {
+				delete(true, null)
+			}
 		}
 	}
 	

--- a/tests/org.eclipse.xtend.ide.swtbot.tests/swtbot/xtend-gen/org/eclipse/xtend/ide/tests/SwtBotProjectHelper.java
+++ b/tests/org.eclipse.xtend.ide.swtbot.tests/swtbot/xtend-gen/org/eclipse/xtend/ide/tests/SwtBotProjectHelper.java
@@ -171,37 +171,33 @@ public class SwtBotProjectHelper {
         if (_t instanceof WidgetNotFoundException) {
           final WidgetNotFoundException e = (WidgetNotFoundException)_t;
           SWTBotShell[] _shells = it.shells();
-          final Procedure1<SWTBotShell> _function = new Procedure1<SWTBotShell>() {
-            @Override
-            public void apply(final SWTBotShell it) {
-              StringConcatenation _builder = new StringConcatenation();
-              _builder.append("Shell: \'");
-              String _text = it.getText();
-              _builder.append(_text, "");
-              _builder.append("\', active: ");
-              boolean _isActive = it.isActive();
-              _builder.append(_isActive, "");
-              InputOutput.<String>println(_builder.toString());
-            }
-          };
-          IterableExtensions.<SWTBotShell>forEach(((Iterable<SWTBotShell>)Conversions.doWrapArray(_shells)), _function);
-          StringConcatenation _builder = new StringConcatenation();
-          _builder.append(SWTBotPreferences.SCREENSHOTS_DIR, "");
-          _builder.append("/MenuFileNotFound");
+          for (final SWTBotShell it_1 : _shells) {
+            StringConcatenation _builder = new StringConcatenation();
+            _builder.append("Shell: \'");
+            String _text = it_1.getText();
+            _builder.append(_text, "");
+            _builder.append("\', active: ");
+            boolean _isActive = it_1.isActive();
+            _builder.append(_isActive, "");
+            InputOutput.<String>println(_builder.toString());
+          }
+          StringConcatenation _builder_1 = new StringConcatenation();
+          _builder_1.append(SWTBotPreferences.SCREENSHOTS_DIR, "");
+          _builder_1.append("/MenuFileNotFound");
           long _currentTimeMillis = System.currentTimeMillis();
-          _builder.append(_currentTimeMillis, "");
-          _builder.append(".");
-          _builder.append(SWTBotPreferences.SCREENSHOT_FORMAT, "");
+          _builder_1.append(_currentTimeMillis, "");
+          _builder_1.append(".");
+          _builder_1.append(SWTBotPreferences.SCREENSHOT_FORMAT, "");
           SWTBotShell[] _shells_1 = it.shells();
-          final Function1<SWTBotShell, Boolean> _function_1 = new Function1<SWTBotShell, Boolean>() {
+          final Function1<SWTBotShell, Boolean> _function = new Function1<SWTBotShell, Boolean>() {
             @Override
             public Boolean apply(final SWTBotShell it) {
               return Boolean.valueOf(it.isActive());
             }
           };
-          Iterable<SWTBotShell> _filter = IterableExtensions.<SWTBotShell>filter(((Iterable<SWTBotShell>)Conversions.doWrapArray(_shells_1)), _function_1);
+          Iterable<SWTBotShell> _filter = IterableExtensions.<SWTBotShell>filter(((Iterable<SWTBotShell>)Conversions.doWrapArray(_shells_1)), _function);
           SWTBotShell _head = IterableExtensions.<SWTBotShell>head(_filter);
-          SWTUtils.captureScreenshot(_builder.toString(), 
+          SWTUtils.captureScreenshot(_builder_1.toString(), 
             _head.widget);
           throw e;
         } else {
@@ -226,13 +222,9 @@ public class SwtBotProjectHelper {
   
   public static void closeAllEditors(final SWTWorkbenchBot it) {
     List<? extends SWTBotEditor> _editors = it.editors();
-    final Procedure1<SWTBotEditor> _function = new Procedure1<SWTBotEditor>() {
-      @Override
-      public void apply(final SWTBotEditor it) {
-        it.close();
-      }
-    };
-    IterableExtensions.forEach(_editors, _function);
+    for (final SWTBotEditor it_1 : _editors) {
+      it_1.close();
+    }
   }
   
   public static void setContent(final SWTBotEclipseEditor it, final CharSequence content) {
@@ -345,17 +337,9 @@ public class SwtBotProjectHelper {
           IProject _project = _root.getProject(project);
           IFolder _folder = _project.getFolder("src");
           IResource[] _members = _folder.members();
-          final Procedure1<IResource> _function = new Procedure1<IResource>() {
-            @Override
-            public void apply(final IResource it) {
-              try {
-                it.delete(true, null);
-              } catch (Throwable _e) {
-                throw Exceptions.sneakyThrow(_e);
-              }
-            }
-          };
-          IterableExtensions.<IResource>forEach(((Iterable<IResource>)Conversions.doWrapArray(_members)), _function);
+          for (final IResource it_1 : _members) {
+            it_1.delete(true, null);
+          }
         } else {
           throw Exceptions.sneakyThrow(_t);
         }

--- a/tests/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTestBuilder.xtend
+++ b/tests/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTestBuilder.xtend
@@ -106,17 +106,17 @@ class QuickfixTestBuilder {
 
 	def assertResolutionLabelsSubset(String... expectedLabels) {
 		val actualLabels = issuesAtCaret.map[resolutions].flatten.map[label].toSet
-		expectedLabels.forEach[
+		for (it : expectedLabels) {
 			assertTrue('Label \'' + it + '\' missing. Got ' + actualLabels.join(', '), actualLabels.contains(it))
-		]
+		}
 		this
 	}
 
 	def assertNoResolutionLabels(String... unExpectedLabels) {
 		val actualLabels = issuesAtCaret.map[resolutions].flatten.map[label].toSet
-		unExpectedLabels.forEach[
+		for (it : unExpectedLabels) {
 			assertFalse('Label \'' + it + '\' should not appear. Got ' + actualLabels.join(', '), actualLabels.contains(it))
-		]
+		}
 		this
 	}
 
@@ -178,13 +178,15 @@ class QuickfixTestBuilder {
 	def tearDown() {
 		editor = null
 		closeAllEditors(false)
-		files.forEach[ delete(true, new NullProgressMonitor) ]
+		for (it : files) {
+			delete(true, new NullProgressMonitor)
+		}
 		files.clear
 		if (modifiedIssueCodes != null) {
 			preferenceStore => [
-				modifiedIssueCodes.forEach [ code |
+				for (code : modifiedIssueCodes) {
 					setToDefault(code)
-				]
+				}
 				setToDefault(XbaseBuilderPreferenceAccess.PREF_USE_COMPILER_SOURCE)
 				setToDefault(XbaseBuilderPreferenceAccess.PREF_JAVA_VERSION)
 			]

--- a/tests/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/FileAsserts.xtend
+++ b/tests/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/FileAsserts.xtend
@@ -26,10 +26,10 @@ class FileAsserts {
 	def assertFileContains(IFile file, String... expectedContents) throws Exception {
 		file.refreshLocal(IResource::DEPTH_ZERO, null);
 		val fileContents = getContentsAsString(file);
-		expectedContents.forEach [ expectation |
+		for (expectation : expectedContents) {
 			if (!fileContents.contains(expectation)) {
 				assertEquals(expectation, fileContents)
 			}
-		]
+		}
 	}
 }

--- a/tests/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTestBuilder.java
+++ b/tests/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTestBuilder.java
@@ -253,16 +253,12 @@ public class QuickfixTestBuilder {
       };
       Iterable<String> _map_1 = IterableExtensions.<IssueResolution, String>map(_flatten, _function_1);
       final Set<String> actualLabels = IterableExtensions.<String>toSet(_map_1);
-      final Procedure1<String> _function_2 = new Procedure1<String>() {
-        @Override
-        public void apply(final String it) {
-          String _join = IterableExtensions.join(actualLabels, ", ");
-          String _plus = ((("Label \'" + it) + "\' missing. Got ") + _join);
-          boolean _contains = actualLabels.contains(it);
-          Assert.assertTrue(_plus, _contains);
-        }
-      };
-      IterableExtensions.<String>forEach(((Iterable<String>)Conversions.doWrapArray(expectedLabels)), _function_2);
+      for (final String it : expectedLabels) {
+        String _join = IterableExtensions.join(actualLabels, ", ");
+        String _plus = ((("Label \'" + it) + "\' missing. Got ") + _join);
+        boolean _contains = actualLabels.contains(it);
+        Assert.assertTrue(_plus, _contains);
+      }
       _xblockexpression = this;
     }
     return _xblockexpression;
@@ -288,16 +284,12 @@ public class QuickfixTestBuilder {
       };
       Iterable<String> _map_1 = IterableExtensions.<IssueResolution, String>map(_flatten, _function_1);
       final Set<String> actualLabels = IterableExtensions.<String>toSet(_map_1);
-      final Procedure1<String> _function_2 = new Procedure1<String>() {
-        @Override
-        public void apply(final String it) {
-          String _join = IterableExtensions.join(actualLabels, ", ");
-          String _plus = ((("Label \'" + it) + "\' should not appear. Got ") + _join);
-          boolean _contains = actualLabels.contains(it);
-          Assert.assertFalse(_plus, _contains);
-        }
-      };
-      IterableExtensions.<String>forEach(((Iterable<String>)Conversions.doWrapArray(unExpectedLabels)), _function_2);
+      for (final String it : unExpectedLabels) {
+        String _join = IterableExtensions.join(actualLabels, ", ");
+        String _plus = ((("Label \'" + it) + "\' should not appear. Got ") + _join);
+        boolean _contains = actualLabels.contains(it);
+        Assert.assertFalse(_plus, _contains);
+      }
       _xblockexpression = this;
     }
     return _xblockexpression;
@@ -449,45 +441,37 @@ public class QuickfixTestBuilder {
   }
   
   public void tearDown() {
-    this.editor = null;
-    this._workbenchTestHelper.closeAllEditors(false);
-    Set<IFile> _files = this._workbenchTestHelper.getFiles();
-    final Procedure1<IFile> _function = new Procedure1<IFile>() {
-      @Override
-      public void apply(final IFile it) {
-        try {
-          NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
-          it.delete(true, _nullProgressMonitor);
-        } catch (Throwable _e) {
-          throw Exceptions.sneakyThrow(_e);
-        }
+    try {
+      this.editor = null;
+      this._workbenchTestHelper.closeAllEditors(false);
+      Set<IFile> _files = this._workbenchTestHelper.getFiles();
+      for (final IFile it : _files) {
+        NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+        it.delete(true, _nullProgressMonitor);
       }
-    };
-    IterableExtensions.<IFile>forEach(_files, _function);
-    Set<IFile> _files_1 = this._workbenchTestHelper.getFiles();
-    _files_1.clear();
-    boolean _notEquals = (!Objects.equal(this.modifiedIssueCodes, null));
-    if (_notEquals) {
-      IPersistentPreferenceStore _preferenceStore = this.getPreferenceStore();
-      final Procedure1<IPersistentPreferenceStore> _function_1 = new Procedure1<IPersistentPreferenceStore>() {
-        @Override
-        public void apply(final IPersistentPreferenceStore it) {
-          final Procedure1<String> _function = new Procedure1<String>() {
-            @Override
-            public void apply(final String code) {
+      Set<IFile> _files_1 = this._workbenchTestHelper.getFiles();
+      _files_1.clear();
+      boolean _notEquals = (!Objects.equal(this.modifiedIssueCodes, null));
+      if (_notEquals) {
+        IPersistentPreferenceStore _preferenceStore = this.getPreferenceStore();
+        final Procedure1<IPersistentPreferenceStore> _function = new Procedure1<IPersistentPreferenceStore>() {
+          @Override
+          public void apply(final IPersistentPreferenceStore it) {
+            for (final String code : QuickfixTestBuilder.this.modifiedIssueCodes) {
               it.setToDefault(code);
             }
-          };
-          IterableExtensions.<String>forEach(QuickfixTestBuilder.this.modifiedIssueCodes, _function);
-          it.setToDefault(XbaseBuilderPreferenceAccess.PREF_USE_COMPILER_SOURCE);
-          it.setToDefault(XbaseBuilderPreferenceAccess.PREF_JAVA_VERSION);
-        }
-      };
-      ObjectExtensions.<IPersistentPreferenceStore>operator_doubleArrow(_preferenceStore, _function_1);
-      this.modifiedIssueCodes = null;
+            it.setToDefault(XbaseBuilderPreferenceAccess.PREF_USE_COMPILER_SOURCE);
+            it.setToDefault(XbaseBuilderPreferenceAccess.PREF_JAVA_VERSION);
+          }
+        };
+        ObjectExtensions.<IPersistentPreferenceStore>operator_doubleArrow(_preferenceStore, _function);
+        this.modifiedIssueCodes = null;
+      }
+      NullProgressMonitor _nullProgressMonitor_1 = new NullProgressMonitor();
+      this._syncUtil.yieldToQueuedDisplayJobs(_nullProgressMonitor_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
     }
-    NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
-    this._syncUtil.yieldToQueuedDisplayJobs(_nullProgressMonitor);
   }
   
   public QuickfixTestBuilder removeFile(final String fileName) {

--- a/tests/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/FileAsserts.java
+++ b/tests/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/FileAsserts.java
@@ -5,10 +5,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
-import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Assert;
 
 @SuppressWarnings("all")
@@ -39,16 +36,12 @@ public class FileAsserts {
   public void assertFileContains(final IFile file, final String... expectedContents) throws Exception {
     file.refreshLocal(IResource.DEPTH_ZERO, null);
     final String fileContents = WorkbenchTestHelper.getContentsAsString(file);
-    final Procedure1<String> _function = new Procedure1<String>() {
-      @Override
-      public void apply(final String expectation) {
-        boolean _contains = fileContents.contains(expectation);
-        boolean _not = (!_contains);
-        if (_not) {
-          Assert.assertEquals(expectation, fileContents);
-        }
+    for (final String expectation : expectedContents) {
+      boolean _contains = fileContents.contains(expectation);
+      boolean _not = (!_contains);
+      if (_not) {
+        Assert.assertEquals(expectation, fileContents);
       }
-    };
-    IterableExtensions.<String>forEach(((Iterable<String>)Conversions.doWrapArray(expectedContents)), _function);
+    }
   }
 }

--- a/tests/org.eclipse.xtend.ide.tests/quarantine/src/org/eclipse/xtend/ide/tests/refactoring/DependentElementsCalculatorTests.xtend
+++ b/tests/org.eclipse.xtend.ide.tests/quarantine/src/org/eclipse/xtend/ide/tests/refactoring/DependentElementsCalculatorTests.xtend
@@ -37,8 +37,9 @@ class DependentElementsCalculatorTests extends AbstractXtendUITestCase {
 		val dependentElementURIs = dependentElementsCalculator.getDependentElementURIs(fooClass, new NullProgressMonitor)
 		assertEquals(3, dependentElementURIs.size);
 		val fooFunction = fooClass.members.get(0) as XtendFunction
-		newArrayList(fooFunction, fooClass.inferredType, fooClass.inferredConstructor)
-			.forEach[assertTrue(it.toString, dependentElementURIs.exists[ element | element == it.URI])]
+		for (it : newArrayList(fooFunction, fooClass.inferredType, fooClass.inferredConstructor)) {
+			assertTrue(it.toString, dependentElementURIs.exists[element|element == it.URI])
+		}
 	}
 	
 	@Test def testPolymorphicDispatch() {
@@ -55,7 +56,8 @@ class DependentElementsCalculatorTests extends AbstractXtendUITestCase {
 		val fooMethod1 = fooClass.members.get(1)
 		val dependentElementURIs = dependentElementsCalculator.getDependentElementURIs(fooMethod1, new NullProgressMonitor)
 		assertEquals(5, dependentElementURIs.size);
-		(fooClass.members + fooClass.inferredType.members).filter[!(it instanceof JvmConstructor)].toList
-			.forEach[assertTrue(it.toString, dependentElementURIs.exists[ element | element == it.URI])]
+		for (it : (fooClass.members + fooClass.inferredType.members).filter[!(it instanceof JvmConstructor)].toList) {
+			assertTrue(it.toString, dependentElementURIs.exists[element|element == it.URI])
+		}
 	}
 }

--- a/tests/org.eclipse.xtend.ide.tests/quarantine/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/DependentElementsCalculatorTests.java
+++ b/tests/org.eclipse.xtend.ide.tests/quarantine/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/DependentElementsCalculatorTests.java
@@ -29,7 +29,6 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -79,22 +78,18 @@ public class DependentElementsCalculatorTests extends AbstractXtendUITestCase {
       JvmGenericType _inferredType = this.associations.getInferredType(fooClass);
       JvmConstructor _inferredConstructor = this.associations.getInferredConstructor(fooClass);
       ArrayList<EObject> _newArrayList = CollectionLiterals.<EObject>newArrayList(fooFunction, _inferredType, _inferredConstructor);
-      final Procedure1<EObject> _function = new Procedure1<EObject>() {
-        @Override
-        public void apply(final EObject it) {
-          String _string = it.toString();
-          final Function1<URI, Boolean> _function = new Function1<URI, Boolean>() {
-            @Override
-            public Boolean apply(final URI element) {
-              URI _uRI = EcoreUtil.getURI(it);
-              return Boolean.valueOf(Objects.equal(element, _uRI));
-            }
-          };
-          boolean _exists = IterableExtensions.<URI>exists(dependentElementURIs, _function);
-          Assert.assertTrue(_string, _exists);
-        }
-      };
-      IterableExtensions.<EObject>forEach(_newArrayList, _function);
+      for (final EObject it : _newArrayList) {
+        String _string = it.toString();
+        final Function1<URI, Boolean> _function = new Function1<URI, Boolean>() {
+          @Override
+          public Boolean apply(final URI element) {
+            URI _uRI = EcoreUtil.getURI(it);
+            return Boolean.valueOf(Objects.equal(element, _uRI));
+          }
+        };
+        boolean _exists = IterableExtensions.<URI>exists(dependentElementURIs, _function);
+        Assert.assertTrue(_string, _exists);
+      }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -143,22 +138,18 @@ public class DependentElementsCalculatorTests extends AbstractXtendUITestCase {
       };
       Iterable<EObject> _filter = IterableExtensions.<EObject>filter(_plus, _function);
       List<EObject> _list = IterableExtensions.<EObject>toList(_filter);
-      final Procedure1<EObject> _function_1 = new Procedure1<EObject>() {
-        @Override
-        public void apply(final EObject it) {
-          String _string = it.toString();
-          final Function1<URI, Boolean> _function = new Function1<URI, Boolean>() {
-            @Override
-            public Boolean apply(final URI element) {
-              URI _uRI = EcoreUtil.getURI(it);
-              return Boolean.valueOf(Objects.equal(element, _uRI));
-            }
-          };
-          boolean _exists = IterableExtensions.<URI>exists(dependentElementURIs, _function);
-          Assert.assertTrue(_string, _exists);
-        }
-      };
-      IterableExtensions.<EObject>forEach(_list, _function_1);
+      for (final EObject it : _list) {
+        String _string = it.toString();
+        final Function1<URI, Boolean> _function_1 = new Function1<URI, Boolean>() {
+          @Override
+          public Boolean apply(final URI element) {
+            URI _uRI = EcoreUtil.getURI(it);
+            return Boolean.valueOf(Objects.equal(element, _uRI));
+          }
+        };
+        boolean _exists = IterableExtensions.<URI>exists(dependentElementURIs, _function_1);
+        Assert.assertTrue(_string, _exists);
+      }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/builder/AbstractQueuedBuildDataTest.xtend
+++ b/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/builder/AbstractQueuedBuildDataTest.xtend
@@ -106,12 +106,12 @@ abstract class AbstractQueuedBuildDataTest extends AbstractXtendUITestCase {
 				if (!haveEObjectDescriptionsChanged) {
 					return names
 				}
-				getNew?.exportedObjects?.forEach [
+				for (it : getNew?.exportedObjects) {
 					names += name.toString
-				]
-				old?.exportedObjects?.forEach [
+				}
+				for (it : old?.exportedObjects) {
 					names += name.toString
-				]
+				}
 				names
 			}].reduce[t, t2|
 			{

--- a/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/builder/WorkspaceScenariosTest.xtend
+++ b/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/builder/WorkspaceScenariosTest.xtend
@@ -196,7 +196,9 @@ class WorkspaceScenariosTest {
 			val jarin = jarInputStream(listOfContents.entrySet.map[key->value].toList)
 			return ByteStreams.toByteArray(jarin)
 		} finally {
-			listOfContents.values.forEach[close]
+			for (it : listOfContents.values) {
+				close
+			}
 			project.delete(true, true, null)
 		}
 	}

--- a/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/XbaseEditorOpenClassFileTest.xtend
+++ b/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/XbaseEditorOpenClassFileTest.xtend
@@ -271,7 +271,9 @@ import org.junit.Before
 			val jarin = jarInputStream(listOfContents.entrySet.map[key->value].toList)
 			return ByteStreams.toByteArray(jarin)
 		} finally {
-			listOfContents.values.forEach[close]
+			for (it : listOfContents.values) {
+				close
+			}
 			project.delete(true, true, null)
 		}
 	}

--- a/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/findrefs/JdtFindReferencesTest.xtend
+++ b/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/findrefs/JdtFindReferencesTest.xtend
@@ -323,10 +323,15 @@ class JdtFindReferencesTest extends AbstractXtendUITestCase {
 			events += it 
 			if(it instanceof MatchEvent) {
 				val matches = matches.filter[m|filters.forall[!filters(m)]]
-				if(kind == MatchEvent::ADDED)
-					matches.forEach[elements += element]
-				else 
-				 	matches.forEach[elements.remove(element)]
+				if (kind == MatchEvent::ADDED) {
+					for (it : matches) {
+						elements += element
+					}
+				} else {
+					for (it : matches) {
+						elements.remove(element)
+					}
+				}
 			}
 		]
 		SearchUtil::runQueryInForeground(workbench.activeWorkbenchWindow, query)

--- a/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/macros/JdtBasedProcessorProviderTest.xtend
+++ b/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/macros/JdtBasedProcessorProviderTest.xtend
@@ -154,9 +154,9 @@ class JdtBasedProcessorProviderTest {
 		val result = createJavaProject(name)
 		result.project.addNature(XtextProjectHelper.NATURE_ID)
 		xtendLibs.addLibsToClasspath(result, null)
-		upstreamProjects.forEach [
+		for (it : upstreamProjects) {
 			addToClasspath(result, JavaCore.newProjectEntry(getPath(), true));
-		]
+		}
 		return result
 	}
 	

--- a/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/macros/UIResourceChangeRegistryTest.xtend
+++ b/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/macros/UIResourceChangeRegistryTest.xtend
@@ -47,16 +47,16 @@ class UIResourceChangeRegistryTest extends AbstractXtendUITestCase {
 	val URI uri = URI.createURI("synthetic://testing/uri")
 	
 	@Test def void testConcurrentDiscard() throws Exception {
-		(1..10000).forEach[ 
+		for (it : 1 .. 10000) { 
 			resourceChangeRegistry.registerCreateOrModify('/foo', uri.appendSegment(it.toString))
-		]
+		}
 		
 		val Runnable r = [
 			val random = new SecureRandom(#[1 as byte])
-			(1..1000).forEach[
+			for (it : 1 .. 1000) {
 				val removedURI = uri.appendSegment(random.nextInt(10000).toString)
 				resourceChangeRegistry.discardCreateOrModifyInformation(removedURI)
-			]
+			}
 		]  
 		val executorService = Executors.newCachedThreadPool
 		try {

--- a/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/builder/AbstractQueuedBuildDataTest.java
+++ b/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/builder/AbstractQueuedBuildDataTest.java
@@ -35,7 +35,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.Functions.Function2;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure0;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Assert;
 
 /**
@@ -177,32 +176,20 @@ public abstract class AbstractQueuedBuildDataTest extends AbstractXtendUITestCas
           if (_new!=null) {
             _exportedObjects=_new.getExportedObjects();
           }
-          if (_exportedObjects!=null) {
-            final Procedure1<IEObjectDescription> _function = new Procedure1<IEObjectDescription>() {
-              @Override
-              public void apply(final IEObjectDescription it) {
-                QualifiedName _name = it.getName();
-                String _string = _name.toString();
-                names.add(_string);
-              }
-            };
-            IterableExtensions.<IEObjectDescription>forEach(_exportedObjects, _function);
+          for (final IEObjectDescription it_1 : _exportedObjects) {
+            QualifiedName _name = it_1.getName();
+            String _string = _name.toString();
+            names.add(_string);
           }
           IResourceDescription _old = it.getOld();
           Iterable<IEObjectDescription> _exportedObjects_1 = null;
           if (_old!=null) {
             _exportedObjects_1=_old.getExportedObjects();
           }
-          if (_exportedObjects_1!=null) {
-            final Procedure1<IEObjectDescription> _function_1 = new Procedure1<IEObjectDescription>() {
-              @Override
-              public void apply(final IEObjectDescription it) {
-                QualifiedName _name = it.getName();
-                String _string = _name.toString();
-                names.add(_string);
-              }
-            };
-            IterableExtensions.<IEObjectDescription>forEach(_exportedObjects_1, _function_1);
+          for (final IEObjectDescription it_2 : _exportedObjects_1) {
+            QualifiedName _name_1 = it_2.getName();
+            String _string_1 = _name_1.toString();
+            names.add(_string_1);
           }
           _xblockexpression = names;
         }

--- a/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/builder/WorkspaceScenariosTest.java
+++ b/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/builder/WorkspaceScenariosTest.java
@@ -48,7 +48,6 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Pair;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -355,17 +354,9 @@ public class WorkspaceScenariosTest {
         return ByteStreams.toByteArray(jarin);
       } finally {
         Collection<InputStream> _values = listOfContents.values();
-        final Procedure1<InputStream> _function_2 = new Procedure1<InputStream>() {
-          @Override
-          public void apply(final InputStream it) {
-            try {
-              it.close();
-            } catch (Throwable _e) {
-              throw Exceptions.sneakyThrow(_e);
-            }
-          }
-        };
-        IterableExtensions.<InputStream>forEach(_values, _function_2);
+        for (final InputStream it : _values) {
+          it.close();
+        }
         project.delete(true, true, null);
       }
     } catch (Throwable _e) {

--- a/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/XbaseEditorOpenClassFileTest.java
+++ b/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/XbaseEditorOpenClassFileTest.java
@@ -42,7 +42,6 @@ import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Pair;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -477,17 +476,9 @@ public class XbaseEditorOpenClassFileTest extends AbstractXtendUITestCase {
         return ByteStreams.toByteArray(jarin);
       } finally {
         Collection<InputStream> _values = listOfContents.values();
-        final Procedure1<InputStream> _function_2 = new Procedure1<InputStream>() {
-          @Override
-          public void apply(final InputStream it) {
-            try {
-              it.close();
-            } catch (Throwable _e) {
-              throw Exceptions.sneakyThrow(_e);
-            }
-          }
-        };
-        IterableExtensions.<InputStream>forEach(_values, _function_2);
+        for (final InputStream it : _values) {
+          it.close();
+        }
         project.delete(true, true, null);
       }
     } catch (Throwable _e) {

--- a/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/findrefs/JdtFindReferencesTest.java
+++ b/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/findrefs/JdtFindReferencesTest.java
@@ -1143,23 +1143,15 @@ public class JdtFindReferencesTest extends AbstractXtendUITestCase {
               int _kind = ((MatchEvent)it).getKind();
               boolean _equals = (_kind == MatchEvent.ADDED);
               if (_equals) {
-                final Procedure1<Match> _function_1 = new Procedure1<Match>() {
-                  @Override
-                  public void apply(final Match it) {
-                    Object _element = it.getElement();
-                    elements.add(_element);
-                  }
-                };
-                IterableExtensions.<Match>forEach(matches, _function_1);
+                for (final Match it_1 : matches) {
+                  Object _element = it_1.getElement();
+                  elements.add(_element);
+                }
               } else {
-                final Procedure1<Match> _function_2 = new Procedure1<Match>() {
-                  @Override
-                  public void apply(final Match it) {
-                    Object _element = it.getElement();
-                    elements.remove(_element);
-                  }
-                };
-                IterableExtensions.<Match>forEach(matches, _function_2);
+                for (final Match it_2 : matches) {
+                  Object _element_1 = it_2.getElement();
+                  elements.remove(_element_1);
+                }
               }
             }
           }

--- a/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/macros/JdtBasedProcessorProviderTest.java
+++ b/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/macros/JdtBasedProcessorProviderTest.java
@@ -23,10 +23,7 @@ import org.eclipse.xtext.junit4.ui.util.IResourcesSetupUtil;
 import org.eclipse.xtext.junit4.ui.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.util.StringInputStream;
-import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -240,19 +237,11 @@ public class JdtBasedProcessorProviderTest {
       IProject _project = result.getProject();
       IResourcesSetupUtil.addNature(_project, XtextProjectHelper.NATURE_ID);
       this.xtendLibs.addLibsToClasspath(result, null);
-      final Procedure1<IJavaProject> _function = new Procedure1<IJavaProject>() {
-        @Override
-        public void apply(final IJavaProject it) {
-          try {
-            IPath _path = it.getPath();
-            IClasspathEntry _newProjectEntry = JavaCore.newProjectEntry(_path, true);
-            JavaProjectSetupUtil.addToClasspath(result, _newProjectEntry);
-          } catch (Throwable _e) {
-            throw Exceptions.sneakyThrow(_e);
-          }
-        }
-      };
-      IterableExtensions.<IJavaProject>forEach(((Iterable<IJavaProject>)Conversions.doWrapArray(upstreamProjects)), _function);
+      for (final IJavaProject it : upstreamProjects) {
+        IPath _path = it.getPath();
+        IClasspathEntry _newProjectEntry = JavaCore.newProjectEntry(_path, true);
+        JavaProjectSetupUtil.addToClasspath(result, _newProjectEntry);
+      }
       return result;
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);

--- a/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/macros/UIResourceChangeRegistryTest.java
+++ b/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/macros/UIResourceChangeRegistryTest.java
@@ -45,7 +45,6 @@ import org.eclipse.xtext.xbase.lib.IntegerRange;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.eclipse.xtext.xbase.lib.Pair;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -174,33 +173,27 @@ public class UIResourceChangeRegistryTest extends AbstractXtendUITestCase {
   public void testConcurrentDiscard() throws Exception {
     try {
       IntegerRange _upTo = new IntegerRange(1, 10000);
-      final Procedure1<Integer> _function = new Procedure1<Integer>() {
-        @Override
-        public void apply(final Integer it) {
-          String _string = it.toString();
-          URI _appendSegment = UIResourceChangeRegistryTest.this.uri.appendSegment(_string);
-          UIResourceChangeRegistryTest.this.resourceChangeRegistry.registerCreateOrModify("/foo", _appendSegment);
-        }
-      };
-      IterableExtensions.<Integer>forEach(_upTo, _function);
-      final Runnable _function_1 = new Runnable() {
+      for (final Integer it : _upTo) {
+        String _string = it.toString();
+        URI _appendSegment = this.uri.appendSegment(_string);
+        this.resourceChangeRegistry.registerCreateOrModify("/foo", _appendSegment);
+      }
+      final Runnable _function = new Runnable() {
         @Override
         public void run() {
           final SecureRandom random = new SecureRandom(new byte[] { ((byte) 1) });
           IntegerRange _upTo = new IntegerRange(1, 1000);
-          final Procedure1<Integer> _function = new Procedure1<Integer>() {
-            @Override
-            public void apply(final Integer it) {
+          for (final Integer it : _upTo) {
+            {
               int _nextInt = random.nextInt(10000);
               String _string = Integer.valueOf(_nextInt).toString();
               final URI removedURI = UIResourceChangeRegistryTest.this.uri.appendSegment(_string);
               UIResourceChangeRegistryTest.this.resourceChangeRegistry.discardCreateOrModifyInformation(removedURI);
             }
-          };
-          IterableExtensions.<Integer>forEach(_upTo, _function);
+          }
         }
       };
-      final Runnable r = _function_1;
+      final Runnable r = _function;
       final ExecutorService executorService = Executors.newCachedThreadPool();
       try {
         final Future<?> future1 = executorService.submit(r);

--- a/tests/org.eclipse.xtext.builder.tests/xtext.standalone.builder.junit.launch
+++ b/tests/org.eclipse.xtext.builder.tests/xtext.standalone.builder.junit.launch
@@ -11,6 +11,8 @@
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.xtext.builder.tests"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
 </launchConfiguration>

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/FormattableDocumentTest.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/formatting2/internal/FormattableDocumentTest.xtend
@@ -51,7 +51,8 @@ class FormattableDocumentTest {
 				idlist  aaa  bbb  ccc  ddd  eee  fff
 			'''
 			formatter = [ IDList model, extension regions, extension document |
-				model.regionFor.ruleCallsTo(IDRule).forEach[prepend[autowrap; oneSpace]]
+				for (it : model.regionFor.ruleCallsTo(IDRule))
+					prepend[autowrap; oneSpace]
 			]
 			expectation = '''
 				idlist aaa

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/XtextResourceSetTest.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/XtextResourceSetTest.xtend
@@ -330,7 +330,7 @@ class SynchronizedXtextResourceSetTest extends AbstractXtextResourceSetTest {
 		]
 		resourceSet.resourceFactoryRegistry.extensionToFactoryMap.put('xmi', nullFactory)
 		val threads = newArrayList()
-		(1..10).forEach [ i |
+		for (i : 1 .. 10) {
 			threads.add(new Thread [
 				val resources = newArrayList
 				for(var int j = 0; j < 5000; j++) {
@@ -340,7 +340,7 @@ class SynchronizedXtextResourceSetTest extends AbstractXtextResourceSetTest {
 					resource.URI = URI.createURI(resource.getURI + 'b')
 				}	
 			])
-		]
+		}
 		for (Thread thread : threads) {
 			thread.start();
 		}

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/GrammarPDAProviderTest.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/serializer/GrammarPDAProviderTest.xtend
@@ -489,7 +489,8 @@ class GrammarPDAProviderTest {
 		''')
 		validator.assertNoErrors(grammar)
 		val pdas = pdaProvider.getGrammarPDAs(grammar)
-		pdas.values.forEach[assertNoLeakedGrammarElements(grammar, it)]
+		for (it : pdas.values)
+			assertNoLeakedGrammarElements(grammar, it)
 
 //		pdas.forEach[p1, p2|p2.toDot(p1.name)]
 		return pdas.keySet.sort.map [

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/wizard/WizardConfigurationTest.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/wizard/WizardConfigurationTest.xtend
@@ -52,9 +52,8 @@ class WizardConfigurationTest {
 		config.ideProject.enabled = true
 		config.preferredBuildSystem = BuildSystem.MAVEN
 		assertTrue(config.needsTychoBuild)
-		#[config.runtimeProject, config.ideProject, config.uiProject].forEach[
+		for (it : #[config.runtimeProject, config.ideProject, config.uiProject])
 			assertTrue(pom.content.contains("eclipse-plugin"))
-		]
 		assertTrue(config.parentProject.pom.content.contains("tycho"))
 	}
 	
@@ -116,49 +115,48 @@ class WizardConfigurationTest {
 	def void inlinedTestProjectsAddTheirDependenciesToTheMainProject() {
 		config.runtimeProject.testProject.enabled = true
 		config.sourceLayout = SourceLayout.MAVEN
-		config.runtimeProject.testProject.externalDependencies.forEach[testDependency|
+		for (testDependency : config.runtimeProject.testProject.externalDependencies) {
 			assertTrue(config.runtimeProject.externalDependencies.exists[
 				maven.artifactId == testDependency.maven.artifactId
 				&& p2.bundleId == testDependency.p2.bundleId
 				&& p2.packages == testDependency.p2.packages
 			])
-		]
+		}
 	}
 	
 	@Test
 	def void inlinedTestProjectsAddTheirSourceFoldersToTheMainProject() {
 		config.runtimeProject.testProject.enabled = true
 		config.sourceLayout = SourceLayout.MAVEN
-		config.runtimeProject.testProject.sourceFolders.forEach[testFolder|
+		for (testFolder : config.runtimeProject.testProject.sourceFolders)
 			assertTrue(config.runtimeProject.sourceFolders.contains(testFolder))
-		]
 	}
 	
 	@Test
 	def void mavenProjectsHaveAPom() {
 		config.preferredBuildSystem = BuildSystem.MAVEN
-		allJavaProjects.filter[isPartOfMavenBuild].forEach[
+		for (it : allJavaProjects.filter[isPartOfMavenBuild]) {
 			enabled = true
 			assertTrue(files.exists[relativePath == "pom.xml"])
-		]
+		}
 	}
 	
 	@Test
 	def void gradleProjectsHaveABuildFile() {
 		config.preferredBuildSystem = BuildSystem.GRADLE
-		allJavaProjects.filter[isPartOfGradleBuild].forEach[
+		for (it : allJavaProjects.filter[isPartOfGradleBuild]) {
 			enabled = true
 			assertTrue(files.exists[relativePath == "build.gradle"])
-		]
+		}
 	}
 	
 	@Test
 	def void pluginProjectsHaveEclipseMetaData() {
-		allJavaProjects.filter[isEclipsePluginProject].forEach[
+		for (it : allJavaProjects.filter[isEclipsePluginProject]) {
 			enabled = true
 			assertTrue(files.exists[relativePath == "MANIFEST.MF"])
 			assertTrue(files.exists[relativePath == "build.properties"])
-		]
+		}
 	}
 	
 	@Test
@@ -198,17 +196,15 @@ class WizardConfigurationTest {
 		config.preferredBuildSystem = BuildSystem.GRADLE
 		config.uiProject.enabled = true
 		config.ideProject.enabled = true
-		config.enabledProjects.filter[eclipsePluginProject].forEach[
+		for (it : config.enabledProjects.filter[eclipsePluginProject])
 			assertTrue(buildGradle.content.contains("eclipseClasspath.enabled=false"))
-		]
 	}
 	
 	@Test
 	def parentContainsOtherProjectsInHierarchicallayout() {
 		config.projectLayout = ProjectLayout.HIERARCHICAL
-		allJavaProjects.forEach[
+		for (it : allJavaProjects) 
 			assertTrue(location.startsWith(config.parentProject.location + "/"))
-		]
 	}
 	
 	@Test
@@ -216,25 +212,25 @@ class WizardConfigurationTest {
 		config.preferredBuildSystem = BuildSystem.MAVEN
 		config.sourceLayout = SourceLayout.PLAIN
 		val plainMavenProjects = allJavaProjects.filter[!isEclipsePluginProject && isPartOfMavenBuild]
-		plainMavenProjects.forEach[
+		for (it : plainMavenProjects) {
 			assertTrue(pom.content.contains("<directory>src</directory>"))
 			assertTrue(pom.content.contains("<source>src-gen</source>"))
 			assertTrue(pom.content.contains("<directory>src-gen</directory>"))
-		]
-		plainMavenProjects.filter[!(it instanceof TestProjectDescriptor)].forEach[
+		}
+		for (it : plainMavenProjects.filter[!(it instanceof TestProjectDescriptor)]) {
 			assertTrue(pom.content.contains("<sourceDirectory>src</sourceDirectory>"))
 			assertTrue(pom.content.contains("add-source"))
 			assertTrue(pom.content.contains("add-resource"))
 			assertFalse(pom.content.contains("add-test-source"))
 			assertFalse(pom.content.contains("add-test-resource"))
-		]
-		plainMavenProjects.filter(TestProjectDescriptor).forEach[
+		}
+		for (it : plainMavenProjects.filter(TestProjectDescriptor)) {
 			assertTrue(pom.content.contains("<testSourceDirectory>src</testSourceDirectory>"))
 			assertTrue(pom.content.contains("add-test-source"))
 			assertTrue(pom.content.contains("add-test-resource"))
 			assertFalse(pom.content.contains("add-source"))
 			assertFalse(pom.content.contains("add-resource"))
-		]
+		}
 	}
 	
 	@Test
@@ -244,21 +240,22 @@ class WizardConfigurationTest {
 		val plainMavenProjects = allJavaProjects.filter[!isEclipsePluginProject && isPartOfMavenBuild]
 		val mainProjects = plainMavenProjects.filter[!(it instanceof TestProjectDescriptor)]
 		
-		plainMavenProjects.forEach[enabled = true]
-		
+		for (it : plainMavenProjects)
+			enabled = true
+				
 		assertTrue(plainMavenProjects.filter(TestProjectDescriptor).forall[isInlined])
-		mainProjects.forEach[
+		for (it : mainProjects) {
 			assertTrue(pom.content.contains("add-source"))
 			assertTrue(pom.content.contains("add-resource"))
 			assertTrue(pom.content.contains("<source>src/main/xtext-gen</source>"))
 			assertTrue(pom.content.contains("<directory>src/main/xtext-gen</directory>"))
-		]
-		mainProjects.filter(TestedProjectDescriptor).forEach[
+		}
+		for (it : mainProjects.filter(TestedProjectDescriptor)) {
 			assertTrue(pom.content.contains("add-test-source"))
 			assertTrue(pom.content.contains("add-test-resource"))
 			assertTrue(pom.content.contains("<source>src/test/xtext-gen</source>"))
 			assertTrue(pom.content.contains("<directory>src/test/xtext-gen</directory>"))
-		]
+		}
 	}
 	
 	@Test
@@ -268,14 +265,15 @@ class WizardConfigurationTest {
 		val plainMavenProjects = allJavaProjects.filter[!isEclipsePluginProject && isPartOfMavenBuild]
 		val mainProjects = plainMavenProjects.filter[!(it instanceof TestProjectDescriptor)]
 		
-		plainMavenProjects.forEach[enabled = true]
+		for (it : plainMavenProjects)
+			enabled = true
 		
-		mainProjects.forEach[
+		for (it : mainProjects) {
 			assertFalse(pom.content.contains("<sourceDirectory>"))
 			assertFalse(pom.content.contains("<directory>src/main/resources</directory>"))
 			assertFalse(pom.content.contains("<testSourceDirectory>"))
 			assertFalse(pom.content.contains("<directory>src/test/resources</directory>"))
-		]
+		}
 	}
 	
 	@Test
@@ -299,9 +297,8 @@ class WizardConfigurationTest {
 		config.preferredBuildSystem = BuildSystem.MAVEN
 		config.uiProject.enabled = true
 		val poms = allJavaProjects.filter(TestProjectDescriptor).filter[isEclipsePluginProject].map[pom]
-		poms.forEach[
+		for (it : poms)
 			assertTrue(content.contains("failIfNoTests"))
-		]
 	}
 	
 	@Test
@@ -312,9 +309,8 @@ class WizardConfigurationTest {
 		val parentGradle = config.parentProject.buildGradle.content
 		assertTrue(parentGradle.contains("sourceCompatibility = '1.6'"))
 		assertTrue(parentGradle.contains("targetCompatibility = '1.6'"))
-		allJavaProjects.map[manifest].forEach[
+		for (it : allJavaProjects.map[manifest])
 			assertTrue(contains("Bundle-RequiredExecutionEnvironment: JavaSE-1.6"))
-		]
 	}
 	
 	@Test
@@ -326,9 +322,8 @@ class WizardConfigurationTest {
 		val parentGradle = config.parentProject.buildGradle.content
 		assertTrue(parentGradle.contains("sourceCompatibility = '1.8'"))
 		assertTrue(parentGradle.contains("targetCompatibility = '1.8'"))
-		allJavaProjects.map[manifest].forEach[
+		for (it : allJavaProjects.map[manifest])
 			assertTrue(contains("Bundle-RequiredExecutionEnvironment: JavaSE-1.8"))
-		]
 	}
 	
 	def allJavaProjects() {

--- a/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/wizard/cli/CliWizardIntegrationTest.xtend
+++ b/tests/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/wizard/cli/CliWizardIntegrationTest.xtend
@@ -36,14 +36,14 @@ class CliWizardIntegrationTest {
 	 */
 	static def void main(String[] args) {
 		val creator = newProjectCreator
-		projectConfigs.forEach [ config |
+		for (config : projectConfigs) {
 			val targetLocation = new File("testdata/wizard-expectations", config.baseName)
 			targetLocation.mkdirs
 			org.eclipse.xtext.util.Files.sweepFolder(targetLocation)
 			config.rootLocation = targetLocation.path
 			creator.createProjects(config)
 			println("Updating expectations for " + config.baseName)
-		]
+		}
 	}
 
 	static val projectConfigs = #[
@@ -126,10 +126,10 @@ class CliWizardIntegrationTest {
 	@Test
 	def testProjectCreation() {
 		creator = newProjectCreator
-		projectConfigs.forEach[config|
+		for (config : projectConfigs) {
 			this.config = config
 			validateCreatedProjects
-		]
+		}
 	}
 
 	private def void validateCreatedProjects() {
@@ -157,7 +157,8 @@ class CliWizardIntegrationTest {
 
 	private def void collectAllFiles(File root, List<File> children) {
 		if (root.isDirectory) {
-			root.listFiles.forEach[collectAllFiles(children)]
+			for (it : root.listFiles)
+				collectAllFiles(children)
 		} else {
 			children.add(root)
 		}
@@ -175,17 +176,15 @@ class CliWizardIntegrationTest {
 		val unexpectedFiles = Sets.difference(actualFiles, expectedFiles)
 		val comparableFiles = Sets.intersection(expectedFiles, actualFiles)
 
-		missingFiles.forEach [
+		for (it : missingFiles)
 			throw new ComparisonFailure('''Missing file: «relativePath»''', content, "")
-		]
-		unexpectedFiles.forEach [
+		for (it : unexpectedFiles)
 			throw new ComparisonFailure('''Unexpected file: «relativePath»''', "", content)
-		]
-		comparableFiles.forEach [
+		for (it : comparableFiles) {
 			val expectedContent = LineDelimiters.toUnix(expectedFilesByPath.get(relativePath).content)
 			val actualContent = LineDelimiters.toUnix(actualFilesByPath.get(relativePath).content)
 			assertEquals(relativePath, expectedContent, actualContent)
-		]
+		}
 	}
 
 	@Data

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/FormattableDocumentTest.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/formatting2/internal/FormattableDocumentTest.java
@@ -35,7 +35,6 @@ import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
 import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.util.TextRegion;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -110,20 +109,16 @@ public class FormattableDocumentTest {
             ISemanticRegionsFinder _regionFor = regions.regionFor(model);
             TerminalRule _iDRule = FormattableDocumentTest.this._formatterTestLanguageGrammarAccess.getIDRule();
             List<ISemanticRegion> _ruleCallsTo = _regionFor.ruleCallsTo(_iDRule);
-            final Procedure1<ISemanticRegion> _function = new Procedure1<ISemanticRegion>() {
-              @Override
-              public void apply(final ISemanticRegion it) {
-                final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
-                  @Override
-                  public void apply(final IHiddenRegionFormatter it) {
-                    it.autowrap();
-                    it.oneSpace();
-                  }
-                };
-                document.prepend(it, _function);
-              }
-            };
-            IterableExtensions.<ISemanticRegion>forEach(_ruleCallsTo, _function);
+            for (final ISemanticRegion it : _ruleCallsTo) {
+              final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
+                @Override
+                public void apply(final IHiddenRegionFormatter it) {
+                  it.autowrap();
+                  it.oneSpace();
+                }
+              };
+              document.prepend(it, _function);
+            }
           }
         };
         it.setFormatter(_function_1);

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/resource/SynchronizedXtextResourceSetTest.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/resource/SynchronizedXtextResourceSetTest.java
@@ -28,7 +28,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IntegerRange;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -62,35 +61,31 @@ public class SynchronizedXtextResourceSetTest extends AbstractXtextResourceSetTe
       _extensionToFactoryMap.put("xmi", nullFactory);
       final ArrayList<Thread> threads = CollectionLiterals.<Thread>newArrayList();
       IntegerRange _upTo = new IntegerRange(1, 10);
-      final Procedure1<Integer> _function_1 = new Procedure1<Integer>() {
-        @Override
-        public void apply(final Integer i) {
-          final Runnable _function = new Runnable() {
-            @Override
-            public void run() {
-              final ArrayList<Resource> resources = CollectionLiterals.<Resource>newArrayList();
-              for (int j = 0; (j < 5000); j++) {
-                {
-                  String _plus = (i + " ");
-                  String _plus_1 = (_plus + Integer.valueOf(j));
-                  String _plus_2 = (_plus_1 + ".xmi");
-                  URI _createURI = URI.createURI(_plus_2);
-                  final Resource resource = resourceSet.createResource(_createURI);
-                  Assert.assertNotNull(resource);
-                  resources.add(resource);
-                  URI _uRI = resource.getURI();
-                  String _plus_3 = (_uRI + "b");
-                  URI _createURI_1 = URI.createURI(_plus_3);
-                  resource.setURI(_createURI_1);
-                }
+      for (final Integer i : _upTo) {
+        final Runnable _function_1 = new Runnable() {
+          @Override
+          public void run() {
+            final ArrayList<Resource> resources = CollectionLiterals.<Resource>newArrayList();
+            for (int j = 0; (j < 5000); j++) {
+              {
+                String _plus = (i + " ");
+                String _plus_1 = (_plus + Integer.valueOf(j));
+                String _plus_2 = (_plus_1 + ".xmi");
+                URI _createURI = URI.createURI(_plus_2);
+                final Resource resource = resourceSet.createResource(_createURI);
+                Assert.assertNotNull(resource);
+                resources.add(resource);
+                URI _uRI = resource.getURI();
+                String _plus_3 = (_uRI + "b");
+                URI _createURI_1 = URI.createURI(_plus_3);
+                resource.setURI(_createURI_1);
               }
             }
-          };
-          Thread _thread = new Thread(_function);
-          threads.add(_thread);
-        }
-      };
-      IterableExtensions.<Integer>forEach(_upTo, _function_1);
+          }
+        };
+        Thread _thread = new Thread(_function_1);
+        threads.add(_thread);
+      }
       for (final Thread thread : threads) {
         thread.start();
       }

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/serializer/GrammarPDAProviderTest.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/serializer/GrammarPDAProviderTest.java
@@ -36,7 +36,6 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -942,16 +941,12 @@ public class GrammarPDAProviderTest {
       this.validator.assertNoErrors(grammar);
       final Map<ISerializationContext, Pda<ISerState, RuleCall>> pdas = this.pdaProvider.getGrammarPDAs(grammar);
       Collection<Pda<ISerState, RuleCall>> _values = pdas.values();
-      final Procedure1<Pda<ISerState, RuleCall>> _function = new Procedure1<Pda<ISerState, RuleCall>>() {
-        @Override
-        public void apply(final Pda<ISerState, RuleCall> it) {
-          GrammarPDAProviderTest.this.assertNoLeakedGrammarElements(grammar, it);
-        }
-      };
-      IterableExtensions.<Pda<ISerState, RuleCall>>forEach(_values, _function);
+      for (final Pda<ISerState, RuleCall> it : _values) {
+        this.assertNoLeakedGrammarElements(grammar, it);
+      }
       Set<ISerializationContext> _keySet = pdas.keySet();
       List<ISerializationContext> _sort = IterableExtensions.<ISerializationContext>sort(_keySet);
-      final Function1<ISerializationContext, String> _function_1 = new Function1<ISerializationContext, String>() {
+      final Function1<ISerializationContext, String> _function = new Function1<ISerializationContext, String>() {
         @Override
         public String apply(final ISerializationContext it) {
           StringConcatenation _builder = new StringConcatenation();
@@ -966,7 +961,7 @@ public class GrammarPDAProviderTest {
           return _builder.toString();
         }
       };
-      List<String> _map = ListExtensions.<ISerializationContext, String>map(_sort, _function_1);
+      List<String> _map = ListExtensions.<ISerializationContext, String>map(_sort, _function);
       return IterableExtensions.join(_map);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/wizard/WizardConfigurationTest.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/wizard/WizardConfigurationTest.java
@@ -129,21 +129,17 @@ public class WizardConfigurationTest {
     RuntimeProjectDescriptor _runtimeProject = this.config.getRuntimeProject();
     IdeProjectDescriptor _ideProject_1 = this.config.getIdeProject();
     UiProjectDescriptor _uiProject_1 = this.config.getUiProject();
-    final Procedure1<ProjectDescriptor> _function = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
-        PomFile _pom = it.pom();
-        String _content = _pom.getContent();
-        boolean _contains = _content.contains("eclipse-plugin");
-        Assert.assertTrue(_contains);
-      }
-    };
-    IterableExtensions.forEach(Collections.<ProjectDescriptor>unmodifiableList(CollectionLiterals.<ProjectDescriptor>newArrayList(_runtimeProject, _ideProject_1, _uiProject_1)), _function);
+    for (final ProjectDescriptor it : Collections.<ProjectDescriptor>unmodifiableList(CollectionLiterals.<ProjectDescriptor>newArrayList(_runtimeProject, _ideProject_1, _uiProject_1))) {
+      PomFile _pom = it.pom();
+      String _content = _pom.getContent();
+      boolean _contains = _content.contains("eclipse-plugin");
+      Assert.assertTrue(_contains);
+    }
     ParentProjectDescriptor _parentProject = this.config.getParentProject();
-    PomFile _pom = _parentProject.pom();
-    String _content = _pom.getContent();
-    boolean _contains = _content.contains("tycho");
-    Assert.assertTrue(_contains);
+    PomFile _pom_1 = _parentProject.pom();
+    String _content_1 = _pom_1.getContent();
+    boolean _contains_1 = _content_1.contains("tycho");
+    Assert.assertTrue(_contains_1);
   }
   
   @Test
@@ -243,49 +239,45 @@ public class WizardConfigurationTest {
     RuntimeProjectDescriptor _runtimeProject_1 = this.config.getRuntimeProject();
     TestProjectDescriptor _testProject_1 = _runtimeProject_1.getTestProject();
     Set<ExternalDependency> _externalDependencies = _testProject_1.getExternalDependencies();
-    final Procedure1<ExternalDependency> _function = new Procedure1<ExternalDependency>() {
-      @Override
-      public void apply(final ExternalDependency testDependency) {
-        RuntimeProjectDescriptor _runtimeProject = WizardConfigurationTest.this.config.getRuntimeProject();
-        Set<ExternalDependency> _externalDependencies = _runtimeProject.getExternalDependencies();
-        final Function1<ExternalDependency, Boolean> _function = new Function1<ExternalDependency, Boolean>() {
-          @Override
-          public Boolean apply(final ExternalDependency it) {
-            boolean _and = false;
-            boolean _and_1 = false;
-            ExternalDependency.MavenCoordinates _maven = it.getMaven();
-            String _artifactId = _maven.getArtifactId();
-            ExternalDependency.MavenCoordinates _maven_1 = testDependency.getMaven();
-            String _artifactId_1 = _maven_1.getArtifactId();
-            boolean _equals = Objects.equal(_artifactId, _artifactId_1);
-            if (!_equals) {
-              _and_1 = false;
-            } else {
-              ExternalDependency.P2Coordinates _p2 = it.getP2();
-              String _bundleId = _p2.getBundleId();
-              ExternalDependency.P2Coordinates _p2_1 = testDependency.getP2();
-              String _bundleId_1 = _p2_1.getBundleId();
-              boolean _equals_1 = Objects.equal(_bundleId, _bundleId_1);
-              _and_1 = _equals_1;
-            }
-            if (!_and_1) {
-              _and = false;
-            } else {
-              ExternalDependency.P2Coordinates _p2_2 = it.getP2();
-              Set<String> _packages = _p2_2.getPackages();
-              ExternalDependency.P2Coordinates _p2_3 = testDependency.getP2();
-              Set<String> _packages_1 = _p2_3.getPackages();
-              boolean _equals_2 = Objects.equal(_packages, _packages_1);
-              _and = _equals_2;
-            }
-            return Boolean.valueOf(_and);
+    for (final ExternalDependency testDependency : _externalDependencies) {
+      RuntimeProjectDescriptor _runtimeProject_2 = this.config.getRuntimeProject();
+      Set<ExternalDependency> _externalDependencies_1 = _runtimeProject_2.getExternalDependencies();
+      final Function1<ExternalDependency, Boolean> _function = new Function1<ExternalDependency, Boolean>() {
+        @Override
+        public Boolean apply(final ExternalDependency it) {
+          boolean _and = false;
+          boolean _and_1 = false;
+          ExternalDependency.MavenCoordinates _maven = it.getMaven();
+          String _artifactId = _maven.getArtifactId();
+          ExternalDependency.MavenCoordinates _maven_1 = testDependency.getMaven();
+          String _artifactId_1 = _maven_1.getArtifactId();
+          boolean _equals = Objects.equal(_artifactId, _artifactId_1);
+          if (!_equals) {
+            _and_1 = false;
+          } else {
+            ExternalDependency.P2Coordinates _p2 = it.getP2();
+            String _bundleId = _p2.getBundleId();
+            ExternalDependency.P2Coordinates _p2_1 = testDependency.getP2();
+            String _bundleId_1 = _p2_1.getBundleId();
+            boolean _equals_1 = Objects.equal(_bundleId, _bundleId_1);
+            _and_1 = _equals_1;
           }
-        };
-        boolean _exists = IterableExtensions.<ExternalDependency>exists(_externalDependencies, _function);
-        Assert.assertTrue(_exists);
-      }
-    };
-    IterableExtensions.<ExternalDependency>forEach(_externalDependencies, _function);
+          if (!_and_1) {
+            _and = false;
+          } else {
+            ExternalDependency.P2Coordinates _p2_2 = it.getP2();
+            Set<String> _packages = _p2_2.getPackages();
+            ExternalDependency.P2Coordinates _p2_3 = testDependency.getP2();
+            Set<String> _packages_1 = _p2_3.getPackages();
+            boolean _equals_2 = Objects.equal(_packages, _packages_1);
+            _and = _equals_2;
+          }
+          return Boolean.valueOf(_and);
+        }
+      };
+      boolean _exists = IterableExtensions.<ExternalDependency>exists(_externalDependencies_1, _function);
+      Assert.assertTrue(_exists);
+    }
   }
   
   @Test
@@ -297,16 +289,12 @@ public class WizardConfigurationTest {
     RuntimeProjectDescriptor _runtimeProject_1 = this.config.getRuntimeProject();
     TestProjectDescriptor _testProject_1 = _runtimeProject_1.getTestProject();
     Set<String> _sourceFolders = _testProject_1.getSourceFolders();
-    final Procedure1<String> _function = new Procedure1<String>() {
-      @Override
-      public void apply(final String testFolder) {
-        RuntimeProjectDescriptor _runtimeProject = WizardConfigurationTest.this.config.getRuntimeProject();
-        Set<String> _sourceFolders = _runtimeProject.getSourceFolders();
-        boolean _contains = _sourceFolders.contains(testFolder);
-        Assert.assertTrue(_contains);
-      }
-    };
-    IterableExtensions.<String>forEach(_sourceFolders, _function);
+    for (final String testFolder : _sourceFolders) {
+      RuntimeProjectDescriptor _runtimeProject_2 = this.config.getRuntimeProject();
+      Set<String> _sourceFolders_1 = _runtimeProject_2.getSourceFolders();
+      boolean _contains = _sourceFolders_1.contains(testFolder);
+      Assert.assertTrue(_contains);
+    }
   }
   
   @Test
@@ -320,23 +308,21 @@ public class WizardConfigurationTest {
       }
     };
     Iterable<? extends ProjectDescriptor> _filter = IterableExtensions.filter(_allJavaProjects, _function);
-    final Procedure1<ProjectDescriptor> _function_1 = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
+    for (final ProjectDescriptor it : _filter) {
+      {
         it.setEnabled(true);
         Iterable<? extends AbstractFile> _files = it.getFiles();
-        final Function1<AbstractFile, Boolean> _function = new Function1<AbstractFile, Boolean>() {
+        final Function1<AbstractFile, Boolean> _function_1 = new Function1<AbstractFile, Boolean>() {
           @Override
           public Boolean apply(final AbstractFile it) {
             String _relativePath = it.getRelativePath();
             return Boolean.valueOf(Objects.equal(_relativePath, "pom.xml"));
           }
         };
-        boolean _exists = IterableExtensions.exists(_files, _function);
+        boolean _exists = IterableExtensions.exists(_files, _function_1);
         Assert.assertTrue(_exists);
       }
-    };
-    IterableExtensions.forEach(_filter, _function_1);
+    }
   }
   
   @Test
@@ -350,23 +336,21 @@ public class WizardConfigurationTest {
       }
     };
     Iterable<? extends ProjectDescriptor> _filter = IterableExtensions.filter(_allJavaProjects, _function);
-    final Procedure1<ProjectDescriptor> _function_1 = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
+    for (final ProjectDescriptor it : _filter) {
+      {
         it.setEnabled(true);
         Iterable<? extends AbstractFile> _files = it.getFiles();
-        final Function1<AbstractFile, Boolean> _function = new Function1<AbstractFile, Boolean>() {
+        final Function1<AbstractFile, Boolean> _function_1 = new Function1<AbstractFile, Boolean>() {
           @Override
           public Boolean apply(final AbstractFile it) {
             String _relativePath = it.getRelativePath();
             return Boolean.valueOf(Objects.equal(_relativePath, "build.gradle"));
           }
         };
-        boolean _exists = IterableExtensions.exists(_files, _function);
+        boolean _exists = IterableExtensions.exists(_files, _function_1);
         Assert.assertTrue(_exists);
       }
-    };
-    IterableExtensions.forEach(_filter, _function_1);
+    }
   }
   
   @Test
@@ -379,33 +363,31 @@ public class WizardConfigurationTest {
       }
     };
     Iterable<? extends ProjectDescriptor> _filter = IterableExtensions.filter(_allJavaProjects, _function);
-    final Procedure1<ProjectDescriptor> _function_1 = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
+    for (final ProjectDescriptor it : _filter) {
+      {
         it.setEnabled(true);
         Iterable<? extends AbstractFile> _files = it.getFiles();
-        final Function1<AbstractFile, Boolean> _function = new Function1<AbstractFile, Boolean>() {
+        final Function1<AbstractFile, Boolean> _function_1 = new Function1<AbstractFile, Boolean>() {
           @Override
           public Boolean apply(final AbstractFile it) {
             String _relativePath = it.getRelativePath();
             return Boolean.valueOf(Objects.equal(_relativePath, "MANIFEST.MF"));
           }
         };
-        boolean _exists = IterableExtensions.exists(_files, _function);
+        boolean _exists = IterableExtensions.exists(_files, _function_1);
         Assert.assertTrue(_exists);
         Iterable<? extends AbstractFile> _files_1 = it.getFiles();
-        final Function1<AbstractFile, Boolean> _function_1 = new Function1<AbstractFile, Boolean>() {
+        final Function1<AbstractFile, Boolean> _function_2 = new Function1<AbstractFile, Boolean>() {
           @Override
           public Boolean apply(final AbstractFile it) {
             String _relativePath = it.getRelativePath();
             return Boolean.valueOf(Objects.equal(_relativePath, "build.properties"));
           }
         };
-        boolean _exists_1 = IterableExtensions.exists(_files_1, _function_1);
+        boolean _exists_1 = IterableExtensions.exists(_files_1, _function_2);
         Assert.assertTrue(_exists_1);
       }
-    };
-    IterableExtensions.forEach(_filter, _function_1);
+    }
   }
   
   @Test
@@ -491,34 +473,26 @@ public class WizardConfigurationTest {
       }
     };
     Iterable<ProjectDescriptor> _filter = IterableExtensions.<ProjectDescriptor>filter(_enabledProjects, _function);
-    final Procedure1<ProjectDescriptor> _function_1 = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
-        GradleBuildFile _buildGradle = it.buildGradle();
-        String _content = _buildGradle.getContent();
-        boolean _contains = _content.contains("eclipseClasspath.enabled=false");
-        Assert.assertTrue(_contains);
-      }
-    };
-    IterableExtensions.<ProjectDescriptor>forEach(_filter, _function_1);
+    for (final ProjectDescriptor it : _filter) {
+      GradleBuildFile _buildGradle = it.buildGradle();
+      String _content = _buildGradle.getContent();
+      boolean _contains = _content.contains("eclipseClasspath.enabled=false");
+      Assert.assertTrue(_contains);
+    }
   }
   
   @Test
   public void parentContainsOtherProjectsInHierarchicallayout() {
     this.config.setProjectLayout(ProjectLayout.HIERARCHICAL);
     List<? extends ProjectDescriptor> _allJavaProjects = this.allJavaProjects();
-    final Procedure1<ProjectDescriptor> _function = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
-        String _location = it.getLocation();
-        ParentProjectDescriptor _parentProject = WizardConfigurationTest.this.config.getParentProject();
-        String _location_1 = _parentProject.getLocation();
-        String _plus = (_location_1 + "/");
-        boolean _startsWith = _location.startsWith(_plus);
-        Assert.assertTrue(_startsWith);
-      }
-    };
-    IterableExtensions.forEach(_allJavaProjects, _function);
+    for (final ProjectDescriptor it : _allJavaProjects) {
+      String _location = it.getLocation();
+      ParentProjectDescriptor _parentProject = this.config.getParentProject();
+      String _location_1 = _parentProject.getLocation();
+      String _plus = (_location_1 + "/");
+      boolean _startsWith = _location.startsWith(_plus);
+      Assert.assertTrue(_startsWith);
+    }
   }
   
   @Test
@@ -542,9 +516,8 @@ public class WizardConfigurationTest {
       }
     };
     final Iterable<? extends ProjectDescriptor> plainMavenProjects = IterableExtensions.filter(_allJavaProjects, _function);
-    final Procedure1<ProjectDescriptor> _function_1 = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
+    for (final ProjectDescriptor it : plainMavenProjects) {
+      {
         PomFile _pom = it.pom();
         String _content = _pom.getContent();
         boolean _contains = _content.contains("<directory>src</directory>");
@@ -558,68 +531,63 @@ public class WizardConfigurationTest {
         boolean _contains_2 = _content_2.contains("<directory>src-gen</directory>");
         Assert.assertTrue(_contains_2);
       }
-    };
-    IterableExtensions.forEach(plainMavenProjects, _function_1);
-    final Function1<ProjectDescriptor, Boolean> _function_2 = new Function1<ProjectDescriptor, Boolean>() {
+    }
+    final Function1<ProjectDescriptor, Boolean> _function_1 = new Function1<ProjectDescriptor, Boolean>() {
       @Override
       public Boolean apply(final ProjectDescriptor it) {
         return Boolean.valueOf((!(it instanceof TestProjectDescriptor)));
       }
     };
-    Iterable<? extends ProjectDescriptor> _filter = IterableExtensions.filter(plainMavenProjects, _function_2);
-    final Procedure1<ProjectDescriptor> _function_3 = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
-        PomFile _pom = it.pom();
+    Iterable<? extends ProjectDescriptor> _filter = IterableExtensions.filter(plainMavenProjects, _function_1);
+    for (final ProjectDescriptor it_1 : _filter) {
+      {
+        PomFile _pom = it_1.pom();
         String _content = _pom.getContent();
         boolean _contains = _content.contains("<sourceDirectory>src</sourceDirectory>");
         Assert.assertTrue(_contains);
-        PomFile _pom_1 = it.pom();
+        PomFile _pom_1 = it_1.pom();
         String _content_1 = _pom_1.getContent();
         boolean _contains_1 = _content_1.contains("add-source");
         Assert.assertTrue(_contains_1);
-        PomFile _pom_2 = it.pom();
+        PomFile _pom_2 = it_1.pom();
         String _content_2 = _pom_2.getContent();
         boolean _contains_2 = _content_2.contains("add-resource");
         Assert.assertTrue(_contains_2);
-        PomFile _pom_3 = it.pom();
+        PomFile _pom_3 = it_1.pom();
         String _content_3 = _pom_3.getContent();
         boolean _contains_3 = _content_3.contains("add-test-source");
         Assert.assertFalse(_contains_3);
-        PomFile _pom_4 = it.pom();
+        PomFile _pom_4 = it_1.pom();
         String _content_4 = _pom_4.getContent();
         boolean _contains_4 = _content_4.contains("add-test-resource");
         Assert.assertFalse(_contains_4);
       }
-    };
-    IterableExtensions.forEach(_filter, _function_3);
+    }
     Iterable<TestProjectDescriptor> _filter_1 = Iterables.<TestProjectDescriptor>filter(plainMavenProjects, TestProjectDescriptor.class);
-    final Procedure1<TestProjectDescriptor> _function_4 = new Procedure1<TestProjectDescriptor>() {
-      @Override
-      public void apply(final TestProjectDescriptor it) {
-        PomFile _pom = it.pom();
+    for (final TestProjectDescriptor it_2 : _filter_1) {
+      {
+        PomFile _pom = it_2.pom();
         String _content = _pom.getContent();
         boolean _contains = _content.contains("<testSourceDirectory>src</testSourceDirectory>");
         Assert.assertTrue(_contains);
-        PomFile _pom_1 = it.pom();
+        PomFile _pom_1 = it_2.pom();
         String _content_1 = _pom_1.getContent();
         boolean _contains_1 = _content_1.contains("add-test-source");
         Assert.assertTrue(_contains_1);
-        PomFile _pom_2 = it.pom();
+        PomFile _pom_2 = it_2.pom();
         String _content_2 = _pom_2.getContent();
         boolean _contains_2 = _content_2.contains("add-test-resource");
         Assert.assertTrue(_contains_2);
-        PomFile _pom_3 = it.pom();
+        PomFile _pom_3 = it_2.pom();
         String _content_3 = _pom_3.getContent();
         boolean _contains_3 = _content_3.contains("add-source");
         Assert.assertFalse(_contains_3);
-        PomFile _pom_4 = it.pom();
+        PomFile _pom_4 = it_2.pom();
         String _content_4 = _pom_4.getContent();
         boolean _contains_4 = _content_4.contains("add-resource");
         Assert.assertFalse(_contains_4);
       }
-    };
-    IterableExtensions.<TestProjectDescriptor>forEach(_filter_1, _function_4);
+    }
   }
   
   @Test
@@ -650,67 +618,59 @@ public class WizardConfigurationTest {
       }
     };
     final Iterable<? extends ProjectDescriptor> mainProjects = IterableExtensions.filter(plainMavenProjects, _function_1);
-    final Procedure1<ProjectDescriptor> _function_2 = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
-        it.setEnabled(true);
-      }
-    };
-    IterableExtensions.forEach(plainMavenProjects, _function_2);
+    for (final ProjectDescriptor it : plainMavenProjects) {
+      it.setEnabled(true);
+    }
     Iterable<TestProjectDescriptor> _filter = Iterables.<TestProjectDescriptor>filter(plainMavenProjects, TestProjectDescriptor.class);
-    final Function1<TestProjectDescriptor, Boolean> _function_3 = new Function1<TestProjectDescriptor, Boolean>() {
+    final Function1<TestProjectDescriptor, Boolean> _function_2 = new Function1<TestProjectDescriptor, Boolean>() {
       @Override
       public Boolean apply(final TestProjectDescriptor it) {
         return Boolean.valueOf(it.isInlined());
       }
     };
-    boolean _forall = IterableExtensions.<TestProjectDescriptor>forall(_filter, _function_3);
+    boolean _forall = IterableExtensions.<TestProjectDescriptor>forall(_filter, _function_2);
     Assert.assertTrue(_forall);
-    final Procedure1<ProjectDescriptor> _function_4 = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
-        PomFile _pom = it.pom();
+    for (final ProjectDescriptor it_1 : mainProjects) {
+      {
+        PomFile _pom = it_1.pom();
         String _content = _pom.getContent();
         boolean _contains = _content.contains("add-source");
         Assert.assertTrue(_contains);
-        PomFile _pom_1 = it.pom();
+        PomFile _pom_1 = it_1.pom();
         String _content_1 = _pom_1.getContent();
         boolean _contains_1 = _content_1.contains("add-resource");
         Assert.assertTrue(_contains_1);
-        PomFile _pom_2 = it.pom();
+        PomFile _pom_2 = it_1.pom();
         String _content_2 = _pom_2.getContent();
         boolean _contains_2 = _content_2.contains("<source>src/main/xtext-gen</source>");
         Assert.assertTrue(_contains_2);
-        PomFile _pom_3 = it.pom();
+        PomFile _pom_3 = it_1.pom();
         String _content_3 = _pom_3.getContent();
         boolean _contains_3 = _content_3.contains("<directory>src/main/xtext-gen</directory>");
         Assert.assertTrue(_contains_3);
       }
-    };
-    IterableExtensions.forEach(mainProjects, _function_4);
+    }
     Iterable<TestedProjectDescriptor> _filter_1 = Iterables.<TestedProjectDescriptor>filter(mainProjects, TestedProjectDescriptor.class);
-    final Procedure1<TestedProjectDescriptor> _function_5 = new Procedure1<TestedProjectDescriptor>() {
-      @Override
-      public void apply(final TestedProjectDescriptor it) {
-        PomFile _pom = it.pom();
+    for (final TestedProjectDescriptor it_2 : _filter_1) {
+      {
+        PomFile _pom = it_2.pom();
         String _content = _pom.getContent();
         boolean _contains = _content.contains("add-test-source");
         Assert.assertTrue(_contains);
-        PomFile _pom_1 = it.pom();
+        PomFile _pom_1 = it_2.pom();
         String _content_1 = _pom_1.getContent();
         boolean _contains_1 = _content_1.contains("add-test-resource");
         Assert.assertTrue(_contains_1);
-        PomFile _pom_2 = it.pom();
+        PomFile _pom_2 = it_2.pom();
         String _content_2 = _pom_2.getContent();
         boolean _contains_2 = _content_2.contains("<source>src/test/xtext-gen</source>");
         Assert.assertTrue(_contains_2);
-        PomFile _pom_3 = it.pom();
+        PomFile _pom_3 = it_2.pom();
         String _content_3 = _pom_3.getContent();
         boolean _contains_3 = _content_3.contains("<directory>src/test/xtext-gen</directory>");
         Assert.assertTrue(_contains_3);
       }
-    };
-    IterableExtensions.<TestedProjectDescriptor>forEach(_filter_1, _function_5);
+    }
   }
   
   @Test
@@ -741,35 +701,29 @@ public class WizardConfigurationTest {
       }
     };
     final Iterable<? extends ProjectDescriptor> mainProjects = IterableExtensions.filter(plainMavenProjects, _function_1);
-    final Procedure1<ProjectDescriptor> _function_2 = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
-        it.setEnabled(true);
-      }
-    };
-    IterableExtensions.forEach(plainMavenProjects, _function_2);
-    final Procedure1<ProjectDescriptor> _function_3 = new Procedure1<ProjectDescriptor>() {
-      @Override
-      public void apply(final ProjectDescriptor it) {
-        PomFile _pom = it.pom();
+    for (final ProjectDescriptor it : plainMavenProjects) {
+      it.setEnabled(true);
+    }
+    for (final ProjectDescriptor it_1 : mainProjects) {
+      {
+        PomFile _pom = it_1.pom();
         String _content = _pom.getContent();
         boolean _contains = _content.contains("<sourceDirectory>");
         Assert.assertFalse(_contains);
-        PomFile _pom_1 = it.pom();
+        PomFile _pom_1 = it_1.pom();
         String _content_1 = _pom_1.getContent();
         boolean _contains_1 = _content_1.contains("<directory>src/main/resources</directory>");
         Assert.assertFalse(_contains_1);
-        PomFile _pom_2 = it.pom();
+        PomFile _pom_2 = it_1.pom();
         String _content_2 = _pom_2.getContent();
         boolean _contains_2 = _content_2.contains("<testSourceDirectory>");
         Assert.assertFalse(_contains_2);
-        PomFile _pom_3 = it.pom();
+        PomFile _pom_3 = it_1.pom();
         String _content_3 = _pom_3.getContent();
         boolean _contains_3 = _content_3.contains("<directory>src/test/resources</directory>");
         Assert.assertFalse(_contains_3);
       }
-    };
-    IterableExtensions.forEach(mainProjects, _function_3);
+    }
   }
   
   @Test
@@ -819,15 +773,11 @@ public class WizardConfigurationTest {
       }
     };
     final Iterable<PomFile> poms = IterableExtensions.<TestProjectDescriptor, PomFile>map(_filter_1, _function_1);
-    final Procedure1<PomFile> _function_2 = new Procedure1<PomFile>() {
-      @Override
-      public void apply(final PomFile it) {
-        String _content = it.getContent();
-        boolean _contains = _content.contains("failIfNoTests");
-        Assert.assertTrue(_contains);
-      }
-    };
-    IterableExtensions.<PomFile>forEach(poms, _function_2);
+    for (final PomFile it : poms) {
+      String _content = it.getContent();
+      boolean _contains = _content.contains("failIfNoTests");
+      Assert.assertTrue(_contains);
+    }
   }
   
   @Test
@@ -854,14 +804,10 @@ public class WizardConfigurationTest {
       }
     };
     List<String> _map = ListExtensions.map(_allJavaProjects, _function);
-    final Procedure1<String> _function_1 = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
-        boolean _contains = it.contains("Bundle-RequiredExecutionEnvironment: JavaSE-1.6");
-        Assert.assertTrue(_contains);
-      }
-    };
-    IterableExtensions.<String>forEach(_map, _function_1);
+    for (final String it : _map) {
+      boolean _contains_4 = it.contains("Bundle-RequiredExecutionEnvironment: JavaSE-1.6");
+      Assert.assertTrue(_contains_4);
+    }
   }
   
   @Test
@@ -889,14 +835,10 @@ public class WizardConfigurationTest {
       }
     };
     List<String> _map = ListExtensions.map(_allJavaProjects, _function);
-    final Procedure1<String> _function_1 = new Procedure1<String>() {
-      @Override
-      public void apply(final String it) {
-        boolean _contains = it.contains("Bundle-RequiredExecutionEnvironment: JavaSE-1.8");
-        Assert.assertTrue(_contains);
-      }
-    };
-    IterableExtensions.<String>forEach(_map, _function_1);
+    for (final String it : _map) {
+      boolean _contains_4 = it.contains("Bundle-RequiredExecutionEnvironment: JavaSE-1.8");
+      Assert.assertTrue(_contains_4);
+    }
   }
   
   public List<? extends ProjectDescriptor> allJavaProjects() {

--- a/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/wizard/cli/CliWizardIntegrationTest.java
+++ b/tests/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/xtext/wizard/cli/CliWizardIntegrationTest.java
@@ -123,11 +123,10 @@ public class CliWizardIntegrationTest {
    * Use this main method to update the expectations to whatever the wizard currently generates
    */
   public static void main(final String[] args) {
-    final CliProjectsCreator creator = CliWizardIntegrationTest.newProjectCreator();
-    final Procedure1<WizardConfiguration> _function = new Procedure1<WizardConfiguration>() {
-      @Override
-      public void apply(final WizardConfiguration config) {
-        try {
+    try {
+      final CliProjectsCreator creator = CliWizardIntegrationTest.newProjectCreator();
+      for (final WizardConfiguration config : CliWizardIntegrationTest.projectConfigs) {
+        {
           String _baseName = config.getBaseName();
           final File targetLocation = new File("testdata/wizard-expectations", _baseName);
           targetLocation.mkdirs();
@@ -138,12 +137,11 @@ public class CliWizardIntegrationTest {
           String _baseName_1 = config.getBaseName();
           String _plus = ("Updating expectations for " + _baseName_1);
           InputOutput.<String>println(_plus);
-        } catch (Throwable _e) {
-          throw Exceptions.sneakyThrow(_e);
         }
       }
-    };
-    IterableExtensions.<WizardConfiguration>forEach(CliWizardIntegrationTest.projectConfigs, _function);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
   }
   
   private final static List<WizardConfiguration> projectConfigs = Collections.<WizardConfiguration>unmodifiableList(CollectionLiterals.<WizardConfiguration>newArrayList(ObjectExtensions.<WizardConfiguration>operator_doubleArrow(
@@ -290,14 +288,12 @@ public class CliWizardIntegrationTest {
   public void testProjectCreation() {
     CliProjectsCreator _newProjectCreator = CliWizardIntegrationTest.newProjectCreator();
     this.creator = _newProjectCreator;
-    final Procedure1<WizardConfiguration> _function = new Procedure1<WizardConfiguration>() {
-      @Override
-      public void apply(final WizardConfiguration config) {
-        CliWizardIntegrationTest.this.config = config;
-        CliWizardIntegrationTest.this.validateCreatedProjects();
+    for (final WizardConfiguration config : CliWizardIntegrationTest.projectConfigs) {
+      {
+        this.config = config;
+        this.validateCreatedProjects();
       }
-    };
-    IterableExtensions.<WizardConfiguration>forEach(CliWizardIntegrationTest.projectConfigs, _function);
+    }
   }
   
   private void validateCreatedProjects() {
@@ -349,13 +345,9 @@ public class CliWizardIntegrationTest {
     boolean _isDirectory = root.isDirectory();
     if (_isDirectory) {
       File[] _listFiles = root.listFiles();
-      final Procedure1<File> _function = new Procedure1<File>() {
-        @Override
-        public void apply(final File it) {
-          CliWizardIntegrationTest.this.collectAllFiles(it, children);
-        }
-      };
-      IterableExtensions.<File>forEach(((Iterable<File>)Conversions.doWrapArray(_listFiles)), _function);
+      for (final File it : _listFiles) {
+        this.collectAllFiles(it, children);
+      }
     } else {
       children.add(root);
     }
@@ -395,36 +387,26 @@ public class CliWizardIntegrationTest {
     final Sets.SetView<CliWizardIntegrationTest.GeneratedFile> missingFiles = Sets.<CliWizardIntegrationTest.GeneratedFile>difference(expectedFiles, actualFiles);
     final Sets.SetView<CliWizardIntegrationTest.GeneratedFile> unexpectedFiles = Sets.<CliWizardIntegrationTest.GeneratedFile>difference(actualFiles, expectedFiles);
     final Sets.SetView<CliWizardIntegrationTest.GeneratedFile> comparableFiles = Sets.<CliWizardIntegrationTest.GeneratedFile>intersection(expectedFiles, actualFiles);
-    final Procedure1<CliWizardIntegrationTest.GeneratedFile> _function_2 = new Procedure1<CliWizardIntegrationTest.GeneratedFile>() {
-      @Override
-      public void apply(final CliWizardIntegrationTest.GeneratedFile it) {
-        StringConcatenation _builder = new StringConcatenation();
-        _builder.append("Missing file: ");
-        _builder.append(it.relativePath, "");
-        throw new ComparisonFailure(_builder.toString(), it.content, "");
-      }
-    };
-    IterableExtensions.<CliWizardIntegrationTest.GeneratedFile>forEach(missingFiles, _function_2);
-    final Procedure1<CliWizardIntegrationTest.GeneratedFile> _function_3 = new Procedure1<CliWizardIntegrationTest.GeneratedFile>() {
-      @Override
-      public void apply(final CliWizardIntegrationTest.GeneratedFile it) {
-        StringConcatenation _builder = new StringConcatenation();
-        _builder.append("Unexpected file: ");
-        _builder.append(it.relativePath, "");
-        throw new ComparisonFailure(_builder.toString(), "", it.content);
-      }
-    };
-    IterableExtensions.<CliWizardIntegrationTest.GeneratedFile>forEach(unexpectedFiles, _function_3);
-    final Procedure1<CliWizardIntegrationTest.GeneratedFile> _function_4 = new Procedure1<CliWizardIntegrationTest.GeneratedFile>() {
-      @Override
-      public void apply(final CliWizardIntegrationTest.GeneratedFile it) {
-        CliWizardIntegrationTest.GeneratedFile _get = expectedFilesByPath.get(it.relativePath);
+    for (final CliWizardIntegrationTest.GeneratedFile it : missingFiles) {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("Missing file: ");
+      _builder.append(it.relativePath, "");
+      throw new ComparisonFailure(_builder.toString(), it.content, "");
+    }
+    for (final CliWizardIntegrationTest.GeneratedFile it_1 : unexpectedFiles) {
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("Unexpected file: ");
+      _builder_1.append(it_1.relativePath, "");
+      throw new ComparisonFailure(_builder_1.toString(), "", it_1.content);
+    }
+    for (final CliWizardIntegrationTest.GeneratedFile it_2 : comparableFiles) {
+      {
+        CliWizardIntegrationTest.GeneratedFile _get = expectedFilesByPath.get(it_2.relativePath);
         final String expectedContent = LineDelimiters.toUnix(_get.content);
-        CliWizardIntegrationTest.GeneratedFile _get_1 = actualFilesByPath.get(it.relativePath);
+        CliWizardIntegrationTest.GeneratedFile _get_1 = actualFilesByPath.get(it_2.relativePath);
         final String actualContent = LineDelimiters.toUnix(_get_1.content);
-        Assert.assertEquals(it.relativePath, expectedContent, actualContent);
+        Assert.assertEquals(it_2.relativePath, expectedContent, actualContent);
       }
-    };
-    IterableExtensions.<CliWizardIntegrationTest.GeneratedFile>forEach(comparableFiles, _function_4);
+    }
   }
 }

--- a/tests/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.xtend
+++ b/tests/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.xtend
@@ -84,11 +84,11 @@ class Storage2UriMapperJavaImplTest extends Assert {
 		assertEquals("" + cachedPackageFragmentRootData, sizeBefore + 1, cachedPackageFragmentRootData.size)
 		assertNotNull(cachedPackageFragmentRootData.keySet.findFirst[contains("foo.jar")])
 
-		cachedPackageFragmentRootData.entrySet.forEach [
+		for (it : cachedPackageFragmentRootData.entrySet) {
 			assertEquals(key, 1, value.associatedRoots.size)
 			val head = value.associatedRoots.keySet.head
 			assertTrue(head, head.startsWith('=testProject/'))
-		]
+		}
 
 		val project2 = createJavaProject('testProject2')
 		addJarToClasspath(project2, file)
@@ -96,20 +96,20 @@ class Storage2UriMapperJavaImplTest extends Assert {
 		assertEquals("" + cachedPackageFragmentRootData, sizeBefore + 1, cachedPackageFragmentRootData.size)
 		assertNotNull(cachedPackageFragmentRootData.keySet.findFirst[contains("foo.jar")])
 
-		cachedPackageFragmentRootData.entrySet.forEach [
+		for (it : cachedPackageFragmentRootData.entrySet) {
 			assertEquals(key, 2, value.associatedRoots.size)
 			val head = value.associatedRoots.keySet.head
 			assertTrue(head, head.startsWith('=testProject/') || head.startsWith('=testProject2/'))
 			val head2 = value.associatedRoots.keySet.tail.head
 			assertTrue(head2, head.startsWith('=testProject/') || head.startsWith('=testProject2/'))
-		]
+		}
 
 		removeJarFromClasspath(project, file);
 		
 		assertEquals("" + cachedPackageFragmentRootData, sizeBefore + 1, cachedPackageFragmentRootData.size)
 		assertNotNull(cachedPackageFragmentRootData.keySet.findFirst[contains("foo.jar")])
 
-		cachedPackageFragmentRootData.entrySet.forEach [
+		for (it : cachedPackageFragmentRootData.entrySet) {
 			if (key.contains("foo.jar")) {
 				assertEquals(key, 1, value.associatedRoots.size)
 				val head = value.associatedRoots.keySet.head
@@ -121,7 +121,7 @@ class Storage2UriMapperJavaImplTest extends Assert {
 				val head2 = value.associatedRoots.keySet.tail.head
 				assertTrue(head2, head.startsWith('=testProject/') || head.startsWith('=testProject2/'))
 			}
-		]
+		}
 
 		removeJarFromClasspath(project2, file);
 		
@@ -129,13 +129,13 @@ class Storage2UriMapperJavaImplTest extends Assert {
 		assertEquals("" + cachedPackageFragmentRootData, sizeBefore, cachedPackageFragmentRootData.size)
 		assertNull(cachedPackageFragmentRootData.keySet.findFirst[contains("foo.jar")])
 
-		cachedPackageFragmentRootData.entrySet.forEach [
+		for (it : cachedPackageFragmentRootData.entrySet) {
 			assertEquals(key, 2, value.associatedRoots.size)
 			val head = value.associatedRoots.keySet.head
 			assertTrue(head, head.startsWith('=testProject/') || head.startsWith('=testProject2/'))
 			val head2 = value.associatedRoots.keySet.tail.head
 			assertTrue(head2, head.startsWith('=testProject/') || head.startsWith('=testProject2/'))
-		]
+		}
 	}
 
 	@Test
@@ -198,24 +198,24 @@ class Storage2UriMapperJavaImplTest extends Assert {
 	def assertFirstProject(int sizeBefore) {
 		assertEquals("" + cachedPackageFragmentRootData, sizeBefore + 1, cachedPackageFragmentRootData.size)
 		assertNotNull(cachedPackageFragmentRootData.keySet.findFirst[contains("foo.jar")])
-		cachedPackageFragmentRootData.entrySet.forEach [
+		for (it : cachedPackageFragmentRootData.entrySet) {
 			assertEquals(key, 1, value.associatedRoots.size)
 			val head = value.associatedRoots.keySet.head
 			assertTrue(head, head.startsWith('=testProject/'))
-		]
+		}
 	}
 
 	def assertBothProjects(int sizeBefore) {
 		assertEquals("" + cachedPackageFragmentRootData, sizeBefore + 1, cachedPackageFragmentRootData.size)
 		assertNotNull(cachedPackageFragmentRootData.keySet.findFirst[contains("foo.jar")])
 
-		cachedPackageFragmentRootData.entrySet.forEach [
+		for (it : cachedPackageFragmentRootData.entrySet) {
 			assertEquals(key, 2, value.associatedRoots.size)
 			val head = value.associatedRoots.keySet.head
 			assertTrue(head, head.startsWith('=testProject/') || head.startsWith('=testProject2/'))
 			val head2 = value.associatedRoots.keySet.last
 			assertTrue(head2, head.startsWith('=testProject/') || head.startsWith('=testProject2/'))
-		]
+		}
 	}
 
 	def createJar(IJavaProject project) {

--- a/tests/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.java
+++ b/tests/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.java
@@ -138,21 +138,19 @@ public class Storage2UriMapperJavaImplTest extends Assert {
       Assert.assertNotNull(_findFirst_1);
       Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_7 = this.getCachedPackageFragmentRootData();
       Set<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _entrySet = _cachedPackageFragmentRootData_7.entrySet();
-      final Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _function_2 = new Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>() {
-        @Override
-        public void apply(final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it) {
+      for (final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it : _entrySet) {
+        {
           String _key = it.getKey();
           Storage2UriMapperJavaImpl.PackageFragmentRootData _value = it.getValue();
-          int _size = _value.associatedRoots.size();
-          Assert.assertEquals(_key, 1, _size);
+          int _size_2 = _value.associatedRoots.size();
+          Assert.assertEquals(_key, 1, _size_2);
           Storage2UriMapperJavaImpl.PackageFragmentRootData _value_1 = it.getValue();
-          Set<String> _keySet = _value_1.associatedRoots.keySet();
-          final String head = IterableExtensions.<String>head(_keySet);
+          Set<String> _keySet_2 = _value_1.associatedRoots.keySet();
+          final String head = IterableExtensions.<String>head(_keySet_2);
           boolean _startsWith = head.startsWith("=testProject/");
           Assert.assertTrue(head, _startsWith);
         }
-      };
-      IterableExtensions.<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>forEach(_entrySet, _function_2);
+      }
       final IJavaProject project2 = JavaProjectSetupUtil.createJavaProject("testProject2");
       JavaProjectSetupUtil.addJarToClasspath(project2, file);
       Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_8 = this.getCachedPackageFragmentRootData();
@@ -162,26 +160,25 @@ public class Storage2UriMapperJavaImplTest extends Assert {
       Assert.assertEquals(_plus_2, (sizeBefore + 1), _size_2);
       Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_10 = this.getCachedPackageFragmentRootData();
       Set<String> _keySet_2 = _cachedPackageFragmentRootData_10.keySet();
-      final Function1<String, Boolean> _function_3 = new Function1<String, Boolean>() {
+      final Function1<String, Boolean> _function_2 = new Function1<String, Boolean>() {
         @Override
         public Boolean apply(final String it) {
           return Boolean.valueOf(it.contains("foo.jar"));
         }
       };
-      String _findFirst_2 = IterableExtensions.<String>findFirst(_keySet_2, _function_3);
+      String _findFirst_2 = IterableExtensions.<String>findFirst(_keySet_2, _function_2);
       Assert.assertNotNull(_findFirst_2);
       Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_11 = this.getCachedPackageFragmentRootData();
       Set<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _entrySet_1 = _cachedPackageFragmentRootData_11.entrySet();
-      final Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _function_4 = new Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>() {
-        @Override
-        public void apply(final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it) {
-          String _key = it.getKey();
-          Storage2UriMapperJavaImpl.PackageFragmentRootData _value = it.getValue();
-          int _size = _value.associatedRoots.size();
-          Assert.assertEquals(_key, 2, _size);
-          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_1 = it.getValue();
-          Set<String> _keySet = _value_1.associatedRoots.keySet();
-          final String head = IterableExtensions.<String>head(_keySet);
+      for (final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it_1 : _entrySet_1) {
+        {
+          String _key = it_1.getKey();
+          Storage2UriMapperJavaImpl.PackageFragmentRootData _value = it_1.getValue();
+          int _size_3 = _value.associatedRoots.size();
+          Assert.assertEquals(_key, 2, _size_3);
+          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_1 = it_1.getValue();
+          Set<String> _keySet_3 = _value_1.associatedRoots.keySet();
+          final String head = IterableExtensions.<String>head(_keySet_3);
           boolean _or = false;
           boolean _startsWith = head.startsWith("=testProject/");
           if (_startsWith) {
@@ -191,9 +188,9 @@ public class Storage2UriMapperJavaImplTest extends Assert {
             _or = _startsWith_1;
           }
           Assert.assertTrue(head, _or);
-          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_2 = it.getValue();
-          Set<String> _keySet_1 = _value_2.associatedRoots.keySet();
-          Iterable<String> _tail = IterableExtensions.<String>tail(_keySet_1);
+          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_2 = it_1.getValue();
+          Set<String> _keySet_4 = _value_2.associatedRoots.keySet();
+          Iterable<String> _tail = IterableExtensions.<String>tail(_keySet_4);
           final String head2 = IterableExtensions.<String>head(_tail);
           boolean _or_1 = false;
           boolean _startsWith_2 = head.startsWith("=testProject/");
@@ -205,8 +202,7 @@ public class Storage2UriMapperJavaImplTest extends Assert {
           }
           Assert.assertTrue(head2, _or_1);
         }
-      };
-      IterableExtensions.<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>forEach(_entrySet_1, _function_4);
+      }
       JavaProjectSetupUtil.removeJarFromClasspath(project, file);
       Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_12 = this.getCachedPackageFragmentRootData();
       String _plus_3 = ("" + _cachedPackageFragmentRootData_12);
@@ -215,118 +211,112 @@ public class Storage2UriMapperJavaImplTest extends Assert {
       Assert.assertEquals(_plus_3, (sizeBefore + 1), _size_3);
       Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_14 = this.getCachedPackageFragmentRootData();
       Set<String> _keySet_3 = _cachedPackageFragmentRootData_14.keySet();
-      final Function1<String, Boolean> _function_5 = new Function1<String, Boolean>() {
+      final Function1<String, Boolean> _function_3 = new Function1<String, Boolean>() {
         @Override
         public Boolean apply(final String it) {
           return Boolean.valueOf(it.contains("foo.jar"));
         }
       };
-      String _findFirst_3 = IterableExtensions.<String>findFirst(_keySet_3, _function_5);
+      String _findFirst_3 = IterableExtensions.<String>findFirst(_keySet_3, _function_3);
       Assert.assertNotNull(_findFirst_3);
       Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_15 = this.getCachedPackageFragmentRootData();
       Set<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _entrySet_2 = _cachedPackageFragmentRootData_15.entrySet();
-      final Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _function_6 = new Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>() {
-        @Override
-        public void apply(final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it) {
-          String _key = it.getKey();
-          boolean _contains = _key.contains("foo.jar");
-          if (_contains) {
-            String _key_1 = it.getKey();
-            Storage2UriMapperJavaImpl.PackageFragmentRootData _value = it.getValue();
-            int _size = _value.associatedRoots.size();
-            Assert.assertEquals(_key_1, 1, _size);
-            Storage2UriMapperJavaImpl.PackageFragmentRootData _value_1 = it.getValue();
-            Set<String> _keySet = _value_1.associatedRoots.keySet();
-            final String head = IterableExtensions.<String>head(_keySet);
-            boolean _startsWith = head.startsWith("=testProject2/");
-            Assert.assertTrue(head, _startsWith);
+      for (final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it_2 : _entrySet_2) {
+        String _key = it_2.getKey();
+        boolean _contains = _key.contains("foo.jar");
+        if (_contains) {
+          String _key_1 = it_2.getKey();
+          Storage2UriMapperJavaImpl.PackageFragmentRootData _value = it_2.getValue();
+          int _size_4 = _value.associatedRoots.size();
+          Assert.assertEquals(_key_1, 1, _size_4);
+          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_1 = it_2.getValue();
+          Set<String> _keySet_4 = _value_1.associatedRoots.keySet();
+          final String head = IterableExtensions.<String>head(_keySet_4);
+          boolean _startsWith = head.startsWith("=testProject2/");
+          Assert.assertTrue(head, _startsWith);
+        } else {
+          String _key_2 = it_2.getKey();
+          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_2 = it_2.getValue();
+          int _size_5 = _value_2.associatedRoots.size();
+          Assert.assertEquals(_key_2, 2, _size_5);
+          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_3 = it_2.getValue();
+          Set<String> _keySet_5 = _value_3.associatedRoots.keySet();
+          final String head_1 = IterableExtensions.<String>head(_keySet_5);
+          boolean _or = false;
+          boolean _startsWith_1 = head_1.startsWith("=testProject/");
+          if (_startsWith_1) {
+            _or = true;
           } else {
-            String _key_2 = it.getKey();
-            Storage2UriMapperJavaImpl.PackageFragmentRootData _value_2 = it.getValue();
-            int _size_1 = _value_2.associatedRoots.size();
-            Assert.assertEquals(_key_2, 2, _size_1);
-            Storage2UriMapperJavaImpl.PackageFragmentRootData _value_3 = it.getValue();
-            Set<String> _keySet_1 = _value_3.associatedRoots.keySet();
-            final String head_1 = IterableExtensions.<String>head(_keySet_1);
-            boolean _or = false;
-            boolean _startsWith_1 = head_1.startsWith("=testProject/");
-            if (_startsWith_1) {
-              _or = true;
-            } else {
-              boolean _startsWith_2 = head_1.startsWith("=testProject2/");
-              _or = _startsWith_2;
-            }
-            Assert.assertTrue(head_1, _or);
-            Storage2UriMapperJavaImpl.PackageFragmentRootData _value_4 = it.getValue();
-            Set<String> _keySet_2 = _value_4.associatedRoots.keySet();
-            Iterable<String> _tail = IterableExtensions.<String>tail(_keySet_2);
-            final String head2 = IterableExtensions.<String>head(_tail);
-            boolean _or_1 = false;
-            boolean _startsWith_3 = head_1.startsWith("=testProject/");
-            if (_startsWith_3) {
-              _or_1 = true;
-            } else {
-              boolean _startsWith_4 = head_1.startsWith("=testProject2/");
-              _or_1 = _startsWith_4;
-            }
-            Assert.assertTrue(head2, _or_1);
+            boolean _startsWith_2 = head_1.startsWith("=testProject2/");
+            _or = _startsWith_2;
           }
+          Assert.assertTrue(head_1, _or);
+          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_4 = it_2.getValue();
+          Set<String> _keySet_6 = _value_4.associatedRoots.keySet();
+          Iterable<String> _tail = IterableExtensions.<String>tail(_keySet_6);
+          final String head2 = IterableExtensions.<String>head(_tail);
+          boolean _or_1 = false;
+          boolean _startsWith_3 = head_1.startsWith("=testProject/");
+          if (_startsWith_3) {
+            _or_1 = true;
+          } else {
+            boolean _startsWith_4 = head_1.startsWith("=testProject2/");
+            _or_1 = _startsWith_4;
+          }
+          Assert.assertTrue(head2, _or_1);
         }
-      };
-      IterableExtensions.<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>forEach(_entrySet_2, _function_6);
+      }
       JavaProjectSetupUtil.removeJarFromClasspath(project2, file);
       Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_16 = this.getCachedPackageFragmentRootData();
       String _plus_4 = ("" + _cachedPackageFragmentRootData_16);
       Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_17 = this.getCachedPackageFragmentRootData();
-      int _size_4 = _cachedPackageFragmentRootData_17.size();
-      Assert.assertEquals(_plus_4, sizeBefore, _size_4);
+      int _size_6 = _cachedPackageFragmentRootData_17.size();
+      Assert.assertEquals(_plus_4, sizeBefore, _size_6);
       Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_18 = this.getCachedPackageFragmentRootData();
-      Set<String> _keySet_4 = _cachedPackageFragmentRootData_18.keySet();
-      final Function1<String, Boolean> _function_7 = new Function1<String, Boolean>() {
+      Set<String> _keySet_7 = _cachedPackageFragmentRootData_18.keySet();
+      final Function1<String, Boolean> _function_4 = new Function1<String, Boolean>() {
         @Override
         public Boolean apply(final String it) {
           return Boolean.valueOf(it.contains("foo.jar"));
         }
       };
-      String _findFirst_4 = IterableExtensions.<String>findFirst(_keySet_4, _function_7);
+      String _findFirst_4 = IterableExtensions.<String>findFirst(_keySet_7, _function_4);
       Assert.assertNull(_findFirst_4);
       Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_19 = this.getCachedPackageFragmentRootData();
       Set<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _entrySet_3 = _cachedPackageFragmentRootData_19.entrySet();
-      final Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _function_8 = new Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>() {
-        @Override
-        public void apply(final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it) {
-          String _key = it.getKey();
-          Storage2UriMapperJavaImpl.PackageFragmentRootData _value = it.getValue();
-          int _size = _value.associatedRoots.size();
-          Assert.assertEquals(_key, 2, _size);
-          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_1 = it.getValue();
-          Set<String> _keySet = _value_1.associatedRoots.keySet();
-          final String head = IterableExtensions.<String>head(_keySet);
-          boolean _or = false;
-          boolean _startsWith = head.startsWith("=testProject/");
-          if (_startsWith) {
-            _or = true;
+      for (final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it_3 : _entrySet_3) {
+        {
+          String _key_3 = it_3.getKey();
+          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_5 = it_3.getValue();
+          int _size_7 = _value_5.associatedRoots.size();
+          Assert.assertEquals(_key_3, 2, _size_7);
+          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_6 = it_3.getValue();
+          Set<String> _keySet_8 = _value_6.associatedRoots.keySet();
+          final String head_2 = IterableExtensions.<String>head(_keySet_8);
+          boolean _or_2 = false;
+          boolean _startsWith_5 = head_2.startsWith("=testProject/");
+          if (_startsWith_5) {
+            _or_2 = true;
           } else {
-            boolean _startsWith_1 = head.startsWith("=testProject2/");
-            _or = _startsWith_1;
+            boolean _startsWith_6 = head_2.startsWith("=testProject2/");
+            _or_2 = _startsWith_6;
           }
-          Assert.assertTrue(head, _or);
-          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_2 = it.getValue();
-          Set<String> _keySet_1 = _value_2.associatedRoots.keySet();
-          Iterable<String> _tail = IterableExtensions.<String>tail(_keySet_1);
-          final String head2 = IterableExtensions.<String>head(_tail);
-          boolean _or_1 = false;
-          boolean _startsWith_2 = head.startsWith("=testProject/");
-          if (_startsWith_2) {
-            _or_1 = true;
+          Assert.assertTrue(head_2, _or_2);
+          Storage2UriMapperJavaImpl.PackageFragmentRootData _value_7 = it_3.getValue();
+          Set<String> _keySet_9 = _value_7.associatedRoots.keySet();
+          Iterable<String> _tail_1 = IterableExtensions.<String>tail(_keySet_9);
+          final String head2_1 = IterableExtensions.<String>head(_tail_1);
+          boolean _or_3 = false;
+          boolean _startsWith_7 = head_2.startsWith("=testProject/");
+          if (_startsWith_7) {
+            _or_3 = true;
           } else {
-            boolean _startsWith_3 = head.startsWith("=testProject2/");
-            _or_1 = _startsWith_3;
+            boolean _startsWith_8 = head_2.startsWith("=testProject2/");
+            _or_3 = _startsWith_8;
           }
-          Assert.assertTrue(head2, _or_1);
+          Assert.assertTrue(head2_1, _or_3);
         }
-      };
-      IterableExtensions.<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>forEach(_entrySet_3, _function_8);
+      }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -425,21 +415,19 @@ public class Storage2UriMapperJavaImplTest extends Assert {
     Assert.assertNotNull(_findFirst);
     Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_3 = this.getCachedPackageFragmentRootData();
     Set<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _entrySet = _cachedPackageFragmentRootData_3.entrySet();
-    final Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _function_1 = new Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>() {
-      @Override
-      public void apply(final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it) {
+    for (final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it : _entrySet) {
+      {
         String _key = it.getKey();
         Storage2UriMapperJavaImpl.PackageFragmentRootData _value = it.getValue();
-        int _size = _value.associatedRoots.size();
-        Assert.assertEquals(_key, 1, _size);
+        int _size_1 = _value.associatedRoots.size();
+        Assert.assertEquals(_key, 1, _size_1);
         Storage2UriMapperJavaImpl.PackageFragmentRootData _value_1 = it.getValue();
-        Set<String> _keySet = _value_1.associatedRoots.keySet();
-        final String head = IterableExtensions.<String>head(_keySet);
+        Set<String> _keySet_1 = _value_1.associatedRoots.keySet();
+        final String head = IterableExtensions.<String>head(_keySet_1);
         boolean _startsWith = head.startsWith("=testProject/");
         Assert.assertTrue(head, _startsWith);
       }
-    };
-    IterableExtensions.<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>forEach(_entrySet, _function_1);
+    }
   }
   
   public void assertBothProjects(final int sizeBefore) {
@@ -460,16 +448,15 @@ public class Storage2UriMapperJavaImplTest extends Assert {
     Assert.assertNotNull(_findFirst);
     Map<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> _cachedPackageFragmentRootData_3 = this.getCachedPackageFragmentRootData();
     Set<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _entrySet = _cachedPackageFragmentRootData_3.entrySet();
-    final Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>> _function_1 = new Procedure1<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>() {
-      @Override
-      public void apply(final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it) {
+    for (final Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData> it : _entrySet) {
+      {
         String _key = it.getKey();
         Storage2UriMapperJavaImpl.PackageFragmentRootData _value = it.getValue();
-        int _size = _value.associatedRoots.size();
-        Assert.assertEquals(_key, 2, _size);
+        int _size_1 = _value.associatedRoots.size();
+        Assert.assertEquals(_key, 2, _size_1);
         Storage2UriMapperJavaImpl.PackageFragmentRootData _value_1 = it.getValue();
-        Set<String> _keySet = _value_1.associatedRoots.keySet();
-        final String head = IterableExtensions.<String>head(_keySet);
+        Set<String> _keySet_1 = _value_1.associatedRoots.keySet();
+        final String head = IterableExtensions.<String>head(_keySet_1);
         boolean _or = false;
         boolean _startsWith = head.startsWith("=testProject/");
         if (_startsWith) {
@@ -480,8 +467,8 @@ public class Storage2UriMapperJavaImplTest extends Assert {
         }
         Assert.assertTrue(head, _or);
         Storage2UriMapperJavaImpl.PackageFragmentRootData _value_2 = it.getValue();
-        Set<String> _keySet_1 = _value_2.associatedRoots.keySet();
-        final String head2 = IterableExtensions.<String>last(_keySet_1);
+        Set<String> _keySet_2 = _value_2.associatedRoots.keySet();
+        final String head2 = IterableExtensions.<String>last(_keySet_2);
         boolean _or_1 = false;
         boolean _startsWith_2 = head.startsWith("=testProject/");
         if (_startsWith_2) {
@@ -492,8 +479,7 @@ public class Storage2UriMapperJavaImplTest extends Assert {
         }
         Assert.assertTrue(head2, _or_1);
       }
-    };
-    IterableExtensions.<Map.Entry<String, Storage2UriMapperJavaImpl.PackageFragmentRootData>>forEach(_entrySet, _function_1);
+    }
   }
   
   public IFile createJar(final IJavaProject project) {

--- a/tests/org.eclipse.xtext.xbase.tests/longrunning/src/org/eclipse/xtext/xbase/tests/typesystem/TestingTypeResolvers.xtend
+++ b/tests/org.eclipse.xtext.xbase.tests/longrunning/src/org/eclipse/xtext/xbase/tests/typesystem/TestingTypeResolvers.xtend
@@ -115,10 +115,10 @@ class InvariantCheckingEagerReentrantTypeResolver extends EagerReentrantTypeReso
 class EagerArgumentTypeComputer extends XbaseTypeComputer {
 	
 	override protected ILinkingCandidate getBestCandidate(List<? extends ILinkingCandidate> candidates) {
-		candidates.forEach[
+		for (it : candidates) {
 			if (it instanceof AbstractPendingLinkingCandidate<?>)
 				it.computeArgumentTypes()
-		]
+		}
 		super.getBestCandidate(candidates)
 	}
 	

--- a/tests/org.eclipse.xtext.xbase.tests/longrunning/src/org/eclipse/xtext/xbase/tests/typesystem/ValidatingTypeComputation.xtend
+++ b/tests/org.eclipse.xtext.xbase.tests/longrunning/src/org/eclipse/xtext/xbase/tests/typesystem/ValidatingTypeComputation.xtend
@@ -92,10 +92,10 @@ class ValidatingRootResolvedTypes extends RootResolvedTypes {
 	
 	override protected getHints(Object handle) {
 		val result = super.getHints(handle)
-		result.forEach[ 
+		for (it : result) { 
 			if (typeReference != null && !typeReference.isOwnedBy(referenceOwner))
 				throw new IllegalArgumentException("reference is not owned by this resolved types")
-		]
+		}
 		return result
 	}
 	
@@ -109,10 +109,10 @@ class ValidatingRootResolvedTypes extends RootResolvedTypes {
 	
 	override getAllHints(Object handle) {
 		val result = super.getAllHints(handle)
-		result.forEach [
+		for (it : result) {
 			if (typeReference != null &&!typeReference.isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("hint is not owned by this resolved types")
-		]
+		}
 		return result
 	}
 	
@@ -145,10 +145,10 @@ class ValidatingRootResolvedTypes extends RootResolvedTypes {
 	}
 	
 	override getMergedType(List<LightweightTypeReference> types) {
-		types.forEach [
+		for (it : types) {
 			if (!isOwnedBy(getOwner()))
 				throw new IllegalArgumentException("result is not owned by this resolved types")
-		]
+		}
 		val result = super.getMergedType(types)
 		if (!result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
@@ -156,10 +156,10 @@ class ValidatingRootResolvedTypes extends RootResolvedTypes {
 	}
 	
 	override mergeTypeData(XExpression expression, List<TypeData> allValues, boolean returnType, boolean nullIfEmpty) {
-		allValues.forEach [
+		for (it : allValues) {
 			if (!isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("result is not owned by this resolved types")
-		]
+		}
 		val result = super.mergeTypeData(expression, allValues, returnType, nullIfEmpty)
 		if (!result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
@@ -182,10 +182,10 @@ class ValidatingRootResolvedTypes extends RootResolvedTypes {
 	
 	override doGetTypeData(XExpression expression) {
 		val result = super.doGetTypeData(expression)
-		result?.forEach [
+		for (it : result) {
 			if (!isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("result is not owned by this resolved types")
-		]
+		}
 		return result
 	}
 
@@ -229,10 +229,10 @@ class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStackedResol
 	
 	override protected getHints(Object handle) {
 		val result = super.getHints(handle)
-		result.forEach[ 
+		for (it : result) {
 			if (typeReference != null && !typeReference.isOwnedBy(referenceOwner))
 				throw new IllegalArgumentException("reference is not owned by this resolved types")
-		]
+		}
 		return result
 	}
 	
@@ -246,10 +246,10 @@ class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStackedResol
 	
 	override getAllHints(Object handle) {
 		val result = super.getAllHints(handle)
-		result.forEach [
+		for (it : result) {
 			if (typeReference != null && !typeReference.isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("hint is not owned by this resolved types")
-		]
+		}
 		return result
 	}
 	
@@ -282,10 +282,10 @@ class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStackedResol
 	}
 	
 	override getMergedType(List<LightweightTypeReference> types) {
-		types.forEach [
+		for (it : types) {
 			if (!isOwnedBy(getOwner()))
 				throw new IllegalArgumentException("result is not owned by this resolved types")
-		]
+		}
 		val result = super.getMergedType(types)
 		if (!result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
@@ -293,10 +293,10 @@ class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStackedResol
 	}
 	
 	override mergeTypeData(XExpression expression, List<TypeData> allValues, boolean returnType, boolean nullIfEmpty) {
-		allValues.forEach [
+		for (it : allValues) {
 			if (!isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("result is not owned by this resolved types")
-		]
+		}
 		val result = super.mergeTypeData(expression, allValues, returnType, nullIfEmpty)
 		if (result != null && !result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
@@ -343,10 +343,10 @@ class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
 	
 	override protected getHints(Object handle) {
 		val result = super.getHints(handle)
-		result.forEach[ 
+		for (it : result) { 
 			if (typeReference != null && !typeReference.isOwnedBy(referenceOwner))
 				throw new IllegalArgumentException("reference is not owned by this resolved types")
-		]
+		}
 		return result
 	}
 	
@@ -360,10 +360,10 @@ class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
 	
 	override getAllHints(Object handle) {
 		val result = super.getAllHints(handle)
-		result.forEach [
+		for (it : result) {
 			if (typeReference != null && !typeReference.isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("hint is not owned by this resolved types")
-		]
+		}
 		return result
 	}
 	
@@ -396,10 +396,10 @@ class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
 	}
 	
 	override getMergedType(List<LightweightTypeReference> types) {
-		types.forEach [
+		for(it:types) {
 			if (!isOwnedBy(getOwner()))
 				throw new IllegalArgumentException("result is not owned by this resolved types")
-		]
+		}
 		val result = super.getMergedType(types)
 		if (!result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
@@ -407,10 +407,10 @@ class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
 	}
 	
 	override mergeTypeData(XExpression expression, List<TypeData> allValues, boolean returnType, boolean nullIfEmpty) {
-		allValues.forEach [
+		for (it : allValues) {
 			if (!isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("result is not owned by this resolved types")
-		]
+		}
 		val result = super.mergeTypeData(expression, allValues, returnType, nullIfEmpty)
 		if (!result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
@@ -456,10 +456,10 @@ class ValidatingReassigningResolvedTypes extends ReassigningStackedResolvedTypes
 	
 	override protected getHints(Object handle) {
 		val result = super.getHints(handle)
-		result.forEach[ 
+		for (it : result) { 
 			if (typeReference != null && !typeReference.isOwnedBy(referenceOwner))
 				throw new IllegalArgumentException("reference is not owned by this resolved types")
-		]
+		}
 		return result
 	}
 	
@@ -473,10 +473,10 @@ class ValidatingReassigningResolvedTypes extends ReassigningStackedResolvedTypes
 	
 	override getAllHints(Object handle) {
 		val result = super.getAllHints(handle)
-		result.forEach [
+		for (it : result) {
 			if (typeReference != null &&!typeReference.isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("hint is not owned by this resolved types")
-		]
+		}
 		return result
 	}
 	
@@ -509,10 +509,10 @@ class ValidatingReassigningResolvedTypes extends ReassigningStackedResolvedTypes
 	}
 	
 	override getMergedType(List<LightweightTypeReference> types) {
-		types.forEach [
+		for (it : types) {
 			if (!isOwnedBy(getOwner()))
 				throw new IllegalArgumentException("result is not owned by this resolved types")
-		]
+		}
 		val result = super.getMergedType(types)
 		if (!result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")
@@ -520,10 +520,10 @@ class ValidatingReassigningResolvedTypes extends ReassigningStackedResolvedTypes
 	}
 	
 	override mergeTypeData(XExpression expression, List<TypeData> allValues, boolean returnType, boolean nullIfEmpty) {
-		allValues.forEach [
+		for (it : allValues) {
 			if (!isOwnedBy(getReferenceOwner()))
 				throw new IllegalArgumentException("result is not owned by this resolved types")
-		]
+		}
 		val result = super.mergeTypeData(expression, allValues, returnType, nullIfEmpty)
 		if (!result.isOwnedBy(getReferenceOwner()))
 			throw new IllegalArgumentException("result is not owned by this resolved types")

--- a/tests/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/EagerArgumentTypeComputer.java
+++ b/tests/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/EagerArgumentTypeComputer.java
@@ -9,8 +9,6 @@ package org.eclipse.xtext.xbase.tests.typesystem;
 
 import com.google.inject.Singleton;
 import java.util.List;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.typesystem.computation.ILinkingCandidate;
 import org.eclipse.xtext.xbase.typesystem.computation.XbaseTypeComputer;
 import org.eclipse.xtext.xbase.typesystem.internal.AbstractPendingLinkingCandidate;
@@ -25,15 +23,11 @@ public class EagerArgumentTypeComputer extends XbaseTypeComputer {
   protected ILinkingCandidate getBestCandidate(final List<? extends ILinkingCandidate> candidates) {
     ILinkingCandidate _xblockexpression = null;
     {
-      final Procedure1<ILinkingCandidate> _function = new Procedure1<ILinkingCandidate>() {
-        @Override
-        public void apply(final ILinkingCandidate it) {
-          if ((it instanceof AbstractPendingLinkingCandidate<?>)) {
-            ((AbstractPendingLinkingCandidate<?>)it).computeArgumentTypes();
-          }
+      for (final ILinkingCandidate it : candidates) {
+        if ((it instanceof AbstractPendingLinkingCandidate<?>)) {
+          ((AbstractPendingLinkingCandidate<?>)it).computeArgumentTypes();
         }
-      };
-      IterableExtensions.forEach(candidates, _function);
+      }
       _xblockexpression = super.getBestCandidate(candidates);
     }
     return _xblockexpression;

--- a/tests/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingExpressionAwareResolvedTypes.java
+++ b/tests/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingExpressionAwareResolvedTypes.java
@@ -11,8 +11,6 @@ import com.google.common.base.Objects;
 import java.util.List;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
 import org.eclipse.xtext.xbase.XExpression;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.tests.typesystem.ValidatingReassigningResolvedTypes;
 import org.eclipse.xtext.xbase.tests.typesystem.ValidatingStackedResolvedTypes;
 import org.eclipse.xtext.xbase.typesystem.internal.AbstractTypeExpectation;
@@ -98,27 +96,23 @@ public class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStack
   @Override
   protected List<LightweightBoundTypeArgument> getHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getHints(handle);
-    final Procedure1<LightweightBoundTypeArgument> _function = new Procedure1<LightweightBoundTypeArgument>() {
-      @Override
-      public void apply(final LightweightBoundTypeArgument it) {
-        boolean _and = false;
-        LightweightTypeReference _typeReference = it.getTypeReference();
-        boolean _notEquals = (!Objects.equal(_typeReference, null));
-        if (!_notEquals) {
-          _and = false;
-        } else {
-          LightweightTypeReference _typeReference_1 = it.getTypeReference();
-          ITypeReferenceOwner _referenceOwner = ValidatingExpressionAwareResolvedTypes.this.getReferenceOwner();
-          boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
-          boolean _not = (!_isOwnedBy);
-          _and = _not;
-        }
-        if (_and) {
-          throw new IllegalArgumentException("reference is not owned by this resolved types");
-        }
+    for (final LightweightBoundTypeArgument it : result) {
+      boolean _and = false;
+      LightweightTypeReference _typeReference = it.getTypeReference();
+      boolean _notEquals = (!Objects.equal(_typeReference, null));
+      if (!_notEquals) {
+        _and = false;
+      } else {
+        LightweightTypeReference _typeReference_1 = it.getTypeReference();
+        ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+        boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
+        boolean _not = (!_isOwnedBy);
+        _and = _not;
       }
-    };
-    IterableExtensions.<LightweightBoundTypeArgument>forEach(result, _function);
+      if (_and) {
+        throw new IllegalArgumentException("reference is not owned by this resolved types");
+      }
+    }
     return result;
   }
   
@@ -146,27 +140,23 @@ public class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStack
   @Override
   public List<LightweightBoundTypeArgument> getAllHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getAllHints(handle);
-    final Procedure1<LightweightBoundTypeArgument> _function = new Procedure1<LightweightBoundTypeArgument>() {
-      @Override
-      public void apply(final LightweightBoundTypeArgument it) {
-        boolean _and = false;
-        LightweightTypeReference _typeReference = it.getTypeReference();
-        boolean _notEquals = (!Objects.equal(_typeReference, null));
-        if (!_notEquals) {
-          _and = false;
-        } else {
-          LightweightTypeReference _typeReference_1 = it.getTypeReference();
-          ITypeReferenceOwner _referenceOwner = ValidatingExpressionAwareResolvedTypes.this.getReferenceOwner();
-          boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
-          boolean _not = (!_isOwnedBy);
-          _and = _not;
-        }
-        if (_and) {
-          throw new IllegalArgumentException("hint is not owned by this resolved types");
-        }
+    for (final LightweightBoundTypeArgument it : result) {
+      boolean _and = false;
+      LightweightTypeReference _typeReference = it.getTypeReference();
+      boolean _notEquals = (!Objects.equal(_typeReference, null));
+      if (!_notEquals) {
+        _and = false;
+      } else {
+        LightweightTypeReference _typeReference_1 = it.getTypeReference();
+        ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+        boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
+        boolean _not = (!_isOwnedBy);
+        _and = _not;
       }
-    };
-    IterableExtensions.<LightweightBoundTypeArgument>forEach(result, _function);
+      if (_and) {
+        throw new IllegalArgumentException("hint is not owned by this resolved types");
+      }
+    }
     return result;
   }
   
@@ -220,23 +210,19 @@ public class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStack
   
   @Override
   public LightweightTypeReference getMergedType(final List<LightweightTypeReference> types) {
-    final Procedure1<LightweightTypeReference> _function = new Procedure1<LightweightTypeReference>() {
-      @Override
-      public void apply(final LightweightTypeReference it) {
-        ITypeReferenceOwner _owner = it.getOwner();
-        boolean _isOwnedBy = it.isOwnedBy(_owner);
-        boolean _not = (!_isOwnedBy);
-        if (_not) {
-          throw new IllegalArgumentException("result is not owned by this resolved types");
-        }
+    for (final LightweightTypeReference it : types) {
+      ITypeReferenceOwner _owner = it.getOwner();
+      boolean _isOwnedBy = it.isOwnedBy(_owner);
+      boolean _not = (!_isOwnedBy);
+      if (_not) {
+        throw new IllegalArgumentException("result is not owned by this resolved types");
       }
-    };
-    IterableExtensions.<LightweightTypeReference>forEach(types, _function);
+    }
     final LightweightTypeReference result = super.getMergedType(types);
     ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
-    boolean _isOwnedBy = result.isOwnedBy(_referenceOwner);
-    boolean _not = (!_isOwnedBy);
-    if (_not) {
+    boolean _isOwnedBy_1 = result.isOwnedBy(_referenceOwner);
+    boolean _not_1 = (!_isOwnedBy_1);
+    if (_not_1) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;
@@ -244,28 +230,24 @@ public class ValidatingExpressionAwareResolvedTypes extends ExpressionAwareStack
   
   @Override
   public TypeData mergeTypeData(final XExpression expression, final List<TypeData> allValues, final boolean returnType, final boolean nullIfEmpty) {
-    final Procedure1<TypeData> _function = new Procedure1<TypeData>() {
-      @Override
-      public void apply(final TypeData it) {
-        ITypeReferenceOwner _referenceOwner = ValidatingExpressionAwareResolvedTypes.this.getReferenceOwner();
-        boolean _isOwnedBy = it.isOwnedBy(_referenceOwner);
-        boolean _not = (!_isOwnedBy);
-        if (_not) {
-          throw new IllegalArgumentException("result is not owned by this resolved types");
-        }
+    for (final TypeData it : allValues) {
+      ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+      boolean _isOwnedBy = it.isOwnedBy(_referenceOwner);
+      boolean _not = (!_isOwnedBy);
+      if (_not) {
+        throw new IllegalArgumentException("result is not owned by this resolved types");
       }
-    };
-    IterableExtensions.<TypeData>forEach(allValues, _function);
+    }
     final TypeData result = super.mergeTypeData(expression, allValues, returnType, nullIfEmpty);
     boolean _and = false;
     boolean _notEquals = (!Objects.equal(result, null));
     if (!_notEquals) {
       _and = false;
     } else {
-      ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
-      boolean _isOwnedBy = result.isOwnedBy(_referenceOwner);
-      boolean _not = (!_isOwnedBy);
-      _and = _not;
+      ITypeReferenceOwner _referenceOwner_1 = this.getReferenceOwner();
+      boolean _isOwnedBy_1 = result.isOwnedBy(_referenceOwner_1);
+      boolean _not_1 = (!_isOwnedBy_1);
+      _and = _not_1;
     }
     if (_and) {
       throw new IllegalArgumentException("result is not owned by this resolved types");

--- a/tests/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingReassigningResolvedTypes.java
+++ b/tests/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingReassigningResolvedTypes.java
@@ -11,8 +11,6 @@ import com.google.common.base.Objects;
 import java.util.List;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
 import org.eclipse.xtext.xbase.XExpression;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.tests.typesystem.ValidatingExpressionAwareResolvedTypes;
 import org.eclipse.xtext.xbase.tests.typesystem.ValidatingStackedResolvedTypes;
 import org.eclipse.xtext.xbase.typesystem.internal.AbstractTypeExpectation;
@@ -99,27 +97,23 @@ public class ValidatingReassigningResolvedTypes extends ReassigningStackedResolv
   @Override
   protected List<LightweightBoundTypeArgument> getHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getHints(handle);
-    final Procedure1<LightweightBoundTypeArgument> _function = new Procedure1<LightweightBoundTypeArgument>() {
-      @Override
-      public void apply(final LightweightBoundTypeArgument it) {
-        boolean _and = false;
-        LightweightTypeReference _typeReference = it.getTypeReference();
-        boolean _notEquals = (!Objects.equal(_typeReference, null));
-        if (!_notEquals) {
-          _and = false;
-        } else {
-          LightweightTypeReference _typeReference_1 = it.getTypeReference();
-          ITypeReferenceOwner _referenceOwner = ValidatingReassigningResolvedTypes.this.getReferenceOwner();
-          boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
-          boolean _not = (!_isOwnedBy);
-          _and = _not;
-        }
-        if (_and) {
-          throw new IllegalArgumentException("reference is not owned by this resolved types");
-        }
+    for (final LightweightBoundTypeArgument it : result) {
+      boolean _and = false;
+      LightweightTypeReference _typeReference = it.getTypeReference();
+      boolean _notEquals = (!Objects.equal(_typeReference, null));
+      if (!_notEquals) {
+        _and = false;
+      } else {
+        LightweightTypeReference _typeReference_1 = it.getTypeReference();
+        ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+        boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
+        boolean _not = (!_isOwnedBy);
+        _and = _not;
       }
-    };
-    IterableExtensions.<LightweightBoundTypeArgument>forEach(result, _function);
+      if (_and) {
+        throw new IllegalArgumentException("reference is not owned by this resolved types");
+      }
+    }
     return result;
   }
   
@@ -147,27 +141,23 @@ public class ValidatingReassigningResolvedTypes extends ReassigningStackedResolv
   @Override
   public List<LightweightBoundTypeArgument> getAllHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getAllHints(handle);
-    final Procedure1<LightweightBoundTypeArgument> _function = new Procedure1<LightweightBoundTypeArgument>() {
-      @Override
-      public void apply(final LightweightBoundTypeArgument it) {
-        boolean _and = false;
-        LightweightTypeReference _typeReference = it.getTypeReference();
-        boolean _notEquals = (!Objects.equal(_typeReference, null));
-        if (!_notEquals) {
-          _and = false;
-        } else {
-          LightweightTypeReference _typeReference_1 = it.getTypeReference();
-          ITypeReferenceOwner _referenceOwner = ValidatingReassigningResolvedTypes.this.getReferenceOwner();
-          boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
-          boolean _not = (!_isOwnedBy);
-          _and = _not;
-        }
-        if (_and) {
-          throw new IllegalArgumentException("hint is not owned by this resolved types");
-        }
+    for (final LightweightBoundTypeArgument it : result) {
+      boolean _and = false;
+      LightweightTypeReference _typeReference = it.getTypeReference();
+      boolean _notEquals = (!Objects.equal(_typeReference, null));
+      if (!_notEquals) {
+        _and = false;
+      } else {
+        LightweightTypeReference _typeReference_1 = it.getTypeReference();
+        ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+        boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
+        boolean _not = (!_isOwnedBy);
+        _and = _not;
       }
-    };
-    IterableExtensions.<LightweightBoundTypeArgument>forEach(result, _function);
+      if (_and) {
+        throw new IllegalArgumentException("hint is not owned by this resolved types");
+      }
+    }
     return result;
   }
   
@@ -228,23 +218,19 @@ public class ValidatingReassigningResolvedTypes extends ReassigningStackedResolv
   
   @Override
   public LightweightTypeReference getMergedType(final List<LightweightTypeReference> types) {
-    final Procedure1<LightweightTypeReference> _function = new Procedure1<LightweightTypeReference>() {
-      @Override
-      public void apply(final LightweightTypeReference it) {
-        ITypeReferenceOwner _owner = it.getOwner();
-        boolean _isOwnedBy = it.isOwnedBy(_owner);
-        boolean _not = (!_isOwnedBy);
-        if (_not) {
-          throw new IllegalArgumentException("result is not owned by this resolved types");
-        }
+    for (final LightweightTypeReference it : types) {
+      ITypeReferenceOwner _owner = it.getOwner();
+      boolean _isOwnedBy = it.isOwnedBy(_owner);
+      boolean _not = (!_isOwnedBy);
+      if (_not) {
+        throw new IllegalArgumentException("result is not owned by this resolved types");
       }
-    };
-    IterableExtensions.<LightweightTypeReference>forEach(types, _function);
+    }
     final LightweightTypeReference result = super.getMergedType(types);
     ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
-    boolean _isOwnedBy = result.isOwnedBy(_referenceOwner);
-    boolean _not = (!_isOwnedBy);
-    if (_not) {
+    boolean _isOwnedBy_1 = result.isOwnedBy(_referenceOwner);
+    boolean _not_1 = (!_isOwnedBy_1);
+    if (_not_1) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;
@@ -252,23 +238,19 @@ public class ValidatingReassigningResolvedTypes extends ReassigningStackedResolv
   
   @Override
   public TypeData mergeTypeData(final XExpression expression, final List<TypeData> allValues, final boolean returnType, final boolean nullIfEmpty) {
-    final Procedure1<TypeData> _function = new Procedure1<TypeData>() {
-      @Override
-      public void apply(final TypeData it) {
-        ITypeReferenceOwner _referenceOwner = ValidatingReassigningResolvedTypes.this.getReferenceOwner();
-        boolean _isOwnedBy = it.isOwnedBy(_referenceOwner);
-        boolean _not = (!_isOwnedBy);
-        if (_not) {
-          throw new IllegalArgumentException("result is not owned by this resolved types");
-        }
+    for (final TypeData it : allValues) {
+      ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+      boolean _isOwnedBy = it.isOwnedBy(_referenceOwner);
+      boolean _not = (!_isOwnedBy);
+      if (_not) {
+        throw new IllegalArgumentException("result is not owned by this resolved types");
       }
-    };
-    IterableExtensions.<TypeData>forEach(allValues, _function);
+    }
     final TypeData result = super.mergeTypeData(expression, allValues, returnType, nullIfEmpty);
-    ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
-    boolean _isOwnedBy = result.isOwnedBy(_referenceOwner);
-    boolean _not = (!_isOwnedBy);
-    if (_not) {
+    ITypeReferenceOwner _referenceOwner_1 = this.getReferenceOwner();
+    boolean _isOwnedBy_1 = result.isOwnedBy(_referenceOwner_1);
+    boolean _not_1 = (!_isOwnedBy_1);
+    if (_not_1) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;

--- a/tests/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingRootResolvedTypes.java
+++ b/tests/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingRootResolvedTypes.java
@@ -12,8 +12,6 @@ import java.util.List;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.xbase.XExpression;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.tests.typesystem.ValidatingExpressionAwareResolvedTypes;
 import org.eclipse.xtext.xbase.tests.typesystem.ValidatingReassigningResolvedTypes;
 import org.eclipse.xtext.xbase.tests.typesystem.ValidatingStackedResolvedTypes;
@@ -104,27 +102,23 @@ public class ValidatingRootResolvedTypes extends RootResolvedTypes {
   @Override
   protected List<LightweightBoundTypeArgument> getHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getHints(handle);
-    final Procedure1<LightweightBoundTypeArgument> _function = new Procedure1<LightweightBoundTypeArgument>() {
-      @Override
-      public void apply(final LightweightBoundTypeArgument it) {
-        boolean _and = false;
-        LightweightTypeReference _typeReference = it.getTypeReference();
-        boolean _notEquals = (!Objects.equal(_typeReference, null));
-        if (!_notEquals) {
-          _and = false;
-        } else {
-          LightweightTypeReference _typeReference_1 = it.getTypeReference();
-          ITypeReferenceOwner _referenceOwner = ValidatingRootResolvedTypes.this.getReferenceOwner();
-          boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
-          boolean _not = (!_isOwnedBy);
-          _and = _not;
-        }
-        if (_and) {
-          throw new IllegalArgumentException("reference is not owned by this resolved types");
-        }
+    for (final LightweightBoundTypeArgument it : result) {
+      boolean _and = false;
+      LightweightTypeReference _typeReference = it.getTypeReference();
+      boolean _notEquals = (!Objects.equal(_typeReference, null));
+      if (!_notEquals) {
+        _and = false;
+      } else {
+        LightweightTypeReference _typeReference_1 = it.getTypeReference();
+        ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+        boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
+        boolean _not = (!_isOwnedBy);
+        _and = _not;
       }
-    };
-    IterableExtensions.<LightweightBoundTypeArgument>forEach(result, _function);
+      if (_and) {
+        throw new IllegalArgumentException("reference is not owned by this resolved types");
+      }
+    }
     return result;
   }
   
@@ -152,27 +146,23 @@ public class ValidatingRootResolvedTypes extends RootResolvedTypes {
   @Override
   public List<LightweightBoundTypeArgument> getAllHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getAllHints(handle);
-    final Procedure1<LightweightBoundTypeArgument> _function = new Procedure1<LightweightBoundTypeArgument>() {
-      @Override
-      public void apply(final LightweightBoundTypeArgument it) {
-        boolean _and = false;
-        LightweightTypeReference _typeReference = it.getTypeReference();
-        boolean _notEquals = (!Objects.equal(_typeReference, null));
-        if (!_notEquals) {
-          _and = false;
-        } else {
-          LightweightTypeReference _typeReference_1 = it.getTypeReference();
-          ITypeReferenceOwner _referenceOwner = ValidatingRootResolvedTypes.this.getReferenceOwner();
-          boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
-          boolean _not = (!_isOwnedBy);
-          _and = _not;
-        }
-        if (_and) {
-          throw new IllegalArgumentException("hint is not owned by this resolved types");
-        }
+    for (final LightweightBoundTypeArgument it : result) {
+      boolean _and = false;
+      LightweightTypeReference _typeReference = it.getTypeReference();
+      boolean _notEquals = (!Objects.equal(_typeReference, null));
+      if (!_notEquals) {
+        _and = false;
+      } else {
+        LightweightTypeReference _typeReference_1 = it.getTypeReference();
+        ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+        boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
+        boolean _not = (!_isOwnedBy);
+        _and = _not;
       }
-    };
-    IterableExtensions.<LightweightBoundTypeArgument>forEach(result, _function);
+      if (_and) {
+        throw new IllegalArgumentException("hint is not owned by this resolved types");
+      }
+    }
     return result;
   }
   
@@ -240,23 +230,19 @@ public class ValidatingRootResolvedTypes extends RootResolvedTypes {
   
   @Override
   public LightweightTypeReference getMergedType(final List<LightweightTypeReference> types) {
-    final Procedure1<LightweightTypeReference> _function = new Procedure1<LightweightTypeReference>() {
-      @Override
-      public void apply(final LightweightTypeReference it) {
-        ITypeReferenceOwner _owner = it.getOwner();
-        boolean _isOwnedBy = it.isOwnedBy(_owner);
-        boolean _not = (!_isOwnedBy);
-        if (_not) {
-          throw new IllegalArgumentException("result is not owned by this resolved types");
-        }
+    for (final LightweightTypeReference it : types) {
+      ITypeReferenceOwner _owner = it.getOwner();
+      boolean _isOwnedBy = it.isOwnedBy(_owner);
+      boolean _not = (!_isOwnedBy);
+      if (_not) {
+        throw new IllegalArgumentException("result is not owned by this resolved types");
       }
-    };
-    IterableExtensions.<LightweightTypeReference>forEach(types, _function);
+    }
     final LightweightTypeReference result = super.getMergedType(types);
     ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
-    boolean _isOwnedBy = result.isOwnedBy(_referenceOwner);
-    boolean _not = (!_isOwnedBy);
-    if (_not) {
+    boolean _isOwnedBy_1 = result.isOwnedBy(_referenceOwner);
+    boolean _not_1 = (!_isOwnedBy_1);
+    if (_not_1) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;
@@ -264,23 +250,19 @@ public class ValidatingRootResolvedTypes extends RootResolvedTypes {
   
   @Override
   public TypeData mergeTypeData(final XExpression expression, final List<TypeData> allValues, final boolean returnType, final boolean nullIfEmpty) {
-    final Procedure1<TypeData> _function = new Procedure1<TypeData>() {
-      @Override
-      public void apply(final TypeData it) {
-        ITypeReferenceOwner _referenceOwner = ValidatingRootResolvedTypes.this.getReferenceOwner();
-        boolean _isOwnedBy = it.isOwnedBy(_referenceOwner);
-        boolean _not = (!_isOwnedBy);
-        if (_not) {
-          throw new IllegalArgumentException("result is not owned by this resolved types");
-        }
+    for (final TypeData it : allValues) {
+      ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+      boolean _isOwnedBy = it.isOwnedBy(_referenceOwner);
+      boolean _not = (!_isOwnedBy);
+      if (_not) {
+        throw new IllegalArgumentException("result is not owned by this resolved types");
       }
-    };
-    IterableExtensions.<TypeData>forEach(allValues, _function);
+    }
     final TypeData result = super.mergeTypeData(expression, allValues, returnType, nullIfEmpty);
-    ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
-    boolean _isOwnedBy = result.isOwnedBy(_referenceOwner);
-    boolean _not = (!_isOwnedBy);
-    if (_not) {
+    ITypeReferenceOwner _referenceOwner_1 = this.getReferenceOwner();
+    boolean _isOwnedBy_1 = result.isOwnedBy(_referenceOwner_1);
+    boolean _not_1 = (!_isOwnedBy_1);
+    if (_not_1) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;
@@ -311,19 +293,13 @@ public class ValidatingRootResolvedTypes extends RootResolvedTypes {
   @Override
   public List<TypeData> doGetTypeData(final XExpression expression) {
     final List<TypeData> result = super.doGetTypeData(expression);
-    if (result!=null) {
-      final Procedure1<TypeData> _function = new Procedure1<TypeData>() {
-        @Override
-        public void apply(final TypeData it) {
-          ITypeReferenceOwner _referenceOwner = ValidatingRootResolvedTypes.this.getReferenceOwner();
-          boolean _isOwnedBy = it.isOwnedBy(_referenceOwner);
-          boolean _not = (!_isOwnedBy);
-          if (_not) {
-            throw new IllegalArgumentException("result is not owned by this resolved types");
-          }
-        }
-      };
-      IterableExtensions.<TypeData>forEach(result, _function);
+    for (final TypeData it : result) {
+      ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+      boolean _isOwnedBy = it.isOwnedBy(_referenceOwner);
+      boolean _not = (!_isOwnedBy);
+      if (_not) {
+        throw new IllegalArgumentException("result is not owned by this resolved types");
+      }
     }
     return result;
   }

--- a/tests/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingStackedResolvedTypes.java
+++ b/tests/org.eclipse.xtext.xbase.tests/longrunning/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ValidatingStackedResolvedTypes.java
@@ -11,8 +11,6 @@ import com.google.common.base.Objects;
 import java.util.List;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
 import org.eclipse.xtext.xbase.XExpression;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.tests.typesystem.ValidatingExpressionAwareResolvedTypes;
 import org.eclipse.xtext.xbase.tests.typesystem.ValidatingReassigningResolvedTypes;
 import org.eclipse.xtext.xbase.typesystem.internal.AbstractTypeExpectation;
@@ -98,27 +96,23 @@ public class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
   @Override
   protected List<LightweightBoundTypeArgument> getHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getHints(handle);
-    final Procedure1<LightweightBoundTypeArgument> _function = new Procedure1<LightweightBoundTypeArgument>() {
-      @Override
-      public void apply(final LightweightBoundTypeArgument it) {
-        boolean _and = false;
-        LightweightTypeReference _typeReference = it.getTypeReference();
-        boolean _notEquals = (!Objects.equal(_typeReference, null));
-        if (!_notEquals) {
-          _and = false;
-        } else {
-          LightweightTypeReference _typeReference_1 = it.getTypeReference();
-          ITypeReferenceOwner _referenceOwner = ValidatingStackedResolvedTypes.this.getReferenceOwner();
-          boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
-          boolean _not = (!_isOwnedBy);
-          _and = _not;
-        }
-        if (_and) {
-          throw new IllegalArgumentException("reference is not owned by this resolved types");
-        }
+    for (final LightweightBoundTypeArgument it : result) {
+      boolean _and = false;
+      LightweightTypeReference _typeReference = it.getTypeReference();
+      boolean _notEquals = (!Objects.equal(_typeReference, null));
+      if (!_notEquals) {
+        _and = false;
+      } else {
+        LightweightTypeReference _typeReference_1 = it.getTypeReference();
+        ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+        boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
+        boolean _not = (!_isOwnedBy);
+        _and = _not;
       }
-    };
-    IterableExtensions.<LightweightBoundTypeArgument>forEach(result, _function);
+      if (_and) {
+        throw new IllegalArgumentException("reference is not owned by this resolved types");
+      }
+    }
     return result;
   }
   
@@ -146,27 +140,23 @@ public class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
   @Override
   public List<LightweightBoundTypeArgument> getAllHints(final Object handle) {
     final List<LightweightBoundTypeArgument> result = super.getAllHints(handle);
-    final Procedure1<LightweightBoundTypeArgument> _function = new Procedure1<LightweightBoundTypeArgument>() {
-      @Override
-      public void apply(final LightweightBoundTypeArgument it) {
-        boolean _and = false;
-        LightweightTypeReference _typeReference = it.getTypeReference();
-        boolean _notEquals = (!Objects.equal(_typeReference, null));
-        if (!_notEquals) {
-          _and = false;
-        } else {
-          LightweightTypeReference _typeReference_1 = it.getTypeReference();
-          ITypeReferenceOwner _referenceOwner = ValidatingStackedResolvedTypes.this.getReferenceOwner();
-          boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
-          boolean _not = (!_isOwnedBy);
-          _and = _not;
-        }
-        if (_and) {
-          throw new IllegalArgumentException("hint is not owned by this resolved types");
-        }
+    for (final LightweightBoundTypeArgument it : result) {
+      boolean _and = false;
+      LightweightTypeReference _typeReference = it.getTypeReference();
+      boolean _notEquals = (!Objects.equal(_typeReference, null));
+      if (!_notEquals) {
+        _and = false;
+      } else {
+        LightweightTypeReference _typeReference_1 = it.getTypeReference();
+        ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+        boolean _isOwnedBy = _typeReference_1.isOwnedBy(_referenceOwner);
+        boolean _not = (!_isOwnedBy);
+        _and = _not;
       }
-    };
-    IterableExtensions.<LightweightBoundTypeArgument>forEach(result, _function);
+      if (_and) {
+        throw new IllegalArgumentException("hint is not owned by this resolved types");
+      }
+    }
     return result;
   }
   
@@ -227,23 +217,19 @@ public class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
   
   @Override
   public LightweightTypeReference getMergedType(final List<LightweightTypeReference> types) {
-    final Procedure1<LightweightTypeReference> _function = new Procedure1<LightweightTypeReference>() {
-      @Override
-      public void apply(final LightweightTypeReference it) {
-        ITypeReferenceOwner _owner = it.getOwner();
-        boolean _isOwnedBy = it.isOwnedBy(_owner);
-        boolean _not = (!_isOwnedBy);
-        if (_not) {
-          throw new IllegalArgumentException("result is not owned by this resolved types");
-        }
+    for (final LightweightTypeReference it : types) {
+      ITypeReferenceOwner _owner = it.getOwner();
+      boolean _isOwnedBy = it.isOwnedBy(_owner);
+      boolean _not = (!_isOwnedBy);
+      if (_not) {
+        throw new IllegalArgumentException("result is not owned by this resolved types");
       }
-    };
-    IterableExtensions.<LightweightTypeReference>forEach(types, _function);
+    }
     final LightweightTypeReference result = super.getMergedType(types);
     ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
-    boolean _isOwnedBy = result.isOwnedBy(_referenceOwner);
-    boolean _not = (!_isOwnedBy);
-    if (_not) {
+    boolean _isOwnedBy_1 = result.isOwnedBy(_referenceOwner);
+    boolean _not_1 = (!_isOwnedBy_1);
+    if (_not_1) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;
@@ -251,23 +237,19 @@ public class ValidatingStackedResolvedTypes extends StackedResolvedTypes {
   
   @Override
   public TypeData mergeTypeData(final XExpression expression, final List<TypeData> allValues, final boolean returnType, final boolean nullIfEmpty) {
-    final Procedure1<TypeData> _function = new Procedure1<TypeData>() {
-      @Override
-      public void apply(final TypeData it) {
-        ITypeReferenceOwner _referenceOwner = ValidatingStackedResolvedTypes.this.getReferenceOwner();
-        boolean _isOwnedBy = it.isOwnedBy(_referenceOwner);
-        boolean _not = (!_isOwnedBy);
-        if (_not) {
-          throw new IllegalArgumentException("result is not owned by this resolved types");
-        }
+    for (final TypeData it : allValues) {
+      ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
+      boolean _isOwnedBy = it.isOwnedBy(_referenceOwner);
+      boolean _not = (!_isOwnedBy);
+      if (_not) {
+        throw new IllegalArgumentException("result is not owned by this resolved types");
       }
-    };
-    IterableExtensions.<TypeData>forEach(allValues, _function);
+    }
     final TypeData result = super.mergeTypeData(expression, allValues, returnType, nullIfEmpty);
-    ITypeReferenceOwner _referenceOwner = this.getReferenceOwner();
-    boolean _isOwnedBy = result.isOwnedBy(_referenceOwner);
-    boolean _not = (!_isOwnedBy);
-    if (_not) {
+    ITypeReferenceOwner _referenceOwner_1 = this.getReferenceOwner();
+    boolean _isOwnedBy_1 = result.isOwnedBy(_referenceOwner_1);
+    boolean _not_1 = (!_isOwnedBy_1);
+    if (_not_1) {
       throw new IllegalArgumentException("result is not owned by this resolved types");
     }
     return result;

--- a/tests/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/ResolvedFeaturesTest.xtend
+++ b/tests/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/ResolvedFeaturesTest.xtend
@@ -118,9 +118,9 @@ class ResolvedFeaturesTest extends AbstractXbaseTestCase {
 		val resolvedOperations = typeof(ArrayList).toResolvedOperations
 		val all = resolvedOperations.getAllOperations
 		assertFalse(all.empty)
-		all.forEach [
+		for (it : all) {
 			assertFalse(declaration.isAbstract)
-		]
+		}
 	}
 	
 	@Test
@@ -158,7 +158,7 @@ class ResolvedFeaturesTest extends AbstractXbaseTestCase {
 		val resolvedOperations = typeof(SoftReference).toResolvedOperations
 		assertEquals(1, resolvedOperations.getDeclaredOperations.size)
 		assertEquals(2, resolvedOperations.getDeclaredConstructors.size)
-		resolvedOperations.getDeclaredConstructors.forEach [
+		for (it : resolvedOperations.getDeclaredConstructors) {
 			switch(declaration.parameters.size) {
 				case 1: {
 					assertEquals("SoftReference(T)", resolvedSignature)
@@ -170,7 +170,7 @@ class ResolvedFeaturesTest extends AbstractXbaseTestCase {
 				}
 				default: fail("Unexpected constructor: " + it)
 			}
-		]
+		}
 	}
 	
 	
@@ -179,7 +179,7 @@ class ResolvedFeaturesTest extends AbstractXbaseTestCase {
 		val resolvedOperations = "null as java.lang.ref.SoftReference<String>".toResolvedOperations
 		assertEquals(1, resolvedOperations.getDeclaredOperations.size)
 		assertEquals(2, resolvedOperations.getDeclaredConstructors.size)
-		resolvedOperations.getDeclaredConstructors.forEach [
+		for (it : resolvedOperations.getDeclaredConstructors) {
 			switch(declaration.parameters.size) {
 				case 1: {
 					assertEquals("SoftReference(java.lang.String)", resolvedSignature)
@@ -191,7 +191,7 @@ class ResolvedFeaturesTest extends AbstractXbaseTestCase {
 				}
 				default: fail("Unexpected constructor: " + it)
 			}
-		]
+		}
 	}
 	
 	@Test

--- a/tests/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/ResolvedOperationTest.xtend
+++ b/tests/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/ResolvedOperationTest.xtend
@@ -158,19 +158,19 @@ class ResolvedOperationTest extends AbstractXbaseTestCase {
 	}
 	
 	def protected withDetails(IResolvedOperation operation, IOverrideCheckResult$OverrideCheckDetails... details) {
-		operation.overriddenAndImplementedMethodCandidates.forEach [
+		for (it : operation.overriddenAndImplementedMethodCandidates) {
 			val checkResult = operation.isOverridingOrImplementing(it)
 			val actual = checkResult.details
 			assertTrue('''Failed: «actual».containsAll(«details.toList»)''', actual.containsAll(details))
-		]
+		}
 	}
 	
 	def protected withDetail(IResolvedOperation operation, IOverrideCheckResult$OverrideCheckDetails detail) {
-		operation.overriddenAndImplementedMethodCandidates.forEach [
+		for (it : operation.overriddenAndImplementedMethodCandidates) {
 			val checkResult = operation.isOverridingOrImplementing(it)
 			val actual = checkResult.details
 			assertTrue('''Failed: «actual».contains(«detail»)''', actual.contains(detail))
-		]
+		}
 	}
 	
 	@Test
@@ -380,9 +380,9 @@ class ResolvedOperationTest extends AbstractXbaseTestCase {
 	def void testVarArgsMismatch_01() {
 		val operation = '(null as testdata.MethodOverrides4).withVarArgs(null)'.toOperation
 		operation.declaration.visibility = JvmVisibility::PROTECTED
-		operation.overriddenAndImplementedMethodCandidates.forEach [
+		for (it : operation.overriddenAndImplementedMethodCandidates) {
 			visibility = JvmVisibility::PUBLIC
-		]
+		}
 		operation.has(1).candidatesAndOverrides(1).withDetails(REDUCED_VISIBILITY, VAR_ARG_MISMATCH)
 	}
 	
@@ -390,9 +390,9 @@ class ResolvedOperationTest extends AbstractXbaseTestCase {
 	def void testVarArgsMismatch_02() {
 		val operation = '(null as testdata.MethodOverrides4).withArray(null)'.toOperation
 		operation.declaration.visibility = JvmVisibility::PROTECTED
-		operation.overriddenAndImplementedMethodCandidates.forEach [
+		for (it : operation.overriddenAndImplementedMethodCandidates) {
 			visibility = JvmVisibility::DEFAULT
-		]
+		}
 		operation.has(1).candidatesAndOverrides(1).withDetails(VAR_ARG_MISMATCH)
 	}
 	
@@ -403,10 +403,10 @@ class ResolvedOperationTest extends AbstractXbaseTestCase {
 			visibility = JvmVisibility::PUBLIC
 			setStatic(true)
 		]
-		operation.overriddenAndImplementedMethodCandidates.forEach [
+		for (it : operation.overriddenAndImplementedMethodCandidates) {
 			visibility = JvmVisibility::PROTECTED
 			setStatic(true)
-		]
+		}
 		operation.has(1).candidatesAndOverrides(1).withExactDetails(SHADOWED, VAR_ARG_MISMATCH)
 	}
 	
@@ -417,9 +417,9 @@ class ResolvedOperationTest extends AbstractXbaseTestCase {
 			visibility = JvmVisibility::PROTECTED
 			setStatic(true)
 		]
-		operation.overriddenAndImplementedMethodCandidates.forEach [
+		for (it : operation.overriddenAndImplementedMethodCandidates) {
 			visibility = JvmVisibility::PROTECTED
-		]
+		}
 		operation.has(1).candidatesAndOverrides(0).withDetails(STATIC_MISMATCH, VAR_ARG_MISMATCH)
 	}
 	
@@ -429,9 +429,9 @@ class ResolvedOperationTest extends AbstractXbaseTestCase {
 		operation.declaration => [
 			visibility = JvmVisibility::PROTECTED
 		]
-		operation.overriddenAndImplementedMethodCandidates.forEach [
+		for (it : operation.overriddenAndImplementedMethodCandidates) {
 			visibility = JvmVisibility::PROTECTED
-		]
+		}
 		operation.has(1).candidatesAndOverrides(0).withExactDetails(PARAMETER_TYPE_MISMATCH, SAME_ERASURE)
 	}
 	
@@ -441,9 +441,9 @@ class ResolvedOperationTest extends AbstractXbaseTestCase {
 		operation.declaration => [
 			visibility = JvmVisibility::PROTECTED
 		]
-		operation.overriddenAndImplementedMethodCandidates.forEach [
+		for (it : operation.overriddenAndImplementedMethodCandidates) {
 			visibility = JvmVisibility::PROTECTED
-		]
+		}
 		operation.has(1).candidatesAndOverrides(0).withExactDetails(TYPE_PARAMETER_MISMATCH, SAME_ERASURE)
 	}
 	
@@ -453,9 +453,9 @@ class ResolvedOperationTest extends AbstractXbaseTestCase {
 		operation.declaration => [
 			visibility = JvmVisibility::PROTECTED
 		]
-		operation.overriddenAndImplementedMethodCandidates.forEach [
+		for (it : operation.overriddenAndImplementedMethodCandidates) {
 			visibility = JvmVisibility::PROTECTED
-		]
+		}
 		operation.has(1).candidatesAndOverrides(0).withExactDetails(TYPE_PARAMETER_MISMATCH, SAME_ERASURE)
 	}
 }

--- a/tests/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ResolvedFeaturesTest.java
+++ b/tests/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ResolvedFeaturesTest.java
@@ -29,7 +29,6 @@ import org.eclipse.xtext.xbase.XTypeLiteral;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.tests.AbstractXbaseTestCase;
 import org.eclipse.xtext.xbase.typesystem.override.IResolvedConstructor;
 import org.eclipse.xtext.xbase.typesystem.override.IResolvedField;
@@ -167,15 +166,11 @@ public class ResolvedFeaturesTest extends AbstractXbaseTestCase {
     final List<IResolvedOperation> all = resolvedOperations.getAllOperations();
     boolean _isEmpty = all.isEmpty();
     Assert.assertFalse(_isEmpty);
-    final Procedure1<IResolvedOperation> _function = new Procedure1<IResolvedOperation>() {
-      @Override
-      public void apply(final IResolvedOperation it) {
-        JvmOperation _declaration = it.getDeclaration();
-        boolean _isAbstract = _declaration.isAbstract();
-        Assert.assertFalse(_isAbstract);
-      }
-    };
-    IterableExtensions.<IResolvedOperation>forEach(all, _function);
+    for (final IResolvedOperation it : all) {
+      JvmOperation _declaration = it.getDeclaration();
+      boolean _isAbstract = _declaration.isAbstract();
+      Assert.assertFalse(_isAbstract);
+    }
   }
   
   @Test
@@ -271,32 +266,28 @@ public class ResolvedFeaturesTest extends AbstractXbaseTestCase {
     int _size_1 = _declaredConstructors.size();
     Assert.assertEquals(2, _size_1);
     List<IResolvedConstructor> _declaredConstructors_1 = resolvedOperations.getDeclaredConstructors();
-    final Procedure1<IResolvedConstructor> _function = new Procedure1<IResolvedConstructor>() {
-      @Override
-      public void apply(final IResolvedConstructor it) {
-        JvmConstructor _declaration = it.getDeclaration();
-        EList<JvmFormalParameter> _parameters = _declaration.getParameters();
-        int _size = _parameters.size();
-        switch (_size) {
-          case 1:
-            String _resolvedSignature = it.getResolvedSignature();
-            Assert.assertEquals("SoftReference(T)", _resolvedSignature);
-            String _resolvedErasureSignature = it.getResolvedErasureSignature();
-            Assert.assertEquals("SoftReference(java.lang.Object)", _resolvedErasureSignature);
-            break;
-          case 2:
-            String _resolvedSignature_1 = it.getResolvedSignature();
-            Assert.assertEquals("SoftReference(T,java.lang.ref.ReferenceQueue<? super T>)", _resolvedSignature_1);
-            String _resolvedErasureSignature_1 = it.getResolvedErasureSignature();
-            Assert.assertEquals("SoftReference(java.lang.Object,java.lang.ref.ReferenceQueue)", _resolvedErasureSignature_1);
-            break;
-          default:
-            Assert.fail(("Unexpected constructor: " + it));
-            break;
-        }
+    for (final IResolvedConstructor it : _declaredConstructors_1) {
+      JvmConstructor _declaration = it.getDeclaration();
+      EList<JvmFormalParameter> _parameters = _declaration.getParameters();
+      int _size_2 = _parameters.size();
+      switch (_size_2) {
+        case 1:
+          String _resolvedSignature = it.getResolvedSignature();
+          Assert.assertEquals("SoftReference(T)", _resolvedSignature);
+          String _resolvedErasureSignature = it.getResolvedErasureSignature();
+          Assert.assertEquals("SoftReference(java.lang.Object)", _resolvedErasureSignature);
+          break;
+        case 2:
+          String _resolvedSignature_1 = it.getResolvedSignature();
+          Assert.assertEquals("SoftReference(T,java.lang.ref.ReferenceQueue<? super T>)", _resolvedSignature_1);
+          String _resolvedErasureSignature_1 = it.getResolvedErasureSignature();
+          Assert.assertEquals("SoftReference(java.lang.Object,java.lang.ref.ReferenceQueue)", _resolvedErasureSignature_1);
+          break;
+        default:
+          Assert.fail(("Unexpected constructor: " + it));
+          break;
       }
-    };
-    IterableExtensions.<IResolvedConstructor>forEach(_declaredConstructors_1, _function);
+    }
   }
   
   @Test
@@ -309,32 +300,28 @@ public class ResolvedFeaturesTest extends AbstractXbaseTestCase {
     int _size_1 = _declaredConstructors.size();
     Assert.assertEquals(2, _size_1);
     List<IResolvedConstructor> _declaredConstructors_1 = resolvedOperations.getDeclaredConstructors();
-    final Procedure1<IResolvedConstructor> _function = new Procedure1<IResolvedConstructor>() {
-      @Override
-      public void apply(final IResolvedConstructor it) {
-        JvmConstructor _declaration = it.getDeclaration();
-        EList<JvmFormalParameter> _parameters = _declaration.getParameters();
-        int _size = _parameters.size();
-        switch (_size) {
-          case 1:
-            String _resolvedSignature = it.getResolvedSignature();
-            Assert.assertEquals("SoftReference(java.lang.String)", _resolvedSignature);
-            String _resolvedErasureSignature = it.getResolvedErasureSignature();
-            Assert.assertEquals("SoftReference(java.lang.String)", _resolvedErasureSignature);
-            break;
-          case 2:
-            String _resolvedSignature_1 = it.getResolvedSignature();
-            Assert.assertEquals("SoftReference(java.lang.String,java.lang.ref.ReferenceQueue<? super java.lang.String>)", _resolvedSignature_1);
-            String _resolvedErasureSignature_1 = it.getResolvedErasureSignature();
-            Assert.assertEquals("SoftReference(java.lang.String,java.lang.ref.ReferenceQueue)", _resolvedErasureSignature_1);
-            break;
-          default:
-            Assert.fail(("Unexpected constructor: " + it));
-            break;
-        }
+    for (final IResolvedConstructor it : _declaredConstructors_1) {
+      JvmConstructor _declaration = it.getDeclaration();
+      EList<JvmFormalParameter> _parameters = _declaration.getParameters();
+      int _size_2 = _parameters.size();
+      switch (_size_2) {
+        case 1:
+          String _resolvedSignature = it.getResolvedSignature();
+          Assert.assertEquals("SoftReference(java.lang.String)", _resolvedSignature);
+          String _resolvedErasureSignature = it.getResolvedErasureSignature();
+          Assert.assertEquals("SoftReference(java.lang.String)", _resolvedErasureSignature);
+          break;
+        case 2:
+          String _resolvedSignature_1 = it.getResolvedSignature();
+          Assert.assertEquals("SoftReference(java.lang.String,java.lang.ref.ReferenceQueue<? super java.lang.String>)", _resolvedSignature_1);
+          String _resolvedErasureSignature_1 = it.getResolvedErasureSignature();
+          Assert.assertEquals("SoftReference(java.lang.String,java.lang.ref.ReferenceQueue)", _resolvedErasureSignature_1);
+          break;
+        default:
+          Assert.fail(("Unexpected constructor: " + it));
+          break;
       }
-    };
-    IterableExtensions.<IResolvedConstructor>forEach(_declaredConstructors_1, _function);
+    }
   }
   
   @Test

--- a/tests/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ResolvedOperationTest.java
+++ b/tests/org.eclipse.xtext.xbase.tests/xtend-gen/org/eclipse/xtext/xbase/tests/typesystem/ResolvedOperationTest.java
@@ -247,9 +247,8 @@ public class ResolvedOperationTest extends AbstractXbaseTestCase {
   
   protected void withDetails(final IResolvedOperation operation, final IOverrideCheckResult.OverrideCheckDetails... details) {
     List<JvmOperation> _overriddenAndImplementedMethodCandidates = operation.getOverriddenAndImplementedMethodCandidates();
-    final Procedure1<JvmOperation> _function = new Procedure1<JvmOperation>() {
-      @Override
-      public void apply(final JvmOperation it) {
+    for (final JvmOperation it : _overriddenAndImplementedMethodCandidates) {
+      {
         final IOverrideCheckResult checkResult = operation.isOverridingOrImplementing(it);
         final EnumSet<IOverrideCheckResult.OverrideCheckDetails> actual = checkResult.getDetails();
         StringConcatenation _builder = new StringConcatenation();
@@ -262,15 +261,13 @@ public class ResolvedOperationTest extends AbstractXbaseTestCase {
         boolean _containsAll = actual.containsAll(((Collection<?>)Conversions.doWrapArray(details)));
         Assert.assertTrue(_builder.toString(), _containsAll);
       }
-    };
-    IterableExtensions.<JvmOperation>forEach(_overriddenAndImplementedMethodCandidates, _function);
+    }
   }
   
   protected void withDetail(final IResolvedOperation operation, final IOverrideCheckResult.OverrideCheckDetails detail) {
     List<JvmOperation> _overriddenAndImplementedMethodCandidates = operation.getOverriddenAndImplementedMethodCandidates();
-    final Procedure1<JvmOperation> _function = new Procedure1<JvmOperation>() {
-      @Override
-      public void apply(final JvmOperation it) {
+    for (final JvmOperation it : _overriddenAndImplementedMethodCandidates) {
+      {
         final IOverrideCheckResult checkResult = operation.isOverridingOrImplementing(it);
         final EnumSet<IOverrideCheckResult.OverrideCheckDetails> actual = checkResult.getDetails();
         StringConcatenation _builder = new StringConcatenation();
@@ -282,8 +279,7 @@ public class ResolvedOperationTest extends AbstractXbaseTestCase {
         boolean _contains = actual.contains(detail);
         Assert.assertTrue(_builder.toString(), _contains);
       }
-    };
-    IterableExtensions.<JvmOperation>forEach(_overriddenAndImplementedMethodCandidates, _function);
+    }
   }
   
   @Test
@@ -568,13 +564,9 @@ public class ResolvedOperationTest extends AbstractXbaseTestCase {
     JvmOperation _declaration = operation.getDeclaration();
     _declaration.setVisibility(JvmVisibility.PROTECTED);
     List<JvmOperation> _overriddenAndImplementedMethodCandidates = operation.getOverriddenAndImplementedMethodCandidates();
-    final Procedure1<JvmOperation> _function = new Procedure1<JvmOperation>() {
-      @Override
-      public void apply(final JvmOperation it) {
-        it.setVisibility(JvmVisibility.PUBLIC);
-      }
-    };
-    IterableExtensions.<JvmOperation>forEach(_overriddenAndImplementedMethodCandidates, _function);
+    for (final JvmOperation it : _overriddenAndImplementedMethodCandidates) {
+      it.setVisibility(JvmVisibility.PUBLIC);
+    }
     IResolvedOperation _has = this.has(operation, 1);
     IResolvedOperation _candidatesAndOverrides = this.candidatesAndOverrides(_has, 1);
     this.withDetails(_candidatesAndOverrides, IOverrideCheckResult.OverrideCheckDetails.REDUCED_VISIBILITY, IOverrideCheckResult.OverrideCheckDetails.VAR_ARG_MISMATCH);
@@ -586,13 +578,9 @@ public class ResolvedOperationTest extends AbstractXbaseTestCase {
     JvmOperation _declaration = operation.getDeclaration();
     _declaration.setVisibility(JvmVisibility.PROTECTED);
     List<JvmOperation> _overriddenAndImplementedMethodCandidates = operation.getOverriddenAndImplementedMethodCandidates();
-    final Procedure1<JvmOperation> _function = new Procedure1<JvmOperation>() {
-      @Override
-      public void apply(final JvmOperation it) {
-        it.setVisibility(JvmVisibility.DEFAULT);
-      }
-    };
-    IterableExtensions.<JvmOperation>forEach(_overriddenAndImplementedMethodCandidates, _function);
+    for (final JvmOperation it : _overriddenAndImplementedMethodCandidates) {
+      it.setVisibility(JvmVisibility.DEFAULT);
+    }
     IResolvedOperation _has = this.has(operation, 1);
     IResolvedOperation _candidatesAndOverrides = this.candidatesAndOverrides(_has, 1);
     this.withDetails(_candidatesAndOverrides, IOverrideCheckResult.OverrideCheckDetails.VAR_ARG_MISMATCH);
@@ -611,14 +599,12 @@ public class ResolvedOperationTest extends AbstractXbaseTestCase {
     };
     ObjectExtensions.<JvmOperation>operator_doubleArrow(_declaration, _function);
     List<JvmOperation> _overriddenAndImplementedMethodCandidates = operation.getOverriddenAndImplementedMethodCandidates();
-    final Procedure1<JvmOperation> _function_1 = new Procedure1<JvmOperation>() {
-      @Override
-      public void apply(final JvmOperation it) {
+    for (final JvmOperation it : _overriddenAndImplementedMethodCandidates) {
+      {
         it.setVisibility(JvmVisibility.PROTECTED);
         it.setStatic(true);
       }
-    };
-    IterableExtensions.<JvmOperation>forEach(_overriddenAndImplementedMethodCandidates, _function_1);
+    }
     IResolvedOperation _has = this.has(operation, 1);
     IResolvedOperation _candidatesAndOverrides = this.candidatesAndOverrides(_has, 1);
     this.withExactDetails(_candidatesAndOverrides, IOverrideCheckResult.OverrideCheckDetails.SHADOWED, IOverrideCheckResult.OverrideCheckDetails.VAR_ARG_MISMATCH);
@@ -637,13 +623,9 @@ public class ResolvedOperationTest extends AbstractXbaseTestCase {
     };
     ObjectExtensions.<JvmOperation>operator_doubleArrow(_declaration, _function);
     List<JvmOperation> _overriddenAndImplementedMethodCandidates = operation.getOverriddenAndImplementedMethodCandidates();
-    final Procedure1<JvmOperation> _function_1 = new Procedure1<JvmOperation>() {
-      @Override
-      public void apply(final JvmOperation it) {
-        it.setVisibility(JvmVisibility.PROTECTED);
-      }
-    };
-    IterableExtensions.<JvmOperation>forEach(_overriddenAndImplementedMethodCandidates, _function_1);
+    for (final JvmOperation it : _overriddenAndImplementedMethodCandidates) {
+      it.setVisibility(JvmVisibility.PROTECTED);
+    }
     IResolvedOperation _has = this.has(operation, 1);
     IResolvedOperation _candidatesAndOverrides = this.candidatesAndOverrides(_has, 0);
     this.withDetails(_candidatesAndOverrides, IOverrideCheckResult.OverrideCheckDetails.STATIC_MISMATCH, IOverrideCheckResult.OverrideCheckDetails.VAR_ARG_MISMATCH);
@@ -661,13 +643,9 @@ public class ResolvedOperationTest extends AbstractXbaseTestCase {
     };
     ObjectExtensions.<JvmOperation>operator_doubleArrow(_declaration, _function);
     List<JvmOperation> _overriddenAndImplementedMethodCandidates = operation.getOverriddenAndImplementedMethodCandidates();
-    final Procedure1<JvmOperation> _function_1 = new Procedure1<JvmOperation>() {
-      @Override
-      public void apply(final JvmOperation it) {
-        it.setVisibility(JvmVisibility.PROTECTED);
-      }
-    };
-    IterableExtensions.<JvmOperation>forEach(_overriddenAndImplementedMethodCandidates, _function_1);
+    for (final JvmOperation it : _overriddenAndImplementedMethodCandidates) {
+      it.setVisibility(JvmVisibility.PROTECTED);
+    }
     IResolvedOperation _has = this.has(operation, 1);
     IResolvedOperation _candidatesAndOverrides = this.candidatesAndOverrides(_has, 0);
     this.withExactDetails(_candidatesAndOverrides, IOverrideCheckResult.OverrideCheckDetails.PARAMETER_TYPE_MISMATCH, IOverrideCheckResult.OverrideCheckDetails.SAME_ERASURE);
@@ -685,13 +663,9 @@ public class ResolvedOperationTest extends AbstractXbaseTestCase {
     };
     ObjectExtensions.<JvmOperation>operator_doubleArrow(_declaration, _function);
     List<JvmOperation> _overriddenAndImplementedMethodCandidates = operation.getOverriddenAndImplementedMethodCandidates();
-    final Procedure1<JvmOperation> _function_1 = new Procedure1<JvmOperation>() {
-      @Override
-      public void apply(final JvmOperation it) {
-        it.setVisibility(JvmVisibility.PROTECTED);
-      }
-    };
-    IterableExtensions.<JvmOperation>forEach(_overriddenAndImplementedMethodCandidates, _function_1);
+    for (final JvmOperation it : _overriddenAndImplementedMethodCandidates) {
+      it.setVisibility(JvmVisibility.PROTECTED);
+    }
     IResolvedOperation _has = this.has(operation, 1);
     IResolvedOperation _candidatesAndOverrides = this.candidatesAndOverrides(_has, 0);
     this.withExactDetails(_candidatesAndOverrides, IOverrideCheckResult.OverrideCheckDetails.TYPE_PARAMETER_MISMATCH, IOverrideCheckResult.OverrideCheckDetails.SAME_ERASURE);
@@ -709,13 +683,9 @@ public class ResolvedOperationTest extends AbstractXbaseTestCase {
     };
     ObjectExtensions.<JvmOperation>operator_doubleArrow(_declaration, _function);
     List<JvmOperation> _overriddenAndImplementedMethodCandidates = operation.getOverriddenAndImplementedMethodCandidates();
-    final Procedure1<JvmOperation> _function_1 = new Procedure1<JvmOperation>() {
-      @Override
-      public void apply(final JvmOperation it) {
-        it.setVisibility(JvmVisibility.PROTECTED);
-      }
-    };
-    IterableExtensions.<JvmOperation>forEach(_overriddenAndImplementedMethodCandidates, _function_1);
+    for (final JvmOperation it : _overriddenAndImplementedMethodCandidates) {
+      it.setVisibility(JvmVisibility.PROTECTED);
+    }
     IResolvedOperation _has = this.has(operation, 1);
     IResolvedOperation _candidatesAndOverrides = this.candidatesAndOverrides(_has, 0);
     this.withExactDetails(_candidatesAndOverrides, IOverrideCheckResult.OverrideCheckDetails.TYPE_PARAMETER_MISMATCH, IOverrideCheckResult.OverrideCheckDetails.SAME_ERASURE);

--- a/web/org.eclipse.xtext.web.example.jetty/src/main/java/org/eclipse/xtext/web/example/jetty/MyXtextServlet.xtend
+++ b/web/org.eclipse.xtext.web.example.jetty/src/main/java/org/eclipse/xtext/web/example/jetty/MyXtextServlet.xtend
@@ -39,7 +39,9 @@ class MyXtextServlet extends XtextServlet {
 	}
 	
 	override destroy() {
-		executorServices.forEach[shutdown()]
+		for (it : executorServices) {
+			shutdown()
+		}
 		executorServices.clear()
 		super.destroy()
 	}

--- a/web/org.eclipse.xtext.web.example.jetty/src/main/xtend-gen/org/eclipse/xtext/web/example/jetty/MyXtextServlet.java
+++ b/web/org.eclipse.xtext.web.example.jetty/src/main/xtend-gen/org/eclipse/xtext/web/example/jetty/MyXtextServlet.java
@@ -24,7 +24,6 @@ import org.eclipse.xtext.web.server.persistence.ResourceBaseProviderImpl;
 import org.eclipse.xtext.web.servlet.XtextServlet;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
@@ -70,13 +69,9 @@ public class MyXtextServlet extends XtextServlet {
   
   @Override
   public void destroy() {
-    final Procedure1<ExecutorService> _function = new Procedure1<ExecutorService>() {
-      @Override
-      public void apply(final ExecutorService it) {
-        it.shutdown();
-      }
-    };
-    IterableExtensions.<ExecutorService>forEach(this.executorServices, _function);
+    for (final ExecutorService it : this.executorServices) {
+      it.shutdown();
+    }
     this.executorServices.clear();
     super.destroy();
   }

--- a/web/org.eclipse.xtext.web.example.statemachine.ide/src/org/eclipse/xtext/web/example/statemachine/ide/StatemachineSemanticHighlightingCalculator.xtend
+++ b/web/org.eclipse.xtext.web.example.statemachine.ide/src/org/eclipse/xtext/web/example/statemachine/ide/StatemachineSemanticHighlightingCalculator.xtend
@@ -41,8 +41,8 @@ class StatemachineSemanticHighlightingCalculator extends DefaultSemanticHighligh
 	protected def highlightSignal(EObject owner, Signal signal, EStructuralFeature feature,
 			IHighlightedPositionAcceptor acceptor, CancelIndicator cancelIndicator) {
 		cancelIndicator.checkCanceled
-		owner.findNodesForFeature(feature).forEach[
+		for (it : owner.findNodesForFeature(feature)) {
 			acceptor.addPosition(offset, length, signal.eClass.name)
-		]
+		}
 	}
 }

--- a/web/org.eclipse.xtext.web.example.statemachine.ide/xtend-gen/org/eclipse/xtext/web/example/statemachine/ide/StatemachineSemanticHighlightingCalculator.java
+++ b/web/org.eclipse.xtext.web.example.statemachine.ide/xtend-gen/org/eclipse/xtext/web/example/statemachine/ide/StatemachineSemanticHighlightingCalculator.java
@@ -23,8 +23,6 @@ import org.eclipse.xtext.web.example.statemachine.statemachine.Event;
 import org.eclipse.xtext.web.example.statemachine.statemachine.Signal;
 import org.eclipse.xtext.web.example.statemachine.statemachine.StatemachinePackage;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 @SuppressWarnings("all")
 public class StatemachineSemanticHighlightingCalculator extends DefaultSemanticHighlightingCalculator {
@@ -61,16 +59,12 @@ public class StatemachineSemanticHighlightingCalculator extends DefaultSemanticH
   protected void highlightSignal(final EObject owner, final Signal signal, final EStructuralFeature feature, final IHighlightedPositionAcceptor acceptor, final CancelIndicator cancelIndicator) {
     this._operationCanceledManager.checkCanceled(cancelIndicator);
     List<INode> _findNodesForFeature = NodeModelUtils.findNodesForFeature(owner, feature);
-    final Procedure1<INode> _function = new Procedure1<INode>() {
-      @Override
-      public void apply(final INode it) {
-        int _offset = it.getOffset();
-        int _length = it.getLength();
-        EClass _eClass = signal.eClass();
-        String _name = _eClass.getName();
-        acceptor.addPosition(_offset, _length, _name);
-      }
-    };
-    IterableExtensions.<INode>forEach(_findNodesForFeature, _function);
+    for (final INode it : _findNodesForFeature) {
+      int _offset = it.getOffset();
+      int _length = it.getLength();
+      EClass _eClass = signal.eClass();
+      String _name = _eClass.getName();
+      acceptor.addPosition(_offset, _length, _name);
+    }
   }
 }

--- a/web/org.eclipse.xtext.web.example.statemachine/src/org/eclipse/xtext/web/example/statemachine/formatting2/StatemachineFormatter.xtend
+++ b/web/org.eclipse.xtext.web.example.statemachine/src/org/eclipse/xtext/web/example/statemachine/formatting2/StatemachineFormatter.xtend
@@ -68,7 +68,9 @@ class StatemachineFormatter extends AbstractFormatter2 {
 	}
 
 	def dispatch void format(Condition condition, extension IFormattableDocument document) {
-		condition.regionFor.keywords(conditionAccess.andKeyword_1_0).forEach[prepend[oneSpace].append[oneSpace]]
+		for (it : condition.regionFor.keywords(conditionAccess.andKeyword_1_0)) {
+			prepend[oneSpace].append[oneSpace]
+		}
 		for (event : condition.events) {
 			format(event, document);
 		}

--- a/web/org.eclipse.xtext.web.example.statemachine/xtend-gen/org/eclipse/xtext/web/example/statemachine/formatting2/StatemachineFormatter.java
+++ b/web/org.eclipse.xtext.web.example.statemachine/xtend-gen/org/eclipse/xtext/web/example/statemachine/formatting2/StatemachineFormatter.java
@@ -29,7 +29,6 @@ import org.eclipse.xtext.web.example.statemachine.statemachine.State;
 import org.eclipse.xtext.web.example.statemachine.statemachine.Statemachine;
 import org.eclipse.xtext.web.example.statemachine.statemachine.Transition;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 @SuppressWarnings("all")
@@ -225,26 +224,22 @@ public class StatemachineFormatter extends AbstractFormatter2 {
     StatemachineGrammarAccess.ConditionElements _conditionAccess = this._statemachineGrammarAccess.getConditionAccess();
     Keyword _andKeyword_1_0 = _conditionAccess.getAndKeyword_1_0();
     List<ISemanticRegion> _keywords = _regionFor.keywords(_andKeyword_1_0);
-    final Procedure1<ISemanticRegion> _function = new Procedure1<ISemanticRegion>() {
-      @Override
-      public void apply(final ISemanticRegion it) {
-        final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.oneSpace();
-          }
-        };
-        ISemanticRegion _prepend = document.prepend(it, _function);
-        final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
-          @Override
-          public void apply(final IHiddenRegionFormatter it) {
-            it.oneSpace();
-          }
-        };
-        document.append(_prepend, _function_1);
-      }
-    };
-    IterableExtensions.<ISemanticRegion>forEach(_keywords, _function);
+    for (final ISemanticRegion it : _keywords) {
+      final Procedure1<IHiddenRegionFormatter> _function = new Procedure1<IHiddenRegionFormatter>() {
+        @Override
+        public void apply(final IHiddenRegionFormatter it) {
+          it.oneSpace();
+        }
+      };
+      ISemanticRegion _prepend = document.prepend(it, _function);
+      final Procedure1<IHiddenRegionFormatter> _function_1 = new Procedure1<IHiddenRegionFormatter>() {
+        @Override
+        public void apply(final IHiddenRegionFormatter it) {
+          it.oneSpace();
+        }
+      };
+      document.append(_prepend, _function_1);
+    }
     EList<Event> _events = condition.getEvents();
     for (final Event event : _events) {
       this.format(event, document);

--- a/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/validation/ValidationService.xtend
+++ b/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/validation/ValidationService.xtend
@@ -34,10 +34,10 @@ class ValidationService extends AbstractCachedService<ValidationResult> {
 	override compute(IXtextWebDocument it, CancelIndicator cancelIndicator) {
 		val issues = resourceValidator.validate(resource, CheckMode.ALL, cancelIndicator)
 		val result = new ValidationResult
-		issues.filter[severity != Severity.IGNORE].forEach[ issue |
+		for (issue : issues.filter[severity != Severity.IGNORE]) {
 			result.issues += new ValidationResult.Issue(issue.message, issue.severity.translate,
 				issue.lineNumber, issue.column, issue.offset, issue.length)
-		]
+		}
 		return result
 	}
 	

--- a/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/validation/ValidationService.java
+++ b/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/validation/ValidationService.java
@@ -23,7 +23,6 @@ import org.eclipse.xtext.web.server.model.UpdateDocumentService;
 import org.eclipse.xtext.web.server.validation.ValidationResult;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
 /**
  * Service class for model validation.
@@ -53,22 +52,18 @@ public class ValidationService extends AbstractCachedService<ValidationResult> {
       }
     };
     Iterable<Issue> _filter = IterableExtensions.<Issue>filter(issues, _function);
-    final Procedure1<Issue> _function_1 = new Procedure1<Issue>() {
-      @Override
-      public void apply(final Issue issue) {
-        List<ValidationResult.Issue> _issues = result.getIssues();
-        String _message = issue.getMessage();
-        Severity _severity = issue.getSeverity();
-        String _translate = ValidationService.this.translate(_severity);
-        Integer _lineNumber = issue.getLineNumber();
-        Integer _column = issue.getColumn();
-        Integer _offset = issue.getOffset();
-        Integer _length = issue.getLength();
-        ValidationResult.Issue _issue = new ValidationResult.Issue(_message, _translate, _lineNumber, _column, _offset, _length);
-        _issues.add(_issue);
-      }
-    };
-    IterableExtensions.<Issue>forEach(_filter, _function_1);
+    for (final Issue issue : _filter) {
+      List<ValidationResult.Issue> _issues = result.getIssues();
+      String _message = issue.getMessage();
+      Severity _severity = issue.getSeverity();
+      String _translate = this.translate(_severity);
+      Integer _lineNumber = issue.getLineNumber();
+      Integer _column = issue.getColumn();
+      Integer _offset = issue.getOffset();
+      Integer _length = issue.getLength();
+      ValidationResult.Issue _issue = new ValidationResult.Issue(_message, _translate, _lineNumber, _column, _offset, _length);
+      _issues.add(_issue);
+    }
     return result;
   }
   

--- a/web/org.eclipse.xtext.web/src/test/java/org/eclipse/xtext/web/server/test/AbstractWebServerTest.xtend
+++ b/web/org.eclipse.xtext.web/src/test/java/org/eclipse/xtext/web/server/test/AbstractWebServerTest.xtend
@@ -62,7 +62,9 @@ class AbstractWebServerTest extends AbstractXtextTests {
 	}
 	
 	override tearDown() {
-		executorServices.forEach[shutdown()]
+		for (it : executorServices) {
+			shutdown()
+		}
 		executorServices.clear()
 		super.tearDown()
 	}

--- a/web/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/AbstractWebServerTest.java
+++ b/web/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/AbstractWebServerTest.java
@@ -33,7 +33,6 @@ import org.eclipse.xtext.web.server.test.MockServiceContext;
 import org.eclipse.xtext.web.server.test.languages.StatemachineWebModule;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -101,13 +100,9 @@ public class AbstractWebServerTest extends AbstractXtextTests {
   @Override
   public void tearDown() {
     try {
-      final Procedure1<ExecutorService> _function = new Procedure1<ExecutorService>() {
-        @Override
-        public void apply(final ExecutorService it) {
-          it.shutdown();
-        }
-      };
-      IterableExtensions.<ExecutorService>forEach(this.executorServices, _function);
+      for (final ExecutorService it : this.executorServices) {
+        it.shutdown();
+      }
       this.executorServices.clear();
       super.tearDown();
     } catch (Throwable _e) {

--- a/web/org.eclipse.xtext.xbase.web/src/test/java/org/eclipse/xtext/xbase/web/test/AbstractXbaseWebTest.xtend
+++ b/web/org.eclipse.xtext.xbase.web/src/test/java/org/eclipse/xtext/xbase/web/test/AbstractXbaseWebTest.xtend
@@ -61,7 +61,9 @@ class AbstractXbaseWebTest extends AbstractXtextTests {
 	}
 	
 	override tearDown() {
-		executorServices.forEach[shutdown()]
+		for (it : executorServices) {
+			shutdown()
+		}
 		executorServices.clear()
 		super.tearDown()
 	}

--- a/web/org.eclipse.xtext.xbase.web/src/test/xtend-gen/org/eclipse/xtext/xbase/web/test/AbstractXbaseWebTest.java
+++ b/web/org.eclipse.xtext.xbase.web/src/test/xtend-gen/org/eclipse/xtext/xbase/web/test/AbstractXbaseWebTest.java
@@ -30,7 +30,6 @@ import org.eclipse.xtext.web.server.XtextServiceDispatcher;
 import org.eclipse.xtext.web.server.persistence.IResourceBaseProvider;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -100,13 +99,9 @@ public class AbstractXbaseWebTest extends AbstractXtextTests {
   @Override
   public void tearDown() {
     try {
-      final Procedure1<ExecutorService> _function = new Procedure1<ExecutorService>() {
-        @Override
-        public void apply(final ExecutorService it) {
-          it.shutdown();
-        }
-      };
-      IterableExtensions.<ExecutorService>forEach(this.executorServices, _function);
+      for (final ExecutorService it : this.executorServices) {
+        it.shutdown();
+      }
       this.executorServices.clear();
       super.tearDown();
     } catch (Throwable _e) {


### PR DESCRIPTION
because in Java 8 that call is resolved to Iterable.forEach()
which causes the code in src-gen to change.

We'd like to avoid these changes when working in mixed Java 7 / 8
environments. 

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>