### PR TITLE
Fix index guard in getPreviousHiddenPart()

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/NodeHidden.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/NodeHidden.java
@@ -51,7 +51,7 @@ public class NodeHidden extends NodeRegion implements IHiddenRegionPart {
 	public IHiddenRegionPart getPreviousHiddenPart() {
 		List<IHiddenRegionPart> parts = hiddenRegion.getParts();
 		int i = parts.indexOf(this) - 1;
-		if (i > 0)
+		if (i >= 0)
 			return parts.get(i);
 		return null;
 	}


### PR DESCRIPTION
Fixes an index guard that prevents
org.eclipse.xtext.formatting2.regionaccess.internal.NodeHidden#getPreviousHiddenPart()
from returning the first part of a hidden region.

Old behavior:
Given a hidden region consisting of two or more parts
When getPreviousHiddenPart() is called on the second part
Then null is returned

New behaviour:
Given a hidden region consisting of two or more parts
When getPreviousHiddenPart() is called on the second part
Then first part ist returned

Signed-off-by: Moritz Heindl <lenidh@gmail.com>