### PR TITLE
[web] Several improvements

### DIFF
--- a/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/model/XtextWebDocument.xtend
+++ b/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/model/XtextWebDocument.xtend
@@ -39,7 +39,12 @@ class XtextWebDocument implements IXtextWebDocument {
     
     val Map<Class<?>, IServiceResult> cachedServiceResults = newHashMap
     
-	protected def clearCachedServiceResults() {
+    /**
+     * Clear any cached result of {@link AbstractCachedService}. This method is called whenever the text
+     * content of the resource is modified, but it may be necessary to clear the cached services in other
+     * cases, too.
+     */
+	def clearCachedServiceResults() {
 		cachedServiceResults.clear
 	}
 	
@@ -74,19 +79,30 @@ class XtextWebDocument implements IXtextWebDocument {
 	override getStateId() {
 		return Long.toString(resource.modificationStamp, 16)
 	}
-		
+	
+	/**
+	 * Replace the text contents of the contained resource with the given text.
+	 */
 	override setText(String text) {
 		clearCachedServiceResults()
 		resource.reparse(text)
 		refreshText()
 	}
 	
+	/**
+	 * Update a part of the text.
+	 */
 	override updateText(String text, int offset, int replaceLength) {
 		clearCachedServiceResults()
 		resource.update(offset, replaceLength, text)
 		refreshText()
 	}
 	
+	/**
+	 * A new state id should be created whenever the text content is changed. The client must know
+	 * the correct state id in order to send proper requests. If a request with an outdated state id
+	 * is received by the server, the request is rejected.
+	 */
 	override createNewStateId() {
 		val newStateId = resource.modificationStamp + 1
 		resource.modificationStamp = newStateId

--- a/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/syntaxcoloring/HighlightingService.xtend
+++ b/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/syntaxcoloring/HighlightingService.xtend
@@ -15,7 +15,6 @@ import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculat
 import org.eclipse.xtext.util.CancelIndicator
 import org.eclipse.xtext.web.server.model.AbstractCachedService
 import org.eclipse.xtext.web.server.model.IXtextWebDocument
-import org.eclipse.xtext.web.server.model.UpdateDocumentService
 
 /**
  * Service class for semantic highlighting. The syntactic highlighting is assumed
@@ -28,10 +27,9 @@ class HighlightingService extends AbstractCachedService<HighlightingResult> {
 	@Inject ISemanticHighlightingCalculator highlightingCalculator
 	
 	/**
-	 * Return the highlighting result for the given document. The actual highlighting may have
-	 * been computed as part of the background work scheduled after another service request,
-	 * e.g. {@link UpdateDocumentService}. If that background processing has not been done
-	 * yet, it is executed and then the validation issues are collected.
+	 * Compute the highlighting result for the given document. This method should not be called
+	 * directly from the service dispatcher; use {@link #getResult(XtextWebDocumentAccess)} instead
+	 * in order to avoid duplicate computations.
 	 */
 	override compute(IXtextWebDocument it, CancelIndicator cancelIndicator) {
 		val result = new HighlightingResult
@@ -45,4 +43,5 @@ class HighlightingService extends AbstractCachedService<HighlightingResult> {
 			positions += new HighlightingResult.Region(offset, length, ids)			
 		]
 	}
+	
 }

--- a/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/validation/ValidationService.xtend
+++ b/web/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/validation/ValidationService.xtend
@@ -15,7 +15,6 @@ import org.eclipse.xtext.validation.CheckMode
 import org.eclipse.xtext.validation.IResourceValidator
 import org.eclipse.xtext.web.server.model.AbstractCachedService
 import org.eclipse.xtext.web.server.model.IXtextWebDocument
-import org.eclipse.xtext.web.server.model.UpdateDocumentService
 
 /**
  * Service class for model validation.
@@ -26,10 +25,9 @@ class ValidationService extends AbstractCachedService<ValidationResult> {
 	@Inject IResourceValidator resourceValidator
 
 	/**
-	 * Return the validation result for the given document. The actual validation may have
-	 * been computed as part of the background work scheduled after another service request,
-	 * e.g. {@link UpdateDocumentService}. If that background processing has not been done
-	 * yet, it is executed and then the validation issues are collected.
+	 * Compute the validation result for the given document.  This method should not be called
+	 * directly from the service dispatcher; use {@link #getResult(XtextWebDocumentAccess)} instead
+	 * in order to avoid duplicate computations.
 	 */
 	override compute(IXtextWebDocument it, CancelIndicator cancelIndicator) {
 		val issues = resourceValidator.validate(resource, CheckMode.ALL, cancelIndicator)
@@ -49,4 +47,5 @@ class ValidationService extends AbstractCachedService<ValidationResult> {
 			default: "ignore"
 		}
 	}
+	
 }

--- a/web/org.eclipse.xtext.web/src/main/js/xtext/ServiceBuilder.js
+++ b/web/org.eclipse.xtext.web/src/main/js/xtext/ServiceBuilder.js
@@ -145,7 +145,7 @@ define([
 		}
 		if (options.enableGeneratorService || options.enableGeneratorService === undefined) {
 			services.generatorService = new XtextService();
-			services.generatorService.initialize(options.serviceUrl, 'generate', options.resourceId, services.updateService);
+			services.generatorService.initialize(services, 'generate');
 			services.generatorService._initServerData = function(serverData, editorContext, params) {
 				if (params.allArtifacts)
 					serverData.allArtifacts = params.allArtifacts;

--- a/web/org.eclipse.xtext.web/src/main/js/xtext/services/XtextService.js
+++ b/web/org.eclipse.xtext.web/src/main/js/xtext/services/XtextService.js
@@ -15,251 +15,261 @@ define(['jquery'], function(jQuery) {
 	 */
 	function XtextService() {};
 
-	XtextService.prototype = {
-		
-		/**
-		 * Initialize the request metadata for this service class.
-		 */
-		initialize: function(serviceUrl, serviceType, resourceId, updateService) {
-			this._requestUrl = serviceUrl + '/' + serviceType;
-			this._serviceType = serviceType;
+	/**
+	 * Initialize the request metadata for this service class. Two variants:
+	 *  - initialize(serviceUrl, serviceType, resourceId, updateService)
+	 *  - initialize(xtextServices, serviceType)
+	 */
+	XtextService.prototype.initialize = function() {
+		this._serviceType = arguments[1];
+		if (typeof(arguments[0]) === 'string') {
+			this._requestUrl = arguments[0] + '/' + this._serviceType;
+			var resourceId = arguments[2];
 			if (resourceId)
 				this._encodedResourceId = encodeURIComponent(resourceId);
-			if (updateService)
-				this._updateService = updateService;
-		},
-		
-		setState: function(state) {
-			this._state = state;
-		},
-		
-		/**
-		 * Invoke the service with default service behavior.
-		 */
-		invoke: function(editorContext, params, deferred, callbacks) {
-			if (deferred === undefined) {
-				deferred = jQuery.Deferred();
+			this._updateService = arguments[3];
+		} else {
+			var xtextServices = arguments[0];
+			if (xtextServices.options) {
+				this._requestUrl = xtextServices.options.serviceUrl + '/' + this._serviceType;
+				var resourceId = xtextServices.options.resourceId;
+				if (resourceId)
+					this._encodedResourceId = encodeURIComponent(resourceId);
 			}
-			if (jQuery.isFunction(this._checkPreconditions) && !this._checkPreconditions(editorContext, params)) {
-				deferred.reject();
-				return deferred.promise();
-			}
-			var serverData = {
-				contentType: params.contentType
-			};
-			var initResult;
-			if (jQuery.isFunction(this._initServerData))
-				initResult = this._initServerData(serverData, editorContext, params);
-			var httpMethod = 'GET';
-			if (initResult && initResult.httpMethod)
-				httpMethod = initResult.httpMethod;
-			var self = this;
-			if (!(initResult && initResult.suppressContent)) {
-				if (params.sendFullText) {
-					serverData.fullText = editorContext.getText();
-					httpMethod = 'POST';
-				} else {
-					var knownServerState = editorContext.getServerState();
-					if (knownServerState.updateInProgress) {
-						if (self._updateService) {
-							self._updateService.addCompletionCallback(function() {
-								self.invoke(editorContext, params, deferred);
-							});
-						} else {
-							deferred.reject();
-						}
-						return deferred.promise();
-					}
-					if (knownServerState.stateId !== undefined) {
-						serverData.requiredStateId = knownServerState.stateId;
-					}
-				}
-			}
-			
-			var onSuccess;
-			if (jQuery.isFunction(this._getSuccessCallback)) {
-				onSuccess = this._getSuccessCallback(editorContext, params, deferred);
+			this._updateService = xtextServices.updateService;
+		}
+	}
+	
+	XtextService.prototype.setState = function(state) {
+		this._state = state;
+	}
+	
+	/**
+	 * Invoke the service with default service behavior.
+	 */
+	XtextService.prototype.invoke = function(editorContext, params, deferred, callbacks) {
+		if (deferred === undefined) {
+			deferred = jQuery.Deferred();
+		}
+		if (jQuery.isFunction(this._checkPreconditions) && !this._checkPreconditions(editorContext, params)) {
+			deferred.reject();
+			return deferred.promise();
+		}
+		var serverData = {
+			contentType: params.contentType
+		};
+		var initResult;
+		if (jQuery.isFunction(this._initServerData))
+			initResult = this._initServerData(serverData, editorContext, params);
+		var httpMethod = 'GET';
+		if (initResult && initResult.httpMethod)
+			httpMethod = initResult.httpMethod;
+		var self = this;
+		if (!(initResult && initResult.suppressContent)) {
+			if (params.sendFullText) {
+				serverData.fullText = editorContext.getText();
+				httpMethod = 'POST';
 			} else {
-				onSuccess = function(result) {
-					if (result.conflict) {
-						if (self._increaseRecursionCount(editorContext)) {
-							var onConflictResult;
-							if (jQuery.isFunction(self._onConflict)) {
-								onConflictResult = self._onConflict(editorContext, result.conflict);
-							}
-							if (!(onConflictResult && onConflictResult.suppressForcedUpdate) && !params.sendFullText
-									&& result.conflict == 'invalidStateId' && self._updateService) {
-								self._updateService.addCompletionCallback(function() {
-									self.invoke(editorContext, params, deferred);
-								});
-								var knownServerState = editorContext.getServerState();
-								delete knownServerState.stateId;
-								delete knownServerState.text;
-								self._updateService.invoke(editorContext, params);
-							} else {
-								self.invoke(editorContext, params, deferred);
-							}
-						} else {
-							deferred.reject();
-						}
-						return false;
-					}
-					if (jQuery.isFunction(self._processResult)) {
-						var processedResult = self._processResult(result, editorContext);
-						if (processedResult) {
-							deferred.resolve(processedResult);
-							return true;
-						}
-					}
-					deferred.resolve(result);
-				};
-			}
-			
-			var onError = function(xhr, textStatus, errorThrown) {
-				if (xhr.status == 404 && !params.loadFromServer && self._increaseRecursionCount(editorContext)) {
-					var onConflictResult;
-					if (jQuery.isFunction(self._onConflict)) {
-						onConflictResult = self._onConflict(editorContext, errorThrown);
-					}
-					var knownServerState = editorContext.getServerState();
-					if (!(onConflictResult && onConflictResult.suppressForcedUpdate)
-							&& knownServerState.text !== undefined && self._updateService) {
+				var knownServerState = editorContext.getServerState();
+				if (knownServerState.updateInProgress) {
+					if (self._updateService) {
 						self._updateService.addCompletionCallback(function() {
 							self.invoke(editorContext, params, deferred);
 						});
-						delete knownServerState.stateId;
-						delete knownServerState.text;
-						self._updateService.invoke(editorContext, params);
+					} else {
+						deferred.reject();
+					}
+					return deferred.promise();
+				}
+				if (knownServerState.stateId !== undefined) {
+					serverData.requiredStateId = knownServerState.stateId;
+				}
+			}
+		}
+		
+		var onSuccess;
+		if (jQuery.isFunction(this._getSuccessCallback)) {
+			onSuccess = this._getSuccessCallback(editorContext, params, deferred);
+		} else {
+			onSuccess = function(result) {
+				if (result.conflict) {
+					if (self._increaseRecursionCount(editorContext)) {
+						var onConflictResult;
+						if (jQuery.isFunction(self._onConflict)) {
+							onConflictResult = self._onConflict(editorContext, result.conflict);
+						}
+						if (!(onConflictResult && onConflictResult.suppressForcedUpdate) && !params.sendFullText
+								&& result.conflict == 'invalidStateId' && self._updateService) {
+							self._updateService.addCompletionCallback(function() {
+								self.invoke(editorContext, params, deferred);
+							});
+							var knownServerState = editorContext.getServerState();
+							delete knownServerState.stateId;
+							delete knownServerState.text;
+							self._updateService.invoke(editorContext, params);
+						} else {
+							self.invoke(editorContext, params, deferred);
+						}
+					} else {
+						deferred.reject();
+					}
+					return false;
+				}
+				if (jQuery.isFunction(self._processResult)) {
+					var processedResult = self._processResult(result, editorContext);
+					if (processedResult) {
+						deferred.resolve(processedResult);
 						return true;
 					}
 				}
-				deferred.reject(errorThrown);
-			}
-			
-			self.sendRequest(editorContext, {
-				type: httpMethod,
-				data: serverData,
-				success: onSuccess,
-				error: onError
-			}, !params.sendFullText);
-			return deferred.promise().always(function() {
-				self._recursionCount = undefined;
-			});
-		},
-
-		/**
-		 * Send an HTTP request to invoke the service.
-		 */
-		sendRequest: function(editorContext, settings, needsSession) {
-			var self = this;
-			self.setState('started');
-			
-			var onSuccess = settings.success;
-			settings.success = function(result) {
-				var accepted = true;
-				if (jQuery.isFunction(onSuccess)) {
-					accepted = onSuccess(result);
-				}
-				if (accepted || accepted === undefined) {
-					self.setState('finished');
-					if (editorContext.xtextServices) {
-						var successListeners = editorContext.xtextServices.successListeners;
-						if (successListeners) {
-							for (var i = 0; i < successListeners.length; i++) {
-								var listener = successListeners[i];
-								if (jQuery.isFunction(listener)) {
-									listener(self._serviceType, result);
-								}
-							}
-						}
-					}
-				}
+				deferred.resolve(result);
 			};
-			
-			var onError = settings.error;
-			settings.error = function(xhr, textStatus, errorThrown) {
-				var resolved = false;
-				if (jQuery.isFunction(onError)) {
-					resolved = onError(xhr, textStatus, errorThrown);
-				}
-				if (!resolved) {
-					self.setState(undefined);
-					self._reportError(editorContext, textStatus, errorThrown, xhr);
-				}
-			};
-			
-			settings.async = true;
-			var requestUrl = self._requestUrl;
-			if (!settings.data.resource && self._encodedResourceId) {
-				if (requestUrl.indexOf('?') >= 0)
-					requestUrl += '&resource=' + self._encodedResourceId;
-				else
-					requestUrl += '?resource=' + self._encodedResourceId;
-			}
-			
-			if (needsSession && globalState._initPending) {
-				// We have to wait until the initial request has finished to make sure the client has
-				// received a valid session id
-				if (!globalState._waitingRequests)
-					globalState._waitingRequests = [];
-				globalState._waitingRequests.push({requestUrl: requestUrl, settings: settings});
-			} else {
-				if (needsSession && !globalState._initDone) {
-					globalState._initPending = true;
-					var onComplete = settings.complete;
-					settings.complete = function(xhr, textStatus) {
-						if (jQuery.isFunction(onComplete)) {
-							onComplete(xhr, textStatus);
-						}
-						delete globalState._initPending;
-						globalState._initDone = true;
-						if (globalState._waitingRequests) {
-							for (var i = 0; i < globalState._waitingRequests.length; i++) {
-								var request = globalState._waitingRequests[i];
-								jQuery.ajax(request.requestUrl, request.settings);
-							}
-							delete globalState._waitingRequests;
-						}
-					}
-				}
-				jQuery.ajax(requestUrl, settings);
-			}
-		},
+		}
 		
-		/**
-		 * Use this in case of a conflict before retrying the service invocation. If the number
-		 * of retries exceeds the limit, an error is reported and the function returns false.
-		 */
-		_increaseRecursionCount: function(editorContext) {
-			if (this._recursionCount === undefined)
-				this._recursionCount = 1;
+		var onError = function(xhr, textStatus, errorThrown) {
+			if (xhr.status == 404 && !params.loadFromServer && self._increaseRecursionCount(editorContext)) {
+				var onConflictResult;
+				if (jQuery.isFunction(self._onConflict)) {
+					onConflictResult = self._onConflict(editorContext, errorThrown);
+				}
+				var knownServerState = editorContext.getServerState();
+				if (!(onConflictResult && onConflictResult.suppressForcedUpdate)
+						&& knownServerState.text !== undefined && self._updateService) {
+					self._updateService.addCompletionCallback(function() {
+						self.invoke(editorContext, params, deferred);
+					});
+					delete knownServerState.stateId;
+					delete knownServerState.text;
+					self._updateService.invoke(editorContext, params);
+					return true;
+				}
+			}
+			deferred.reject(errorThrown);
+		}
+		
+		self.sendRequest(editorContext, {
+			type: httpMethod,
+			data: serverData,
+			success: onSuccess,
+			error: onError
+		}, !params.sendFullText);
+		return deferred.promise().always(function() {
+			self._recursionCount = undefined;
+		});
+	}
+
+	/**
+	 * Send an HTTP request to invoke the service.
+	 */
+	XtextService.prototype.sendRequest = function(editorContext, settings, needsSession) {
+		var self = this;
+		self.setState('started');
+		
+		var onSuccess = settings.success;
+		settings.success = function(result) {
+			var accepted = true;
+			if (jQuery.isFunction(onSuccess)) {
+				accepted = onSuccess(result);
+			}
+			if (accepted || accepted === undefined) {
+				self.setState('finished');
+				if (editorContext.xtextServices) {
+					var successListeners = editorContext.xtextServices.successListeners;
+					if (successListeners) {
+						for (var i = 0; i < successListeners.length; i++) {
+							var listener = successListeners[i];
+							if (jQuery.isFunction(listener)) {
+								listener(self._serviceType, result);
+							}
+						}
+					}
+				}
+			}
+		};
+		
+		var onError = settings.error;
+		settings.error = function(xhr, textStatus, errorThrown) {
+			var resolved = false;
+			if (jQuery.isFunction(onError)) {
+				resolved = onError(xhr, textStatus, errorThrown);
+			}
+			if (!resolved) {
+				self.setState(undefined);
+				self._reportError(editorContext, textStatus, errorThrown, xhr);
+			}
+		};
+		
+		settings.async = true;
+		var requestUrl = self._requestUrl;
+		if (!settings.data.resource && self._encodedResourceId) {
+			if (requestUrl.indexOf('?') >= 0)
+				requestUrl += '&resource=' + self._encodedResourceId;
 			else
-				this._recursionCount++;
-
-			if (this._recursionCount >= 10) {
-				this._reportError(editorContext, 'warning', 'Xtext service request failed after 10 attempts.', {});
-				return false;
-			}
-			return true;
-		},
+				requestUrl += '?resource=' + self._encodedResourceId;
+		}
 		
-		/**
-		 * Report an error to the listeners.
-		 */
-		_reportError: function(editorContext, severity, message, requestData) {
-			if (editorContext.xtextServices) {
-				var errorListeners = editorContext.xtextServices.errorListeners;
-				if (errorListeners) {
-					for (var i = 0; i < errorListeners.length; i++) {
-						var listener = errorListeners[i];
-						if (jQuery.isFunction(listener)) {
-							listener(this._serviceType, severity, message, requestData);
+		if (needsSession && globalState._initPending) {
+			// We have to wait until the initial request has finished to make sure the client has
+			// received a valid session id
+			if (!globalState._waitingRequests)
+				globalState._waitingRequests = [];
+			globalState._waitingRequests.push({requestUrl: requestUrl, settings: settings});
+		} else {
+			if (needsSession && !globalState._initDone) {
+				globalState._initPending = true;
+				var onComplete = settings.complete;
+				settings.complete = function(xhr, textStatus) {
+					if (jQuery.isFunction(onComplete)) {
+						onComplete(xhr, textStatus);
+					}
+					delete globalState._initPending;
+					globalState._initDone = true;
+					if (globalState._waitingRequests) {
+						for (var i = 0; i < globalState._waitingRequests.length; i++) {
+							var request = globalState._waitingRequests[i];
+							jQuery.ajax(request.requestUrl, request.settings);
 						}
+						delete globalState._waitingRequests;
+					}
+				}
+			}
+			jQuery.ajax(requestUrl, settings);
+		}
+	}
+	
+	/**
+	 * Use this in case of a conflict before retrying the service invocation. If the number
+	 * of retries exceeds the limit, an error is reported and the function returns false.
+	 */
+	XtextService.prototype._increaseRecursionCount = function(editorContext) {
+		if (this._recursionCount === undefined)
+			this._recursionCount = 1;
+		else
+			this._recursionCount++;
+
+		if (this._recursionCount >= 10) {
+			this._reportError(editorContext, 'warning', 'Xtext service request failed after 10 attempts.', {});
+			return false;
+		}
+		return true;
+	},
+	
+	/**
+	 * Report an error to the listeners.
+	 */
+	XtextService.prototype._reportError = function(editorContext, severity, message, requestData) {
+		if (editorContext.xtextServices) {
+			var errorListeners = editorContext.xtextServices.errorListeners;
+			if (errorListeners) {
+				for (var i = 0; i < errorListeners.length; i++) {
+					var listener = errorListeners[i];
+					if (jQuery.isFunction(listener)) {
+						listener(this._serviceType, severity, message, requestData);
 					}
 				}
 			}
 		}
-	};
+	}
 	
 	return XtextService;
 });

--- a/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/model/XtextWebDocument.java
+++ b/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/model/XtextWebDocument.java
@@ -49,7 +49,12 @@ public class XtextWebDocument implements IXtextWebDocument {
   
   private final Map<Class<?>, IServiceResult> cachedServiceResults = CollectionLiterals.<Class<?>, IServiceResult>newHashMap();
   
-  protected void clearCachedServiceResults() {
+  /**
+   * Clear any cached result of {@link AbstractCachedService}. This method is called whenever the text
+   * content of the resource is modified, but it may be necessary to clear the cached services in other
+   * cases, too.
+   */
+  public void clearCachedServiceResults() {
     this.cachedServiceResults.clear();
   }
   
@@ -129,6 +134,9 @@ public class XtextWebDocument implements IXtextWebDocument {
     return Long.toString(_modificationStamp, 16);
   }
   
+  /**
+   * Replace the text contents of the contained resource with the given text.
+   */
   @Override
   public void setText(final String text) {
     try {
@@ -140,6 +148,9 @@ public class XtextWebDocument implements IXtextWebDocument {
     }
   }
   
+  /**
+   * Update a part of the text.
+   */
   @Override
   public void updateText(final String text, final int offset, final int replaceLength) {
     this.clearCachedServiceResults();
@@ -147,6 +158,11 @@ public class XtextWebDocument implements IXtextWebDocument {
     this.refreshText();
   }
   
+  /**
+   * A new state id should be created whenever the text content is changed. The client must know
+   * the correct state id in order to send proper requests. If a request with an outdated state id
+   * is received by the server, the request is rejected.
+   */
   @Override
   public void createNewStateId() {
     long _modificationStamp = this.resource.getModificationStamp();

--- a/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/syntaxcoloring/HighlightingService.java
+++ b/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/syntaxcoloring/HighlightingService.java
@@ -16,7 +16,6 @@ import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.web.server.model.AbstractCachedService;
 import org.eclipse.xtext.web.server.model.IXtextWebDocument;
-import org.eclipse.xtext.web.server.model.UpdateDocumentService;
 import org.eclipse.xtext.web.server.syntaxcoloring.HighlightingResult;
 
 /**
@@ -31,10 +30,9 @@ public class HighlightingService extends AbstractCachedService<HighlightingResul
   private ISemanticHighlightingCalculator highlightingCalculator;
   
   /**
-   * Return the highlighting result for the given document. The actual highlighting may have
-   * been computed as part of the background work scheduled after another service request,
-   * e.g. {@link UpdateDocumentService}. If that background processing has not been done
-   * yet, it is executed and then the validation issues are collected.
+   * Compute the highlighting result for the given document. This method should not be called
+   * directly from the service dispatcher; use {@link #getResult(XtextWebDocumentAccess)} instead
+   * in order to avoid duplicate computations.
    */
   @Override
   public HighlightingResult compute(final IXtextWebDocument it, final CancelIndicator cancelIndicator) {

--- a/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/validation/ValidationService.java
+++ b/web/org.eclipse.xtext.web/src/main/xtend-gen/org/eclipse/xtext/web/server/validation/ValidationService.java
@@ -19,7 +19,6 @@ import org.eclipse.xtext.validation.IResourceValidator;
 import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.web.server.model.AbstractCachedService;
 import org.eclipse.xtext.web.server.model.IXtextWebDocument;
-import org.eclipse.xtext.web.server.model.UpdateDocumentService;
 import org.eclipse.xtext.web.server.validation.ValidationResult;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
@@ -35,10 +34,9 @@ public class ValidationService extends AbstractCachedService<ValidationResult> {
   private IResourceValidator resourceValidator;
   
   /**
-   * Return the validation result for the given document. The actual validation may have
-   * been computed as part of the background work scheduled after another service request,
-   * e.g. {@link UpdateDocumentService}. If that background processing has not been done
-   * yet, it is executed and then the validation issues are collected.
+   * Compute the validation result for the given document.  This method should not be called
+   * directly from the service dispatcher; use {@link #getResult(XtextWebDocumentAccess)} instead
+   * in order to avoid duplicate computations.
    */
   @Override
   public ValidationResult compute(final IXtextWebDocument it, final CancelIndicator cancelIndicator) {


### PR DESCRIPTION
* Made `XtextWebDocument.clearCachedServiceResults()` public: in some applications it is necessary to recompute the cached services on changes of the environment, not only on text change.
* Updated JavaDoc.
* Added overloaded variant of `XtextService.initialize()`: This function is used frequently for custom services, so a shorter version has been added for convenience.
* Changed XtextService implementation so it adds to the function prototype instead of replacing it.