### PR TITLE
[448483] prevent npe in content assist for zero param operator_* methods

### DIFF
--- a/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/ExpressionScope.java
+++ b/plugins/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/typesystem/internal/ExpressionScope.java
@@ -399,6 +399,9 @@ public class ExpressionScope implements IExpressionScope {
 		
 		protected LightweightTypeReference getFirstParameterType(IIdentifiableElementDescription candidate) {
 			JvmOperation operation = (JvmOperation) candidate.getElementOrProxy();
+			if (operation.getParameters().isEmpty()) {
+				return null;
+			}
 			return getParameterType(operation.getParameters().get(0));
 		}
 		

--- a/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/Bug448483Test.xtend
+++ b/tests/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/Bug448483Test.xtend
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.tests.contentassist
+
+import org.junit.Test
+
+/**
+ * @author Christian DIetrich - Initial contribution and API
+ */
+class Bug448483Test extends AbstractXtendContentAssistBugTest {
+	
+	@Test
+	def void testBug448483() {
+		newBuilder.append('''
+			class Test {
+				
+				def -() {
+					DoubleExtensions.<|>
+				}
+			
+			}
+		''')
+			.assertProposalDisplayedAtCursor("toString : String - Class.toString()")
+	}
+	
+}

--- a/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/Bug448483Test.java
+++ b/tests/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/Bug448483Test.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.ide.tests.contentassist;
+
+import org.eclipse.xtend.ide.tests.contentassist.AbstractXtendContentAssistBugTest;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.junit4.ui.ContentAssistProcessorTestBuilder;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.junit.Test;
+
+/**
+ * @author Christian DIetrich - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class Bug448483Test extends AbstractXtendContentAssistBugTest {
+  @Test
+  public void testBug448483() {
+    try {
+      ContentAssistProcessorTestBuilder _newBuilder = this.newBuilder();
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("class Test {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def -() {");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("DoubleExtensions.<|>");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("}");
+      _builder.newLine();
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      ContentAssistProcessorTestBuilder _append = _newBuilder.append(_builder.toString());
+      _append.assertProposalDisplayedAtCursor("toString : String - Class.toString()");
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Christian Dietrich <dietrich@MacDietrich.local>