### PR TITLE
[492661] add missing javax.annotation package import

### DIFF
--- a/plugins/org.eclipse.xtext.xbase/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.xtext.xbase/META-INF/MANIFEST.MF
@@ -118,5 +118,6 @@ Export-Package: org.eclipse.xtext.xbase,
  org.eclipse.xtext.xtype.impl;x-internal:=true,
  org.eclipse.xtext.xtype.util;x-internal:=true
 Import-Package: com.ibm.icu.text;version="4.0.0";resolution:=optional,
+ javax.annotation,
  org.apache.log4j;version="1.2.15"
 Bundle-Localization: plugin


### PR DESCRIPTION
https://bugs.eclipse.org/bugs/show_bug.cgi?id=492661