### PR TITLE
Fixing typo error in author's name.

### DIFF
--- a/xtext-website/community.html
+++ b/xtext-website/community.html
@@ -417,7 +417,7 @@ title: Community
   	          The default execution environment is the <a href="http://www.janusproject.io">Janus platform</a>.</td>
   	          <td>Apache 2 License</td>
   	          <td>Language, Framework</td>
-  	          <td>Sebastian Rodriguez, Nicolas Gaud, StÃ©phane Galland</td>
+  	          <td>Sebastian Rodriguez, Nicolas Gaud, St&eacute;phane Galland</td>
   	        </tr>
   	          <tr>
   	          <td><a href="http://sculptorgenerator.org">Sculptor</a></td>


### PR DESCRIPTION
Accent character in an author name was not well formatted.