### PR TITLE
fixed generated injector provider for old mwe2

### DIFF
--- a/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.tests/src-gen/org/eclipse/xtext/example/domainmodel/DomainmodelInjectorProvider.java
+++ b/examples/org.eclipse.xtext.xtext.ui.examples/contents/org.eclipse.xtext.example.domainmodel.tests/src-gen/org/eclipse/xtext/example/domainmodel/DomainmodelInjectorProvider.java
@@ -10,8 +10,6 @@ import org.eclipse.xtext.junit4.GlobalRegistries.GlobalStateMemento;
 import org.eclipse.xtext.junit4.IInjectorProvider;
 import org.eclipse.xtext.junit4.IRegistryConfigurator;
 
-import com.google.inject.Injector;
-
 public class DomainmodelInjectorProvider implements IInjectorProvider, IRegistryConfigurator {
 
 	protected GlobalStateMemento stateBeforeInjectorCreation;

--- a/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/junit/Junit4Fragment.xpt
+++ b/plugins/org.eclipse.xtext.generator/src/org/eclipse/xtext/generator/junit/Junit4Fragment.xpt
@@ -60,8 +60,6 @@ import org.eclipse.xtext.junit4.GlobalRegistries.GlobalStateMemento;
 import org.eclipse.xtext.junit4.IInjectorProvider;
 import org.eclipse.xtext.junit4.IRegistryConfigurator;
 
-import com.google.inject.Injector;
-
 «classAnnotations()»public class «qualifiedInjectorProviderName().toSimpleName()» implements IInjectorProvider, IRegistryConfigurator {
 
 	protected GlobalStateMemento stateBeforeInjectorCreation;


### PR DESCRIPTION
While working on https://github.com/eclipse/xtext/pull/1040 the generated injector provider for the old mwe2 contains an additional useless

```
import com.google.inject.Injector;
```

This fixes it