### PR TITLE
Mention IF...ELSE...ENDIF expression in documentation

### DIFF
--- a/xtend-website/documentation/203_xtend_expressions.md
+++ b/xtend-website/documentation/203_xtend_expressions.md
@@ -1044,7 +1044,24 @@ def someHTML(Paragraph p) '''
   </html>
 '''
 ```
+You can also use `IF...ELSE...ENDIF` or `IF...ELSEIF...ENDIF` expressions:
 
+```xtend
+def someHTML(Paragraph p) '''
+  <html>
+    <body>
+      «IF p.headLine != null»
+        <h1>«p.headline»</h1>
+      «ELSE»
+        <h1>«p.standartHeadline»</h1>
+      «ENDIF»
+      <p>
+        «p.text»
+      </p>
+    </body>
+  </html>
+'''
+```
 ### Loops in Templates {#template-foreach}
 
 Also a `FOR` expression is available:


### PR DESCRIPTION
Hey guys,
I use XTend for generating HTML Code and (i may be stupid) didnt know for a longer time, that i can use ELSE in the template expression.
I always used IF like

```
IF condition1
  'code'
ENDIF

IF !condition1
  'code'
[ENDIF]
```

I found the documentation on [xtendtech](http://www.xtendtech.com/ivr/help/Script%20Language%20Reference/Conditional%20Statements/conditional%20statements.htm)

Maybe a mention of the alternative uses of IF template expressions may help other (stupid) users of xtend