### PR TITLE
494176: Warning: The file "plugin.xml" does not exist in the workspace

### DIFF
--- a/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/ecore2xtext/NewXtextProjectFromEcoreWizard.java
+++ b/plugins/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/ecore2xtext/NewXtextProjectFromEcoreWizard.java
@@ -16,6 +16,7 @@ import org.eclipse.xtext.xtext.ui.wizard.project.NewXtextProjectWizard;
 import org.eclipse.xtext.xtext.ui.wizard.project.XtextProjectCreator;
 import org.eclipse.xtext.xtext.ui.wizard.project.XtextProjectInfo;
 import org.eclipse.xtext.xtext.wizard.Ecore2XtextConfiguration;
+import org.eclipse.xtext.xtext.wizard.RuntimeProjectDescriptor;
 
 import com.google.inject.Inject;
 
@@ -49,6 +50,8 @@ public class NewXtextProjectFromEcoreWizard extends NewXtextProjectWizard {
 	@Override
 	protected IProjectInfo getProjectInfo() {
 		XtextProjectInfo projectInfo = (XtextProjectInfo) super.getProjectInfo();
+		RuntimeProjectDescriptor runtimeProjectDescriptor = projectInfo.getRuntimeProject();
+		runtimeProjectDescriptor.setWithPluginXml(false);
 		Ecore2XtextConfiguration ecore2Xtext = projectInfo.getEcore2Xtext();
 		ecore2Xtext.getEPackageInfos().addAll(ePackageSelectionPage.getEPackageInfos());
 		ecore2Xtext.setRootElementClass(ePackageSelectionPage.getRootElementClass());

--- a/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
+++ b/plugins/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
@@ -10,11 +10,14 @@ package org.eclipse.xtext.xtext.wizard
 import org.eclipse.xtext.xtext.wizard.ecore2xtext.Ecore2XtextGrammarCreator
 
 import static org.eclipse.xtext.xtext.wizard.ExternalDependency.*
+import org.eclipse.xtend.lib.annotations.Accessors
 
 class RuntimeProjectDescriptor extends TestedProjectDescriptor {
 
 	val grammarCreator = new Ecore2XtextGrammarCreator
 	val RuntimeTestProjectDescriptor testProject
+	@Accessors
+	var boolean withPluginXml = true
 	
 	new(WizardConfiguration config) {
 		super(config)
@@ -99,7 +102,8 @@ class RuntimeProjectDescriptor extends TestedProjectDescriptor {
 	override getBinIncludes() {
 		val includes = newLinkedHashSet
 		includes += super.binIncludes
-		includes += "plugin.xml"
+		if (withPluginXml)
+			includes += "plugin.xml"
 		includes
 	}
 

--- a/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
+++ b/plugins/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.util.XtextVersion;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
@@ -22,6 +23,7 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.eclipse.xtext.xtext.wizard.AbstractFile;
 import org.eclipse.xtext.xtext.wizard.BuildSystem;
@@ -50,6 +52,9 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
   private final Ecore2XtextGrammarCreator grammarCreator = new Ecore2XtextGrammarCreator();
   
   private final RuntimeTestProjectDescriptor testProject;
+  
+  @Accessors
+  private boolean withPluginXml = true;
   
   public RuntimeProjectDescriptor(final WizardConfiguration config) {
     super(config);
@@ -194,7 +199,9 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
       final LinkedHashSet<String> includes = CollectionLiterals.<String>newLinkedHashSet();
       Set<String> _binIncludes = super.getBinIncludes();
       Iterables.<String>addAll(includes, _binIncludes);
-      includes.add("plugin.xml");
+      if (this.withPluginXml) {
+        includes.add("plugin.xml");
+      }
       _xblockexpression = includes;
     }
     return _xblockexpression;
@@ -1578,5 +1585,14 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
     _builder.append("</assembly>");
     _builder.newLine();
     return _builder;
+  }
+  
+  @Pure
+  public boolean isWithPluginXml() {
+    return this.withPluginXml;
+  }
+  
+  public void setWithPluginXml(final boolean withPluginXml) {
+    this.withPluginXml = withPluginXml;
   }
 }


### PR DESCRIPTION
Now the reference to plugin.xml in the build.properties is not generated by the "Create the Xtext Project from an existing ecore model" 

Task-Url: https://bugs.eclipse.org/bugs/show_bug.cgi?id=494176
Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>