### PR TITLE
Bug 492234 - [wizard] Include sources in the generated .target file

### DIFF
--- a/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
+++ b/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
@@ -52,7 +52,7 @@ class TargetPlatformProject extends ProjectDescriptor {
 		<?pde version="3.8"?>
 		<target name="«name»" sequenceNumber="1">
 		<locations>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -63,11 +63,11 @@ class TargetPlatformProject extends ProjectDescriptor {
 		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 		<repository location="http://download.eclipse.org/releases/mars/201506241002/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
 		<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.8.1/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
 		«IF config.xtextVersion.isSnapshot»
 			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/nightly/"/>

--- a/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
+++ b/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
@@ -94,7 +94,7 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.newLineIfNotEmpty();
     _builder.append("<locations>");
     _builder.newLine();
-    _builder.append("<location includeAllPlatforms=\"false\" includeConfigurePhase=\"false\" includeMode=\"planner\" includeSource=\"false\" type=\"InstallableUnit\">");
+    _builder.append("<location includeAllPlatforms=\"false\" includeConfigurePhase=\"false\" includeMode=\"planner\" includeSource=\"true\" type=\"InstallableUnit\">");
     _builder.newLine();
     _builder.append("<unit id=\"org.eclipse.jdt.feature.group\" version=\"0.0.0\"/>");
     _builder.newLine();
@@ -116,7 +116,7 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.newLine();
     _builder.append("</location>");
     _builder.newLine();
-    _builder.append("<location includeAllPlatforms=\"false\" includeConfigurePhase=\"false\" includeMode=\"planner\" includeSource=\"false\" type=\"InstallableUnit\">");
+    _builder.append("<location includeAllPlatforms=\"false\" includeConfigurePhase=\"false\" includeMode=\"planner\" includeSource=\"true\" type=\"InstallableUnit\">");
     _builder.newLine();
     _builder.append("<unit id=\"org.eclipse.emf.mwe2.launcher.feature.group\" version=\"0.0.0\"/>");
     _builder.newLine();
@@ -124,7 +124,7 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.newLine();
     _builder.append("</location>");
     _builder.newLine();
-    _builder.append("<location includeAllPlatforms=\"false\" includeConfigurePhase=\"false\" includeMode=\"planner\" includeSource=\"false\" type=\"InstallableUnit\">");
+    _builder.append("<location includeAllPlatforms=\"false\" includeConfigurePhase=\"false\" includeMode=\"planner\" includeSource=\"true\" type=\"InstallableUnit\">");
     _builder.newLine();
     _builder.append("<unit id=\"org.eclipse.xtext.sdk.feature.group\" version=\"0.0.0\"/>");
     _builder.newLine();

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.target/org.xtext.example.full.target.target
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.target/org.xtext.example.full.target.target
@@ -2,7 +2,7 @@
 <?pde version="3.8"?>
 <target name="org.xtext.example.full.target" sequenceNumber="1">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -13,11 +13,11 @@
 <unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 <repository location="http://download.eclipse.org/releases/mars/201506241002/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.8.1/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/nightly/"/>
 </location>

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.web/build.gradle
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.full/org.xtext.example.full.parent/org.xtext.example.full.web/build.gradle
@@ -7,11 +7,11 @@ dependencies {
 	compile "org.eclipse.xtext:org.eclipse.xtext.xbase.web:${xtextVersion}"
 	compile "org.eclipse.xtext:org.eclipse.xtext.web.servlet:${xtextVersion}"
 	compile "org.eclipse.xtend:org.eclipse.xtend.lib:${xtextVersion}"
-	compile "org.webjars:requirejs:2.1.20"
-	compile "org.webjars:jquery:2.1.4"
-	compile "org.webjars:ace:1.2.0"
-	providedCompile "org.eclipse.jetty:jetty-annotations:9.2.11.v20150529"
-	providedCompile "org.slf4j:slf4j-simple:1.7.12"
+	compile "org.webjars:requirejs:2.2.0"
+	compile "org.webjars:jquery:2.2.3"
+	compile "org.webjars:ace:1.2.2"
+	providedCompile "org.eclipse.jetty:jetty-annotations:9.3.8.v20160314"
+	providedCompile "org.slf4j:slf4j-simple:1.7.21"
 }
 task jettyRun(type:JavaExec) {
 	dependsOn(sourceSets.main.runtimeClasspath)

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/org.xtext.example.gradle.web/build.gradle
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.gradle/org.xtext.example.gradle.parent/org.xtext.example.gradle.web/build.gradle
@@ -7,11 +7,11 @@ dependencies {
 	compile "org.eclipse.xtext:org.eclipse.xtext.xbase.web:${xtextVersion}"
 	compile "org.eclipse.xtext:org.eclipse.xtext.web.servlet:${xtextVersion}"
 	compile "org.eclipse.xtend:org.eclipse.xtend.lib:${xtextVersion}"
-	compile "org.webjars:requirejs:2.1.20"
-	compile "org.webjars:jquery:2.1.4"
-	compile "org.webjars:ace:1.2.0"
-	providedCompile "org.eclipse.jetty:jetty-annotations:9.2.11.v20150529"
-	providedCompile "org.slf4j:slf4j-simple:1.7.12"
+	compile "org.webjars:requirejs:2.2.0"
+	compile "org.webjars:jquery:2.2.3"
+	compile "org.webjars:ace:1.2.2"
+	providedCompile "org.eclipse.jetty:jetty-annotations:9.3.8.v20160314"
+	providedCompile "org.slf4j:slf4j-simple:1.7.21"
 }
 task jettyRun(type:JavaExec) {
 	dependsOn(sourceSets.main.runtimeClasspath)

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.target/org.xtext.example.mavenTycho.target.target
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.target/org.xtext.example.mavenTycho.target.target
@@ -2,7 +2,7 @@
 <?pde version="3.8"?>
 <target name="org.xtext.example.mavenTycho.target" sequenceNumber="1">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -13,11 +13,11 @@
 <unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 <repository location="http://download.eclipse.org/releases/mars/201506241002/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.8.1/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/nightly/"/>
 </location>

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.web/pom.xml
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTycho/org.xtext.example.mavenTycho.parent/org.xtext.example.mavenTycho.web/pom.xml
@@ -101,28 +101,28 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>requirejs</artifactId>
-			<version>2.1.20</version>
+			<version>2.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>jquery</artifactId>
-			<version>2.1.4</version>
+			<version>2.2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>ace</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-annotations</artifactId>
-			<version>9.2.11.v20150529</version>
+			<version>9.3.8.v20160314</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.12</version>
+			<version>1.7.21</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.target/org.xtext.example.mavenTychoP2.target.target
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.target/org.xtext.example.mavenTychoP2.target.target
@@ -2,7 +2,7 @@
 <?pde version="3.8"?>
 <target name="org.xtext.example.mavenTychoP2.target" sequenceNumber="1">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -13,11 +13,11 @@
 <unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 <repository location="http://download.eclipse.org/releases/mars/201506241002/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.8.1/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/nightly/"/>
 </location>

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.web/pom.xml
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.mavenTychoP2/org.xtext.example.mavenTychoP2.parent/org.xtext.example.mavenTychoP2.web/pom.xml
@@ -101,28 +101,28 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>requirejs</artifactId>
-			<version>2.1.20</version>
+			<version>2.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>jquery</artifactId>
-			<version>2.1.4</version>
+			<version>2.2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>ace</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-annotations</artifactId>
-			<version>9.2.11.v20150529</version>
+			<version>9.3.8.v20160314</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.12</version>
+			<version>1.7.21</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven.web/pom.xml
+++ b/tests/org.eclipse.xtext.tests/testdata/wizard-expectations/org.xtext.example.plainMaven/org.xtext.example.plainMaven.parent/org.xtext.example.plainMaven.web/pom.xml
@@ -91,28 +91,28 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>requirejs</artifactId>
-			<version>2.1.20</version>
+			<version>2.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>jquery</artifactId>
-			<version>2.1.4</version>
+			<version>2.2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>ace</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-annotations</artifactId>
-			<version>9.2.11.v20150529</version>
+			<version>9.3.8.v20160314</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.12</version>
+			<version>1.7.21</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
The target definition file generated by the Xtext project wizard is not set to include the sources, that is, includeSource="false".

Instead, I think that sources should be included by default in a target definition file: if the developer uses the .target file for defining the target platform of his workbench, then having the sources while developing is really helpful.  I know that for some features the generated .target file includes the .sdk which already includes sources (e.g., Xtext and EMF), but that's not the case for the platform, pde and jdt.

On the other hand, including sources will not disturb the Tycho build, since the includeSource is ignored by default.  This means that sources will not have to be downloaded during the target platform resolution of the Maven/Tycho build.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=492234