### PR TITLE
updated comment in the generated JvmModelInferrer for the new generator infrastructure

### DIFF
--- a/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.xtend
+++ b/plugins/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.xtend
@@ -215,9 +215,7 @@ class XbaseGeneratorFragment2 extends AbstractXtextGeneratorFragment {
 				 *            {@link IJvmDeclaredTypeAcceptor#accept(org.eclipse.xtext.common.types.JvmDeclaredType)
 				 *            accept(..)} method takes the constructed empty type for the
 				 *            pre-indexing phase. This one is further initialized in the
-				 *            indexing phase using the closure you pass to the returned
-				 *            {@link org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor.IPostIndexingInitializing#initializeLater(org.eclipse.xtext.xbase.lib.Procedures.Procedure1)
-				 *            initializeLater(..)}.
+				 *            indexing phase using the lambda you pass as the last argument.
 				 * @param isPreIndexingPhase
 				 *            whether the method is called in a pre-indexing phase, i.e.
 				 *            when the global index is not yet fully updated. You must not

--- a/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.java
+++ b/plugins/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/xbase/XbaseGeneratorFragment2.java
@@ -420,13 +420,7 @@ public class XbaseGeneratorFragment2 extends AbstractXtextGeneratorFragment {
         _builder.append("*            pre-indexing phase. This one is further initialized in the");
         _builder.newLine();
         _builder.append("\t ");
-        _builder.append("*            indexing phase using the closure you pass to the returned");
-        _builder.newLine();
-        _builder.append("\t ");
-        _builder.append("*            {@link org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor.IPostIndexingInitializing#initializeLater(org.eclipse.xtext.xbase.lib.Procedures.Procedure1)");
-        _builder.newLine();
-        _builder.append("\t ");
-        _builder.append("*            initializeLater(..)}.");
+        _builder.append("*            indexing phase using the lambda you pass as the last argument.");
         _builder.newLine();
         _builder.append("\t ");
         _builder.append("* @param isPreIndexingPhase");


### PR DESCRIPTION
The generated JvmModelInferrer was still referring to the deprecated
IJvmDeclaredTypeAcceptor.IPostIndexingInitializing#initializeLater in
the comment section.

This corresponds to the old PR https://github.com/eclipse/xtext/pull/435
whose fix had not been ported to the new generator infrastructure.

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>