### PR TITLE
AFC in the table of community projects.

### DIFF
--- a/xtext-website/community.html
+++ b/xtext-website/community.html
@@ -117,6 +117,14 @@ title: Community
   	          <td>Language</td>
   	          <td>Mohamed Bouragba, Mohamed Said, Maxime Kapusta and Yoann Vasseur</td>
   	        </tr>
+ 		<tr>
+   	          <td><a href="http://www.arakhne.org/afc">AFC</a></td>
+   	          <td>AFC is a Java library that provides mathematic primitives, and other useful utility tools. The mathematic primitives
+   	          (vector, point, matrix, shape, etc.) are providing operator overridings for Xtext-based languages.</td>
+   	          <td>Apache 2 License</td>
+   	          <td>Library</td>
+   	          <td>St&eacute;phane Galland, et al</td>
+   	        </tr>
   	        <tr>
   	          <td><a href="http://www.artop.org/">ARText (part&nbsp;of&nbsp;Artop)</a></td>
   	          <td>ARText, a textual language for the specification of AUTOSAR


### PR DESCRIPTION
AFC is a Java library that uses the annotations from the Xtext base library (@Pure, etc.) and provides operator overriding functions for a couple of classes, including the mathematical primitives.