### PR TITLE
[web] Added generator service options 'allArtifacts' and 'includeContent'

### DIFF
--- a/web/org.eclipse.xtext.web.example.jetty/src/main/webapp/orion-statemachine-autogenerate.html
+++ b/web/org.eclipse.xtext.web.example.jetty/src/main/webapp/orion-statemachine-autogenerate.html
@@ -18,15 +18,21 @@
 		require(["orion/code_edit/built-codeEdit-amd"], function() {
 			require(['xtext/xtext-orion'], function(xtext) {
 				xtext.createEditor({syntaxDefinition: "xtext/statemachine-syntax"}).done(function(editorViewer) {
+					var xtextServices = editorViewer.xtextServices;
 					$('#save-button').click(function() {
-						editorViewer.xtextServices.saveResource();
+						xtextServices.saveResource();
 					});
 					$('#revert-button').click(function() {
-						editorViewer.xtextServices.revertResource();
+						xtextServices.revertResource();
 					});
-					editorViewer.xtextServices.successListeners.push(function(serviceType, result) {
+					xtextServices.successListeners.push(function(serviceType, result) {
 						if (serviceType == 'validate' && result.issues.every(function(issue) {issue.severity != 'error'})) {
+							// Option 1: use a simple GET request
 							$('#generator-result').html('<iframe src="http://' + location.host + '/xtext-service/generate?resource=example1.statemachine"></iframe>');
+							// Option 2: use the 'generate' function
+							xtextServices.generate({artifactId: '/hidden.txt'}).done(function(result) {
+								console.log(result);
+							});
 						}
 					});
 				});

--- a/web/org.eclipse.xtext.web.servlet/src/main/xtend-gen/org/eclipse/xtext/web/servlet/XtextServlet.java
+++ b/web/org.eclipse.xtext.web.servlet/src/main/xtend-gen/org/eclipse/xtext/web/servlet/XtextServlet.java
@@ -23,12 +23,13 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
 import org.eclipse.xtext.web.server.IServiceContext;
 import org.eclipse.xtext.web.server.IServiceResult;
+import org.eclipse.xtext.web.server.IUnwrappableServiceResult;
 import org.eclipse.xtext.web.server.InvalidRequestException;
 import org.eclipse.xtext.web.server.XtextServiceDispatcher;
-import org.eclipse.xtext.web.server.generator.GeneratorResult;
 import org.eclipse.xtext.web.servlet.HttpServiceContext;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function0;
+import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
  * An HTTP servlet for publishing the Xtext services. Include this into your web server by creating
@@ -165,8 +166,8 @@ public class XtextServlet extends HttpServlet {
   
   /**
    * Invoke the service function of the given service descriptor and write its result to the
-   * servlet response in Json format. An exception is made for code generation: here the document
-   * itself is written into the response instead of wrapping it into a Json object.
+   * servlet response in Json format. An exception is made for {@link IUnwrappableServiceResult}:
+   * here the document itself is written into the response instead of wrapping it into a Json object.
    */
   protected void doService(final XtextServiceDispatcher.ServiceDescriptor service, final HttpServletResponse response) {
     try {
@@ -176,9 +177,10 @@ public class XtextServlet extends HttpServlet {
       String _encoding = this.getEncoding(service, result);
       response.setCharacterEncoding(_encoding);
       response.setHeader("Cache-Control", "no-cache");
-      if ((result instanceof GeneratorResult)) {
+      if (((result instanceof IUnwrappableServiceResult) && (((IUnwrappableServiceResult) result).getContent() != null))) {
+        final IUnwrappableServiceResult unwrapResult = ((IUnwrappableServiceResult) result);
         String _elvis = null;
-        String _contentType = ((GeneratorResult)result).getContentType();
+        String _contentType = unwrapResult.getContentType();
         if (_contentType != null) {
           _elvis = _contentType;
         } else {
@@ -186,7 +188,7 @@ public class XtextServlet extends HttpServlet {
         }
         response.setContentType(_elvis);
         PrintWriter _writer = response.getWriter();
-        String _content = ((GeneratorResult)result).getContent();
+        String _content = unwrapResult.getContent();
         _writer.write(_content);
       } else {
         response.setContentType("text/x-json");
@@ -219,27 +221,34 @@ public class XtextServlet extends HttpServlet {
     }
     final URI emfURI = URI.createURI(_elvis);
     final String contentType = serviceContext.getParameter("contentType");
-    if ((contentType == null)) {
+    boolean _isNullOrEmpty = StringExtensions.isNullOrEmpty(contentType);
+    if (_isNullOrEmpty) {
       IResourceServiceProvider _resourceServiceProvider = this.serviceProviderRegistry.getResourceServiceProvider(emfURI);
       resourceServiceProvider = _resourceServiceProvider;
-      boolean _equals = Objects.equal(resourceServiceProvider, null);
-      if (_equals) {
-        StringConcatenation _builder = new StringConcatenation();
-        _builder.append("Unable to identify the Xtext language for resource ");
-        _builder.append(emfURI, "");
-        _builder.append(".");
-        throw new InvalidRequestException.UnknownLanguageException(_builder.toString());
+      if ((resourceServiceProvider == null)) {
+        String _string = emfURI.toString();
+        boolean _isEmpty = _string.isEmpty();
+        if (_isEmpty) {
+          StringConcatenation _builder = new StringConcatenation();
+          _builder.append("Unable to identify the Xtext language: missing parameter \'resource\' or \'contentType\'.");
+          throw new InvalidRequestException.UnknownLanguageException(_builder.toString());
+        } else {
+          StringConcatenation _builder_1 = new StringConcatenation();
+          _builder_1.append("Unable to identify the Xtext language for resource ");
+          _builder_1.append(emfURI, "");
+          _builder_1.append(".");
+          throw new InvalidRequestException.UnknownLanguageException(_builder_1.toString());
+        }
       }
     } else {
       IResourceServiceProvider _resourceServiceProvider_1 = this.serviceProviderRegistry.getResourceServiceProvider(emfURI, contentType);
       resourceServiceProvider = _resourceServiceProvider_1;
-      boolean _equals_1 = Objects.equal(resourceServiceProvider, null);
-      if (_equals_1) {
-        StringConcatenation _builder_1 = new StringConcatenation();
-        _builder_1.append("Unable to identify the Xtext language for contentType ");
-        _builder_1.append(contentType, "");
-        _builder_1.append(".");
-        throw new InvalidRequestException.UnknownLanguageException(_builder_1.toString());
+      if ((resourceServiceProvider == null)) {
+        StringConcatenation _builder_2 = new StringConcatenation();
+        _builder_2.append("Unable to identify the Xtext language for contentType ");
+        _builder_2.append(contentType, "");
+        _builder_2.append(".");
+        throw new InvalidRequestException.UnknownLanguageException(_builder_2.toString());
       }
     }
     return resourceServiceProvider.<Injector>get(Injector.class);

--- a/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/IUnwrappableServiceResult.xtend
+++ b/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/IUnwrappableServiceResult.xtend
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.web.server
+
+/**
+ * Service results that implement this interface are unwrapped, i.e. the content of the result object
+ * is sent to the client instead of a Json object.
+ */
+interface IUnwrappableServiceResult extends IServiceResult {
+	
+	/**
+	 * The actual content to write into the request response.
+	 */
+	def String getContent()
+	
+	/**
+	 * The content type of the text content.
+	 */
+	def String getContentType()
+	
+}

--- a/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/XtextServiceDispatcher.xtend
+++ b/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/XtextServiceDispatcher.xtend
@@ -434,15 +434,27 @@ class XtextServiceDispatcher {
 	protected def getGeneratorService(IServiceContext context)
 			throws InvalidRequestException {
 		val document = getDocumentAccess(context)
-		val artifactId = context.getParameter('artifact')
+		val allArtifacts = getBoolean(context, 'allArtifacts', Optional.of(false))
+		val includeContent = getBoolean(context, 'includeContent', Optional.of(true))
 		new ServiceDescriptor => [
-			service = [
-				try {
-					generatorService.getArtifact(document, artifactId)
-				} catch (Throwable throwable) {
-					handleError(throwable)
-				}
-			]
+			if (allArtifacts) {
+				service = [
+					try {
+						generatorService.getResult(document, includeContent)
+					} catch (Throwable throwable) {
+						handleError(throwable)
+					}
+				]
+			} else {
+				val artifactId = context.getParameter('artifact')
+				service = [
+					try {
+						generatorService.getArtifact(document, artifactId, includeContent)
+					} catch (Throwable throwable) {
+						handleError(throwable)
+					}
+				]
+			}
 		]
 	}
 	

--- a/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/generator/GeneratorResult.xtend
+++ b/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/generator/GeneratorResult.xtend
@@ -9,7 +9,7 @@ package org.eclipse.xtext.web.server.generator
 
 import org.eclipse.xtend.lib.annotations.Data
 import org.eclipse.xtend.lib.annotations.ToString
-import org.eclipse.xtext.web.server.IServiceResult
+import org.eclipse.xtext.web.server.IUnwrappableServiceResult
 
 /**
  * Result object returned by the generator service. This object is usually not sent in
@@ -17,7 +17,7 @@ import org.eclipse.xtext.web.server.IServiceResult
  */
 @Data
 @ToString(skipNulls = true)
-class GeneratorResult implements IServiceResult {
+class GeneratorResult implements IUnwrappableServiceResult {
 	
 	String name
 	String contentType

--- a/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/model/AbstractCachedService.xtend
+++ b/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/model/AbstractCachedService.xtend
@@ -26,7 +26,9 @@ abstract class AbstractCachedService<T extends IServiceResult> {
 	}
 
 	/**
-	 * Perform the actual computations to obtain a result.
+	 * Perform the actual computations to obtain a result. This method should not be called
+	 * directly from the service dispatcher; use {@link #getResult(XtextWebDocumentAccess)} instead
+	 * in order to avoid duplicate computations.
 	 */
 	def T compute(IXtextWebDocument it, CancelIndicator cancelIndicator)
 	

--- a/web/org.eclipse.xtext.web/src/main/js/xtext/ServiceBuilder.js
+++ b/web/org.eclipse.xtext.web/src/main/js/xtext/ServiceBuilder.js
@@ -147,8 +147,12 @@ define([
 			services.generatorService = new XtextService();
 			services.generatorService.initialize(options.serviceUrl, 'generate', options.resourceId, services.updateService);
 			services.generatorService._initServerData = function(serverData, editorContext, params) {
-				if (params.artifactId)
+				if (params.allArtifacts)
+					serverData.allArtifacts = params.allArtifacts;
+				else if (params.artifactId)
 					serverData.artifact = params.artifactId;
+				if (params.includeContent !== undefined)
+					serverData.includeContent = params.includeContent;
 			}
 			services.generate = function(addParams) {
 				return services.generatorService.invoke(editorContext, ServiceBuilder.mergeOptions(addParams, options));

--- a/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/IUnwrappableServiceResult.java
+++ b/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/IUnwrappableServiceResult.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.web.server;
+
+import org.eclipse.xtext.web.server.IServiceResult;
+
+/**
+ * Service results that implement this interface are unwrapped, i.e. the content of the result object
+ * is sent to the client instead of a Json object.
+ */
+@SuppressWarnings("all")
+public interface IUnwrappableServiceResult extends IServiceResult {
+  /**
+   * The actual content to write into the request response.
+   */
+  public abstract String getContent();
+  
+  /**
+   * The content type of the text content.
+   */
+  public abstract String getContentType();
+}

--- a/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/XtextServiceDispatcher.java
+++ b/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/XtextServiceDispatcher.java
@@ -884,29 +884,54 @@ public class XtextServiceDispatcher {
     XtextServiceDispatcher.ServiceDescriptor _xblockexpression = null;
     {
       final XtextWebDocumentAccess document = this.getDocumentAccess(context);
-      final String artifactId = context.getParameter("artifact");
+      Optional<Boolean> _of = Optional.<Boolean>of(Boolean.valueOf(false));
+      final boolean allArtifacts = this.getBoolean(context, "allArtifacts", _of);
+      Optional<Boolean> _of_1 = Optional.<Boolean>of(Boolean.valueOf(true));
+      final boolean includeContent = this.getBoolean(context, "includeContent", _of_1);
       XtextServiceDispatcher.ServiceDescriptor _serviceDescriptor = new XtextServiceDispatcher.ServiceDescriptor();
       final Procedure1<XtextServiceDispatcher.ServiceDescriptor> _function = new Procedure1<XtextServiceDispatcher.ServiceDescriptor>() {
         @Override
         public void apply(final XtextServiceDispatcher.ServiceDescriptor it) {
-          final Function0<IServiceResult> _function = new Function0<IServiceResult>() {
-            @Override
-            public IServiceResult apply() {
-              IServiceResult _xtrycatchfinallyexpression = null;
-              try {
-                _xtrycatchfinallyexpression = XtextServiceDispatcher.this.generatorService.getArtifact(document, artifactId);
-              } catch (final Throwable _t) {
-                if (_t instanceof Throwable) {
-                  final Throwable throwable = (Throwable)_t;
-                  _xtrycatchfinallyexpression = XtextServiceDispatcher.this.handleError(it, throwable);
-                } else {
-                  throw Exceptions.sneakyThrow(_t);
+          if (allArtifacts) {
+            final Function0<IServiceResult> _function = new Function0<IServiceResult>() {
+              @Override
+              public IServiceResult apply() {
+                IServiceResult _xtrycatchfinallyexpression = null;
+                try {
+                  _xtrycatchfinallyexpression = XtextServiceDispatcher.this.generatorService.getResult(document, includeContent);
+                } catch (final Throwable _t) {
+                  if (_t instanceof Throwable) {
+                    final Throwable throwable = (Throwable)_t;
+                    _xtrycatchfinallyexpression = XtextServiceDispatcher.this.handleError(it, throwable);
+                  } else {
+                    throw Exceptions.sneakyThrow(_t);
+                  }
                 }
+                return _xtrycatchfinallyexpression;
               }
-              return _xtrycatchfinallyexpression;
-            }
-          };
-          it.service = _function;
+            };
+            it.service = _function;
+          } else {
+            final String artifactId = context.getParameter("artifact");
+            final Function0<IServiceResult> _function_1 = new Function0<IServiceResult>() {
+              @Override
+              public IServiceResult apply() {
+                IServiceResult _xtrycatchfinallyexpression = null;
+                try {
+                  _xtrycatchfinallyexpression = XtextServiceDispatcher.this.generatorService.getArtifact(document, artifactId, includeContent);
+                } catch (final Throwable _t) {
+                  if (_t instanceof Throwable) {
+                    final Throwable throwable = (Throwable)_t;
+                    _xtrycatchfinallyexpression = XtextServiceDispatcher.this.handleError(it, throwable);
+                  } else {
+                    throw Exceptions.sneakyThrow(_t);
+                  }
+                }
+                return _xtrycatchfinallyexpression;
+              }
+            };
+            it.service = _function_1;
+          }
         }
       };
       _xblockexpression = ObjectExtensions.<XtextServiceDispatcher.ServiceDescriptor>operator_doubleArrow(_serviceDescriptor, _function);

--- a/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/generator/GeneratorResult.java
+++ b/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/generator/GeneratorResult.java
@@ -9,7 +9,7 @@ package org.eclipse.xtext.web.server.generator;
 
 import org.eclipse.xtend.lib.annotations.Data;
 import org.eclipse.xtend.lib.annotations.ToString;
-import org.eclipse.xtext.web.server.IServiceResult;
+import org.eclipse.xtext.web.server.IUnwrappableServiceResult;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -20,7 +20,7 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 @Data
 @ToString(skipNulls = true)
 @SuppressWarnings("all")
-public class GeneratorResult implements IServiceResult {
+public class GeneratorResult implements IUnwrappableServiceResult {
   private final String name;
   
   private final String contentType;

--- a/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/generator/GeneratorService.java
+++ b/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/generator/GeneratorService.java
@@ -32,6 +32,7 @@ import org.eclipse.xtext.web.server.model.XtextWebDocumentAccess;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -97,6 +98,7 @@ public class GeneratorService extends AbstractCachedService<GeneratorService.Gen
   
   /**
    * The default artifact name that is accessed when no specific artifact is requested.
+   * Value: "DEFAULT_OUTPUT/DEFAULT_ARTIFACT"
    */
   public final static String DEFAULT_ARTIFACT = (IFileSystemAccess.DEFAULT_OUTPUT + "/DEFAULT_ARTIFACT");
   
@@ -110,7 +112,7 @@ public class GeneratorService extends AbstractCachedService<GeneratorService.Gen
   private Provider<InMemoryFileSystemAccess> fileSystemAccessProvider;
   
   /**
-   * Generate artifacts for the given document.
+   * Generate artifacts for the given document. The result can be fetched with {@link #getResult(XtextWebDocumentAccess)}.
    */
   @Override
   public GeneratorService.GeneratedArtifacts compute(final IXtextWebDocument it, final CancelIndicator cancelIndicator) {
@@ -146,6 +148,13 @@ public class GeneratorService extends AbstractCachedService<GeneratorService.Gen
     return result;
   }
   
+  /**
+   * Retrieve the generated artifact with given identifier. The identifier must match the name of one of
+   * the generator results; each name is created by concatenating the output configuration name and the file
+   * name (see {@link InMemoryFileSystemAccess#getFileName(String,String)}). If artifactId is null,
+   * {@link #DEFAULT_ARTIFACT} is used as identifier. If the requested artifact is in {@link IFileSystemAccess#DEFAULT_OUTPUT},
+   * the output configuration prefix may be omitted.
+   */
   public GeneratorResult getArtifact(final XtextWebDocumentAccess document, final String artifactId) {
     GeneratorService.GeneratedArtifacts _result = this.getResult(document);
     final List<GeneratorResult> artifacts = _result.artifacts;
@@ -180,5 +189,45 @@ public class GeneratorService extends AbstractCachedService<GeneratorService.Gen
       throw new InvalidRequestException.ResourceNotFoundException("The requested generator artifact was not found.");
     }
     return result;
+  }
+  
+  /**
+   * Retrieve the generated artifact with given identifier. If {@code includeContent} is false,
+   * only the metadata is included in the service result.
+   */
+  public GeneratorResult getArtifact(final XtextWebDocumentAccess document, final String artifactId, final boolean includeContent) {
+    final GeneratorResult result = this.getArtifact(document, artifactId);
+    if (includeContent) {
+      return result;
+    } else {
+      String _name = result.getName();
+      String _contentType = result.getContentType();
+      return new GeneratorResult(_name, _contentType, null);
+    }
+  }
+  
+  /**
+   * Returns a {@link GeneratedArtifacts} result with or without content. If {@code includeContent} is false,
+   * only the metadata is included in the service result, which is useful to explore the generated artifacts.
+   */
+  public GeneratorService.GeneratedArtifacts getResult(final XtextWebDocumentAccess document, final boolean includeContent) {
+    if (includeContent) {
+      return this.getResult(document);
+    } else {
+      GeneratorService.GeneratedArtifacts _result = this.getResult(document);
+      final List<GeneratorResult> artifacts = _result.artifacts;
+      final GeneratorService.GeneratedArtifacts result = new GeneratorService.GeneratedArtifacts();
+      final Function1<GeneratorResult, GeneratorResult> _function = new Function1<GeneratorResult, GeneratorResult>() {
+        @Override
+        public GeneratorResult apply(final GeneratorResult it) {
+          String _name = it.getName();
+          String _contentType = it.getContentType();
+          return new GeneratorResult(_name, _contentType, null);
+        }
+      };
+      List<GeneratorResult> _map = ListExtensions.<GeneratorResult, GeneratorResult>map(artifacts, _function);
+      result.artifacts.addAll(_map);
+      return result;
+    }
   }
 }

--- a/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/model/AbstractCachedService.java
+++ b/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/model/AbstractCachedService.java
@@ -28,7 +28,9 @@ public abstract class AbstractCachedService<T extends IServiceResult> {
   }
   
   /**
-   * Perform the actual computations to obtain a result.
+   * Perform the actual computations to obtain a result. This method should not be called
+   * directly from the service dispatcher; use {@link #getResult(XtextWebDocumentAccess)} instead
+   * in order to avoid duplicate computations.
    */
   public abstract T compute(final IXtextWebDocument it, final CancelIndicator cancelIndicator);
 }

--- a/web/org.eclipse.xtext.web/src/test/java/org/eclipse/xtext/web/server/test/GeneratorTest.xtend
+++ b/web/org.eclipse.xtext.web/src/test/java/org/eclipse/xtext/web/server/test/GeneratorTest.xtend
@@ -14,6 +14,7 @@ import org.eclipse.xtext.generator.IGeneratorContext
 import org.eclipse.xtext.web.example.statemachine.StatemachineRuntimeModule
 import org.eclipse.xtext.web.example.statemachine.statemachine.Statemachine
 import org.eclipse.xtext.web.server.generator.GeneratorResult
+import org.eclipse.xtext.web.server.generator.GeneratorService
 import org.eclipse.xtext.web.server.test.GeneratorTest.Generator
 import org.junit.Test
 
@@ -84,6 +85,60 @@ class GeneratorTest extends AbstractWebServerTest {
 		assertEquals(1, generatorInstance.invocationCount)
 		generate.service.apply()
 		assertEquals(1, generatorInstance.invocationCount)
+	}
+	
+	@Test def testGetResultWithoutContent() {
+		val file = createFile('state foo end state bar end')
+		val generate = getService(#{'serviceType' -> 'generate', 'resource' -> file.name, 'artifact' -> 'DEFAULT_OUTPUT/test.txt',
+				'includeContent' -> 'false'})
+		val result = generate.service.apply() as GeneratorResult
+		val String expectedResult = '''
+			GeneratorResult [
+			  name = "DEFAULT_OUTPUT/test.txt"
+			  contentType = "text/plain"
+			]'''
+		assertEquals(expectedResult, result.toString)
+	}
+	
+	@Test def testGetAllResults() {
+		val file = createFile('state foo end state bar end')
+		val generate = getService(#{'serviceType' -> 'generate', 'resource' -> file.name, 'allArtifacts' -> 'true'})
+		val result = generate.service.apply() as GeneratorService.GeneratedArtifacts
+		val String expectedResult = '''
+			GeneratedArtifacts [
+			  artifacts = ArrayList (
+			    GeneratorResult [
+			      name = "DEFAULT_OUTPUT/DEFAULT_ARTIFACT"
+			      content = "foo,bar\n"
+			    ],
+			    GeneratorResult [
+			      name = "DEFAULT_OUTPUT/test.txt"
+			      contentType = "text/plain"
+			      content = "hello, world!"
+			    ]
+			  )
+			]'''
+		assertEquals(expectedResult, result.toString)
+	}
+	
+	@Test def testGetAllResultsWithoutContent() {
+		val file = createFile('state foo end state bar end')
+		val generate = getService(#{'serviceType' -> 'generate', 'resource' -> file.name, 'allArtifacts' -> 'true',
+				'includeContent' -> 'false'})
+		val result = generate.service.apply() as GeneratorService.GeneratedArtifacts
+		val String expectedResult = '''
+			GeneratedArtifacts [
+			  artifacts = ArrayList (
+			    GeneratorResult [
+			      name = "DEFAULT_OUTPUT/DEFAULT_ARTIFACT"
+			    ],
+			    GeneratorResult [
+			      name = "DEFAULT_OUTPUT/test.txt"
+			      contentType = "text/plain"
+			    ]
+			  )
+			]'''
+		assertEquals(expectedResult, result.toString)
 	}
 	
 }

--- a/web/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/GeneratorTest.java
+++ b/web/org.eclipse.xtext.web/src/test/xtend-gen/org/eclipse/xtext/web/server/test/GeneratorTest.java
@@ -25,6 +25,7 @@ import org.eclipse.xtext.web.example.statemachine.statemachine.Statemachine;
 import org.eclipse.xtext.web.server.IServiceResult;
 import org.eclipse.xtext.web.server.XtextServiceDispatcher;
 import org.eclipse.xtext.web.server.generator.GeneratorResult;
+import org.eclipse.xtext.web.server.generator.GeneratorService;
 import org.eclipse.xtext.web.server.test.AbstractWebServerTest;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function0;
@@ -156,5 +157,133 @@ public class GeneratorTest extends AbstractWebServerTest {
     Function0<? extends IServiceResult> _service_1 = generate.getService();
     _service_1.apply();
     Assert.assertEquals(1, GeneratorTest.generatorInstance.invocationCount);
+  }
+  
+  @Test
+  public void testGetResultWithoutContent() {
+    final File file = this.createFile("state foo end state bar end");
+    Pair<String, String> _mappedTo = Pair.<String, String>of("serviceType", "generate");
+    String _name = file.getName();
+    Pair<String, String> _mappedTo_1 = Pair.<String, String>of("resource", _name);
+    Pair<String, String> _mappedTo_2 = Pair.<String, String>of("artifact", "DEFAULT_OUTPUT/test.txt");
+    Pair<String, String> _mappedTo_3 = Pair.<String, String>of("includeContent", "false");
+    final XtextServiceDispatcher.ServiceDescriptor generate = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2, _mappedTo_3)));
+    Function0<? extends IServiceResult> _service = generate.getService();
+    IServiceResult _apply = _service.apply();
+    final GeneratorResult result = ((GeneratorResult) _apply);
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("GeneratorResult [");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("name = \"DEFAULT_OUTPUT/test.txt\"");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("contentType = \"text/plain\"");
+    _builder.newLine();
+    _builder.append("]");
+    final String expectedResult = _builder.toString();
+    String _string = result.toString();
+    Assert.assertEquals(expectedResult, _string);
+  }
+  
+  @Test
+  public void testGetAllResults() {
+    final File file = this.createFile("state foo end state bar end");
+    Pair<String, String> _mappedTo = Pair.<String, String>of("serviceType", "generate");
+    String _name = file.getName();
+    Pair<String, String> _mappedTo_1 = Pair.<String, String>of("resource", _name);
+    Pair<String, String> _mappedTo_2 = Pair.<String, String>of("allArtifacts", "true");
+    final XtextServiceDispatcher.ServiceDescriptor generate = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2)));
+    Function0<? extends IServiceResult> _service = generate.getService();
+    IServiceResult _apply = _service.apply();
+    final GeneratorService.GeneratedArtifacts result = ((GeneratorService.GeneratedArtifacts) _apply);
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("GeneratedArtifacts [");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("artifacts = ArrayList (");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("GeneratorResult [");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("name = \"DEFAULT_OUTPUT/DEFAULT_ARTIFACT\"");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("content = \"foo,bar\\n\"");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("],");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("GeneratorResult [");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("name = \"DEFAULT_OUTPUT/test.txt\"");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("contentType = \"text/plain\"");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("content = \"hello, world!\"");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("]");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append(")");
+    _builder.newLine();
+    _builder.append("]");
+    final String expectedResult = _builder.toString();
+    String _string = result.toString();
+    Assert.assertEquals(expectedResult, _string);
+  }
+  
+  @Test
+  public void testGetAllResultsWithoutContent() {
+    final File file = this.createFile("state foo end state bar end");
+    Pair<String, String> _mappedTo = Pair.<String, String>of("serviceType", "generate");
+    String _name = file.getName();
+    Pair<String, String> _mappedTo_1 = Pair.<String, String>of("resource", _name);
+    Pair<String, String> _mappedTo_2 = Pair.<String, String>of("allArtifacts", "true");
+    Pair<String, String> _mappedTo_3 = Pair.<String, String>of("includeContent", "false");
+    final XtextServiceDispatcher.ServiceDescriptor generate = this.getService(Collections.<String, String>unmodifiableMap(CollectionLiterals.<String, String>newHashMap(_mappedTo, _mappedTo_1, _mappedTo_2, _mappedTo_3)));
+    Function0<? extends IServiceResult> _service = generate.getService();
+    IServiceResult _apply = _service.apply();
+    final GeneratorService.GeneratedArtifacts result = ((GeneratorService.GeneratedArtifacts) _apply);
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("GeneratedArtifacts [");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("artifacts = ArrayList (");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("GeneratorResult [");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("name = \"DEFAULT_OUTPUT/DEFAULT_ARTIFACT\"");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("],");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("GeneratorResult [");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("name = \"DEFAULT_OUTPUT/test.txt\"");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("contentType = \"text/plain\"");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("]");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append(")");
+    _builder.newLine();
+    _builder.append("]");
+    final String expectedResult = _builder.toString();
+    String _string = result.toString();
+    Assert.assertEquals(expectedResult, _string);
   }
 }


### PR DESCRIPTION
If `allArtifacts` is set to `true`, the generator service returns all artifacts instead of a specific one. If `includeContent` is set to `false`, only the name and the content type of the requested artifact(s) is returned. That can be useful if the artifact names are not known in the client, e.g. when the JvmModelInferrer is used to generate Java types and the names of these types depend on the document contents. Then you can either fetch all generated types at once or first fetch their names and then send a dedicated request for each type.

Please review.