### PR TITLE
Replaced === with .equals

### DIFF
--- a/xtext-website/documentation/103_domainmodelnextsteps.md
+++ b/xtext-website/documentation/103_domainmodelnextsteps.md
@@ -262,7 +262,7 @@ def void checkFeatureNameIsUnique(Feature f) {
     var superEntity = (f.eContainer as Entity).superType
     while (superEntity !== null) {
         for (other : superEntity.features) {
-            if (f.name === other.name) {
+            if (f.name.equals(other.name)) {
                 error("Feature names have to be unique",
                     DomainmodelPackage.Literals.FEATURE__NAME)
                 return


### PR DESCRIPTION
Replaced `===` with `.equals` for matching correctly the names in the `checkFeatureNameIsUnique`.