### PR TITLE
[serializer] never attempt to call ValueConverter with wrong rule

### DIFF
--- a/plugins/org.eclipse.xtext/src/org/eclipse/xtext/linking/impl/LinkingHelper.java
+++ b/plugins/org.eclipse.xtext/src/org/eclipse/xtext/linking/impl/LinkingHelper.java
@@ -37,15 +37,22 @@ public class LinkingHelper {
 	 *            may be any crossreferencable element, i.e. a keyword or a rulecall
 	 */
 	public String getRuleNameFrom(EObject grammarElement) {
+		AbstractRule rule = getRuleFrom(grammarElement);
+		return rule != null ? rule.getName() : null;
+	}
+	
+	/**
+	 * @since 2.10
+	 */
+	public AbstractRule getRuleFrom(EObject grammarElement) {
 		if (!(grammarElement instanceof Keyword || grammarElement instanceof RuleCall || grammarElement instanceof CrossReference))
 			throw new IllegalArgumentException("grammarElement is of type: '" + grammarElement.eClass().getName() + "'");
-		AbstractRule rule = null;
 		EObject elementToUse = grammarElement;
 		if (grammarElement instanceof CrossReference)
 			elementToUse = ((CrossReference) grammarElement).getTerminal();
 		if (elementToUse instanceof RuleCall)
-			rule = ((RuleCall) elementToUse).getRule();
-		return rule != null ? rule.getName() : null;
+			return ((RuleCall) elementToUse).getRule();
+		return null;
 	}
 
 	public String getCrossRefNodeAsString(INode node, boolean convert) {


### PR DESCRIPTION
---Example---
Rule: name=FQN | name=STRING;
-------------

When FQN has been parsed but the serializer decided to write out 
STRING it was calling the IValueConverter with FQN's INode and rule 
STRING. That's obviously wrong input for the ValueConverter. 

The fix just prevents the IValueConverter to be called in this scenario,
causing the INode's text to be ignored; Instead fresh output is
generated via IValueConverter.toString(...) 

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>