### PR TITLE
[bug 494120]: Trim a uri's fragment to load a resource in LoadingResourceAccess

### DIFF
--- a/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/LoadingResourceAccess.java
+++ b/plugins/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/LoadingResourceAccess.java
@@ -35,7 +35,8 @@ public class LoadingResourceAccess implements IReferenceFinder.ILocalResourceAcc
 	
 	@Override
 	public <R> R readOnly(URI targetURI, IUnitOfWork<R, ResourceSet> work) {
-		Iterable<Pair<IStorage, IProject>> storages = storage2UriMapper.getStorages(targetURI.trimFragment());
+		URI resourceURI = targetURI.trimFragment();
+		Iterable<Pair<IStorage, IProject>> storages = storage2UriMapper.getStorages(resourceURI);
 		Iterator<Pair<IStorage, IProject>> iterator = storages.iterator();
 		while(iterator.hasNext()) {
 			Pair<IStorage, IProject> pair = iterator.next();
@@ -43,7 +44,7 @@ public class LoadingResourceAccess implements IReferenceFinder.ILocalResourceAcc
 			if (project != null) {
 				ResourceSet resourceSet = resourceSetProvider.get(project);
 				if(resourceSet != null)
-					resourceSet.getResource(targetURI, true);
+					resourceSet.getResource(resourceURI, true);
 					try {
 						return work.exec(resourceSet);
 					} catch (Exception e) {


### PR DESCRIPTION
Change-Id: I03b3bc26a8335ca7638e217d7aac1f80787b3fcd
Signed-off-by: akosyakov <anton.kosyakov@typefox.io>