### PR TITLE
Bug 539605: Remove logos from companies not member of eclipse

### DIFF
--- a/xtext-website/index.html
+++ b/xtext-website/index.html
@@ -34,7 +34,7 @@ title: Language Engineering Made Easy!
 <div id="intro-quotes" class="intro-reference">
   <div class="container">
     <ul id="newsticker" class="newsticker">
-      <li>Event: <a href="https://www.eclipsecon.org/europe2017/" target="_blank" style="text-decoration: underline; color: #fff;">EclipseCon Europe 2017</a></li>
+      <li>Event: <a href="https://www.eclipsecon.org/europe2018/" target="_blank" style="text-decoration: underline; color: #fff;">EclipseCon Europe 2018</a></li>
     </ul>
   </div>
 </div>
@@ -102,11 +102,8 @@ title: Language Engineering Made Easy!
     <ul class="companies">
       <li><img src="{{ site.baseurl }}/images/logo-google.png" alt="Google"/>
         <img src="{{ site.baseurl }}/images/Siemens-logo.svg" alt="Siemens"/>
-        <img src="{{ site.baseurl }}/images/logo_morgan_stanley.svg" alt="Morgan Stanley"/></li>
       <li>
-        <img src="{{ site.baseurl }}/images/ESA_logo.svg" alt="ESA"/>
         <img src="{{ site.baseurl }}/images/Bosch-Logo.svg" alt="Bosch"/>
-        <img src="{{ site.baseurl }}/images/SAIC_Logo.svg" alt="SAIC"/>
         <img src="{{ site.baseurl }}/images/SAP-Logo.svg" alt="SAP"/></li>
     </ul>
   </div>


### PR DESCRIPTION
Remove logos from companies not member of eclipse foundation.
Also update link to EclipseCon from 2017 to 2018.

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>