### PR TITLE
Add info about the finiseh setup process to contrib. guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,10 @@ All committers should feel responsible to read incoming issues. When you read a 
 3. On the *Product* page, select *Eclipse IDE for Eclipse Committers*.
 4. On the *Projects* page, expand the *Xtext* node.
 5. Below the *Xtext* node there is a subproject entry for each module. Select those you would like to install. If in doubt, select all of them.
-6. Choose your preferred installation settings on the *Variables* page. Enter credentials for your Bugzilla and GitHub account.
+6. Choose your preferred installation settings on the *Variables* page. Enter credentials for your Eclipse and GitHub account.
 7. Finish the wizard, drink a cup of coffee, and watch how your Xtext development environment is assembled.
+
+When you run your freshly installed Eclipse IDE for the first time it will clone the relevant repositories and automatically set up your workspace with a number of projects.
 
 ## Contribute via Fork
 All you need is a [GitHub](https://github.com/) account.


### PR DESCRIPTION
Due to a [bug in EGit](https://bugs.eclipse.org/bugs/show_bug.cgi?id=526867), Eclipse could not clone the Xtext repos on startup in my installation. However, I did not know that the setup will clone the repos automatically and set up the workspace for you. To make that clear, I added the following sentence:
```
When you run your freshly installed Eclipse IDE for the first time it will clone the relevant repositories and automatically set up your workspace with a number of projects.
```

