### PR TITLE
Bug 492728 - [wizard][gradle] Project Wizard, IntelliJ Plugin, Gradle and Buildship problems

### DIFF
--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/ProjectFactory.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/ProjectFactory.java
@@ -141,8 +141,8 @@ public class ProjectFactory {
 			project.setDescription(description, subMonitor.newChild(1));
 			project.setDefaultCharset(defaultCharset, subMonitor.newChild(1));
 			createFolders(project, subMonitor, shell);
-			enhanceProject(project, subMonitor, shell);
 
+			// first run contributors...
 			if (contributors != null) {
 				IFileCreator fileCreator = new IFileCreator() {
 
@@ -155,6 +155,12 @@ public class ProjectFactory {
 					contributor.contributeFiles(project, fileCreator);
 				}
 			}
+
+			// then enhance project; in some cases it is crucial to enhance the project
+			// only after contributions, like in the case of gradle projects
+			// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492728
+			enhanceProject(project, subMonitor, shell);
+
 			return project;
 		} catch (final CoreException exception) {
 			logger.error(exception.getMessage(), exception);

--- a/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
+++ b/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
@@ -42,6 +42,7 @@ import org.eclipse.xtext.xtext.wizard.AbstractFile;
 import org.eclipse.xtext.xtext.wizard.BinaryFile;
 import org.eclipse.xtext.xtext.wizard.ParentProjectDescriptor;
 import org.eclipse.xtext.xtext.wizard.ProjectDescriptor;
+import org.eclipse.xtext.xtext.wizard.ProjectLayout;
 import org.eclipse.xtext.xtext.wizard.TextFile;
 
 import com.google.common.collect.Lists;
@@ -256,6 +257,8 @@ public class XtextProjectCreator extends WorkspaceModifyOperation implements IPr
 		private String getConnectionLogicalPath() {
 			if (descriptor instanceof ParentProjectDescriptor) {
 				return "";
+			} else if (descriptor.getConfig().getProjectLayout() == ProjectLayout.FLAT) {
+				return "../" + descriptor.getConfig().getParentProject().getName();
 			} else {
 				return "..";
 			}

--- a/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
+++ b/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
@@ -8,7 +8,9 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.ui.wizard.project;
 
+import static com.google.common.collect.Iterables.*;
 import static com.google.common.collect.Sets.*;
+import static org.eclipse.xtext.xbase.lib.IterableExtensions.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,6 +46,8 @@ import org.eclipse.xtext.xtext.wizard.ParentProjectDescriptor;
 import org.eclipse.xtext.xtext.wizard.ProjectDescriptor;
 import org.eclipse.xtext.xtext.wizard.TextFile;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -240,7 +244,7 @@ public class XtextProjectCreator extends WorkspaceModifyOperation implements IPr
 				"connection.java.home=null\n" +
 				"connection.jvm.arguments=\n" +
 				"connection.project.dir=" + getConnectionLogicalPath() +"\n" +
-				"derived.resources=.gradle,build\n" +
+				"derived.resources=" + getDerivedResources() + "\n" +
 				"eclipse.preferences.version=1\n" +
 				"project.path=\\" + getLogicalPath() + "\n",
 			".settings/org.eclipse.buildship.core.prefs");
@@ -260,6 +264,30 @@ public class XtextProjectCreator extends WorkspaceModifyOperation implements IPr
 			} else {
 				return "..";
 			}
+		}
+
+		private String getDerivedResources() {
+			String derived = ".gradle,build";
+			if (descriptor instanceof ParentProjectDescriptor) {
+				return derived + "," + 
+					join(
+						transform(
+							filter(descriptor.getConfig().getEnabledProjects(),
+								new Predicate<ProjectDescriptor>() {
+									@Override
+									public boolean apply(ProjectDescriptor p) {
+										return p != descriptor && p.isPartOfGradleBuild();
+									}
+								}),
+							new Function<ProjectDescriptor, String>() {
+								@Override
+								public String apply(ProjectDescriptor p) {
+									return p.getName();
+								}
+							}),
+						",");
+			}
+			return derived;
 		}
 	}
 

--- a/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
+++ b/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
@@ -8,9 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.ui.wizard.project;
 
-import static com.google.common.collect.Iterables.*;
 import static com.google.common.collect.Sets.*;
-import static org.eclipse.xtext.xbase.lib.IterableExtensions.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,8 +44,6 @@ import org.eclipse.xtext.xtext.wizard.ParentProjectDescriptor;
 import org.eclipse.xtext.xtext.wizard.ProjectDescriptor;
 import org.eclipse.xtext.xtext.wizard.TextFile;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -244,7 +240,6 @@ public class XtextProjectCreator extends WorkspaceModifyOperation implements IPr
 				"connection.java.home=null\n" +
 				"connection.jvm.arguments=\n" +
 				"connection.project.dir=" + getConnectionLogicalPath() +"\n" +
-				"derived.resources=" + getDerivedResources() + "\n" +
 				"eclipse.preferences.version=1\n" +
 				"project.path=\\" + getLogicalPath() + "\n",
 			".settings/org.eclipse.buildship.core.prefs");
@@ -266,29 +261,6 @@ public class XtextProjectCreator extends WorkspaceModifyOperation implements IPr
 			}
 		}
 
-		private String getDerivedResources() {
-			String derived = ".gradle,build";
-			if (descriptor instanceof ParentProjectDescriptor) {
-				return derived + "," + 
-					join(
-						transform(
-							filter(descriptor.getConfig().getEnabledProjects(),
-								new Predicate<ProjectDescriptor>() {
-									@Override
-									public boolean apply(ProjectDescriptor p) {
-										return p != descriptor && p.isPartOfGradleBuild();
-									}
-								}),
-							new Function<ProjectDescriptor, String>() {
-								@Override
-								public String apply(ProjectDescriptor p) {
-									return p.getName();
-								}
-							}),
-						",");
-			}
-			return derived;
-		}
 	}
 
 	private boolean isPluginProject(ProjectDescriptor descriptor) {

--- a/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
+++ b/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
@@ -234,23 +234,31 @@ public class XtextProjectCreator extends WorkspaceModifyOperation implements IPr
 		@Override
 		public void contributeFiles(IProject project, IFileCreator fileWriter) {
 			fileWriter.writeToFile(
-				"{\n" +
-				"	\"1.0\": {\n" +
-				"		\"project_path\": \""+ getLogicalPath() + "\",\n" +
-				"		\"project_dir\": \""+ descriptor.getLocation() + "\",\n" +
-				"		\"connection_project_dir\": \""+ descriptor.getConfig().getParentProject().getLocation() + "\",\n" +
-				"		\"connection_gradle_distribution\": \"GRADLE_DISTRIBUTION(WRAPPER)\"\n" +
-				"	}\n" +
-				"}\n",
-			".settings/gradle.prefs");
+				"connection.arguments=\n" +
+				"connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)\n" +
+				"connection.gradle.user.home=null\n" +
+				"connection.java.home=null\n" +
+				"connection.jvm.arguments=\n" +
+				"connection.project.dir=" + getConnectionLogicalPath() +"\n" +
+				"derived.resources=.gradle,build\n" +
+				"eclipse.preferences.version=1\n" +
+				"project.path=\\" + getLogicalPath() + "\n",
+			".settings/org.eclipse.buildship.core.prefs");
 		}
-
 
 		private String getLogicalPath() {
 			if (descriptor instanceof ParentProjectDescriptor) {
 				return ":";
 			} else {
 				return ":" + descriptor.getName();
+			}
+		}
+
+		private String getConnectionLogicalPath() {
+			if (descriptor instanceof ParentProjectDescriptor) {
+				return "";
+			} else {
+				return "..";
 			}
 		}
 	}


### PR DESCRIPTION
The Xtext project wizard does not work together with Buildship when selecting Intellij Plugin and Gradle: Buildship throws an exception because it can't find org.xtext.example.mydsl.parent/org.xtext.example.mydsl.idea/.settings/org.eclipse.buildship.core.prefs

This PR generates that file instead of gradle.prefs (which, anyway, would be converted to org.eclipse.buildship.core.prefs. The convertion would not take place for the .idea project because JavaProjectFactory.enhanceProject would fail to set the classpath, since Buildship throws the above exception).

ATTENTION: this also requires ProjectCreator.createProject to enhance the project ONLY AFTER having called all the contributors.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=492728