### PR TITLE
missing xtend-gen source folder in domainmodel.ui

### DIFF
--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.ui/build.properties
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.ui/build.properties
@@ -1,4 +1,6 @@
-source.. = src/,src-gen/
+source.. = src/,\
+           src-gen/,\
+           xtend-gen/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\


### PR DESCRIPTION
Recently, Xtend files has been added to domainmodel.ui, and the
xtend-gen folder was not in the build.properties

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>