### PR TITLE
493399: [wizard] plugin.xml in bin.includes in all generated projects

### DIFF
--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/ProjectFactory.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/ProjectFactory.java
@@ -64,6 +64,8 @@ public class ProjectFactory {
 
 	private List<IProjectFactoryContributor> contributors;
 
+	private List<IProjectFactoryContributor> earlyContributors;
+
 	public ProjectFactory addBuilderIds(String... builderIds) {
 		if (this.builderIds == null)
 			this.builderIds = Lists.newArrayList();
@@ -118,7 +120,19 @@ public class ProjectFactory {
 		}
 		contributors.add(projectFactoryContributor);
 	}
-	
+
+	/**
+	 * This contributors will be executed before enhancing the project.
+	 * 
+	 * @since 2.10
+	 */
+	public void addEarlyContributor(IProjectFactoryContributor projectFactoryContributor) {
+		if (this.earlyContributors == null) {
+			earlyContributors = Lists.newArrayList();
+		}
+		earlyContributors.add(projectFactoryContributor);
+	}
+
 	/**
 	 * @since 2.4
 	 */
@@ -142,24 +156,33 @@ public class ProjectFactory {
 			project.setDefaultCharset(defaultCharset, subMonitor.newChild(1));
 			createFolders(project, subMonitor, shell);
 
-			// first run contributors...
-			if (contributors != null) {
-				IFileCreator fileCreator = new IFileCreator() {
+			IFileCreator fileCreator = new IFileCreator() {
+				@Override
+				public IFile writeToFile(CharSequence chars, String fileName) {
+					return ProjectFactory.this.writeToFile(chars, fileName, project, subMonitor);
+				}
+			};
 
-					@Override
-					public IFile writeToFile(CharSequence chars, String fileName) {
-						return ProjectFactory.this.writeToFile(chars, fileName, project, subMonitor);
-					}
-				};
-				for (IProjectFactoryContributor contributor : contributors) {
+			// first run early contributors...
+			// in some cases it is crucial to enhance the project
+			// only after contributions, like in the case of gradle projects
+			// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492728
+			if (earlyContributors != null) {
+				for (IProjectFactoryContributor contributor : earlyContributors) {
 					contributor.contributeFiles(project, fileCreator);
 				}
 			}
 
-			// then enhance project; in some cases it is crucial to enhance the project
-			// only after contributions, like in the case of gradle projects
-			// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492728
+			// then enhance project
 			enhanceProject(project, subMonitor, shell);
+
+			// then all the other contributors...
+			// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=493399
+			if (contributors != null) {
+				for (IProjectFactoryContributor contributor : contributors) {
+					contributor.contributeFiles(project, fileCreator);
+				}
+			}
 
 			return project;
 		} catch (final CoreException exception) {

--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/ProjectFactory.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/ProjectFactory.java
@@ -122,7 +122,7 @@ public class ProjectFactory {
 	}
 
 	/**
-	 * This contributors will be executed before enhancing the project.
+	 * These contributors will be executed before enhancing the project.
 	 * 
 	 * @since 2.10
 	 */

--- a/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
+++ b/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
@@ -154,7 +154,7 @@ public class XtextProjectCreator extends WorkspaceModifyOperation implements IPr
 		if (needsBuildshipIntegration(descriptor)) {
 			factory.addProjectNatures("org.eclipse.buildship.core.gradleprojectnature");
 			factory.addBuilderIds("org.eclipse.buildship.core.gradleprojectbuilder");
-			factory.addContributor(new GradleContributor(descriptor));
+			factory.addEarlyContributor(new GradleContributor(descriptor));
 		}
 	}
 


### PR DESCRIPTION
I'm afraid that with this PR https://github.com/eclipse/xtext/pull/1015 for bug 492728 I introduced a small bug that makes the Xtext project wizard generate a build.properties where plugin.xml is always bin.included, leading to warnings in the generated projects. Sorry about that O:)

In the PR I swapped the execution of project contributors and enhanceProject (aa766a03f3a346d25152e634cc8a5cfed8719cea), and the latter will always generate a build.properties with that inclusion, overriding what the project contributors have generated.

To fix this, while keeping the fix for bug 492728 (which requires that the buildship properties file is generated *before* enhancing the projects) I introduced early contributors, which are executed before enhancing the project.

Thus the workflow would be:

execute early contributors
enhance the project
execute all the other contributors

Task-Url: https://bugs.eclipse.org/bugs/show_bug.cgi?id=493399