### PR TITLE
Explicit dependency on org.eclipse.rcp in ui.tests

### DIFF
--- a/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
+++ b/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
@@ -94,7 +94,8 @@ abstract class TestProjectDescriptor extends ProjectDescriptor {
 										<extraRequirements>
 											<!-- to get the org.eclipse.osgi.compatibility.state plugin
 											if the target platform is Luna or later.
-											(backward compatible with kepler and previous versions) -->
+											(backward compatible with kepler and previous versions)
+											see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492149 -->
 											<requirement>
 												<type>eclipse-feature</type>
 												<id>org.eclipse.rcp</id>

--- a/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
+++ b/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.xtend
@@ -85,6 +85,26 @@ abstract class TestProjectDescriptor extends ProjectDescriptor {
 									«ENDIF»
 								</configuration>
 							</plugin>
+							«IF needsUiHarness»
+							<plugin>
+								<groupId>org.eclipse.tycho</groupId>
+								<artifactId>target-platform-configuration</artifactId>
+								<configuration>
+									<dependency-resolution>
+										<extraRequirements>
+											<!-- to get the org.eclipse.osgi.compatibility.state plugin
+											if the target platform is Luna or later.
+											(backward compatible with kepler and previous versions) -->
+											<requirement>
+												<type>eclipse-feature</type>
+												<id>org.eclipse.rcp</id>
+												<versionRange>0.0.0</versionRange>
+											</requirement>
+										</extraRequirements>
+									</dependency-resolution>
+								</configuration>
+							</plugin>
+							«ENDIF»
 						«ENDIF»
 						«IF !isEclipsePluginProject»
 							<plugin>

--- a/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
+++ b/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
@@ -252,7 +252,11 @@ public abstract class TestProjectDescriptor extends ProjectDescriptor {
                 _builder.newLine();
                 _builder.append("\t\t");
                 _builder.append("\t\t\t\t");
-                _builder.append("(backward compatible with kepler and previous versions) -->");
+                _builder.append("(backward compatible with kepler and previous versions)");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t\t\t");
+                _builder.append("see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492149 -->");
                 _builder.newLine();
                 _builder.append("\t\t");
                 _builder.append("\t\t\t\t");

--- a/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
+++ b/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TestProjectDescriptor.java
@@ -216,6 +216,81 @@ public abstract class TestProjectDescriptor extends ProjectDescriptor {
             _builder.append("\t\t");
             _builder.append("</plugin>");
             _builder.newLine();
+            {
+              boolean _needsUiHarness_1 = TestProjectDescriptor.this.needsUiHarness();
+              if (_needsUiHarness_1) {
+                _builder.append("\t\t");
+                _builder.append("<plugin>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t");
+                _builder.append("<groupId>org.eclipse.tycho</groupId>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t");
+                _builder.append("<artifactId>target-platform-configuration</artifactId>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t");
+                _builder.append("<configuration>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t");
+                _builder.append("<dependency-resolution>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t\t");
+                _builder.append("<extraRequirements>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t\t\t");
+                _builder.append("<!-- to get the org.eclipse.osgi.compatibility.state plugin");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t\t\t");
+                _builder.append("if the target platform is Luna or later.");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t\t\t");
+                _builder.append("(backward compatible with kepler and previous versions) -->");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t\t\t");
+                _builder.append("<requirement>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t\t\t\t");
+                _builder.append("<type>eclipse-feature</type>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t\t\t\t");
+                _builder.append("<id>org.eclipse.rcp</id>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t\t\t\t");
+                _builder.append("<versionRange>0.0.0</versionRange>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t\t\t");
+                _builder.append("</requirement>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t\t");
+                _builder.append("</extraRequirements>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t\t");
+                _builder.append("</dependency-resolution>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("\t");
+                _builder.append("</configuration>");
+                _builder.newLine();
+                _builder.append("\t\t");
+                _builder.append("</plugin>");
+                _builder.newLine();
+              }
+            }
           }
         }
         {

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui.tests/pom.xml
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui.tests/pom.xml
@@ -32,7 +32,8 @@
 						<extraRequirements>
 							<!-- to get the org.eclipse.osgi.compatibility.state plugin
 							if the target platform is Luna or later.
-							(backward compatible with kepler and previous versions) -->
+							(backward compatible with kepler and previous versions)
+							see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492149 -->
 							<requirement>
 								<type>eclipse-feature</type>
 								<id>org.eclipse.rcp</id>

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui.tests/pom.xml
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.ui.tests/pom.xml
@@ -24,6 +24,24 @@
 					<useUIHarness>true</useUIHarness>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<configuration>
+					<dependency-resolution>
+						<extraRequirements>
+							<!-- to get the org.eclipse.osgi.compatibility.state plugin
+							if the target platform is Luna or later.
+							(backward compatible with kepler and previous versions) -->
+							<requirement>
+								<type>eclipse-feature</type>
+								<id>org.eclipse.rcp</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui.tests/pom.xml
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui.tests/pom.xml
@@ -32,7 +32,8 @@
 						<extraRequirements>
 							<!-- to get the org.eclipse.osgi.compatibility.state plugin
 							if the target platform is Luna or later.
-							(backward compatible with kepler and previous versions) -->
+							(backward compatible with kepler and previous versions)
+							see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492149 -->
 							<requirement>
 								<type>eclipse-feature</type>
 								<id>org.eclipse.rcp</id>

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui.tests/pom.xml
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.ui.tests/pom.xml
@@ -24,6 +24,24 @@
 					<useUIHarness>true</useUIHarness>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<configuration>
+					<dependency-resolution>
+						<extraRequirements>
+							<!-- to get the org.eclipse.osgi.compatibility.state plugin
+							if the target platform is Luna or later.
+							(backward compatible with kepler and previous versions) -->
+							<requirement>
+								<type>eclipse-feature</type>
+								<id>org.eclipse.rcp</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui.tests/pom.xml
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui.tests/pom.xml
@@ -32,7 +32,8 @@
 						<extraRequirements>
 							<!-- to get the org.eclipse.osgi.compatibility.state plugin
 							if the target platform is Luna or later.
-							(backward compatible with kepler and previous versions) -->
+							(backward compatible with kepler and previous versions)
+							see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492149 -->
 							<requirement>
 								<type>eclipse-feature</type>
 								<id>org.eclipse.rcp</id>

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui.tests/pom.xml
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.ui.tests/pom.xml
@@ -24,6 +24,24 @@
 					<useUIHarness>true</useUIHarness>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<configuration>
+					<dependency-resolution>
+						<extraRequirements>
+							<!-- to get the org.eclipse.osgi.compatibility.state plugin
+							if the target platform is Luna or later.
+							(backward compatible with kepler and previous versions) -->
+							<requirement>
+								<type>eclipse-feature</type>
+								<id>org.eclipse.rcp</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
If you have a ui test that needs the workbench or an editor, if you do
not have org.eclipse.osgi.compatibility.state, introduced in Luna, in
the dependencies the workbench and editors will be null and the UI tests
will fail. By adding org.eclipse.rcp feature as a dependency, then
org.eclipse.osgi.compatibility.state will be dragged in and UI tests
will work, since the workbench will be available.  Adding
org.eclipse.rcp is safe also for previous Eclipse target platforms,
while adding org.eclipse.osgi.compatibility.state only will not work in
Eclipse versions earlier than Luna.

At least, that's what I do to run UI tests that require the workbench.

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>