### PR TITLE
[#1804] added hint about Java 11 move to release notes

### DIFF
--- a/xtend-website/_posts/releasenotes/2020-09-01-version-2-23-0.md
+++ b/xtend-website/_posts/releasenotes/2020-09-01-version-2-23-0.md
@@ -12,6 +12,9 @@ Xtend 2.23.0 is a maintenance release.
 
 As you might have recognized, the number of people contributing to Xtext & Xtend on a regular basis has declined over the past years and so has the number of contributions. At the same time the amount of work for basic maintenance has stayed the same or even increased with the new release cadence of Java and the Eclipse simultaneous release. Briefly: The future maintenance of Xtext & especially Xtend is at risk. If you care, please join the discussion in [https://github.com/eclipse/xtext/issues/1721](https://github.com/eclipse/xtext/issues/1721).
 
+## Xtext, Xtend, Eclipse, and Java 11
+
+The Eclipse Platform and Java Development Tools have decided to migrate to Java 11 with the new 2020-09 (4.17) release. Xtext and Xtend depend on these projects both for the integration into Eclipse as well as in the LSP and standalone mode. We decided to follow suit to close a window of opportunity for hard to find bugs. Therefore, the version 2.24 of Xtext and Xtend which is due along with Eclipse 2020-12 will be the first release that depends on Java 11. Please feel encouraged to join the discussion in [https://github.com/eclipse/xtext/issues/1804](https://github.com/eclipse/xtext/issues/1804) if you have any concerns, general comments or other suggestions.
 
 ## Credits
 

--- a/xtext-website/_posts/releasenotes/2020-09-01-version-2-23-0.md
+++ b/xtext-website/_posts/releasenotes/2020-09-01-version-2-23-0.md
@@ -21,6 +21,11 @@ As you might have recognized, the number of people contributing to Xtext on a re
 
 ## Deprecations
 
+## Xtext and Java 11
+
+## Xtext, Xtend, Eclipse, and Java 11
+
+The Eclipse Platform and Java Development Tools have decided to migrate to Java 11 with the new 2020-09 (4.17) release. Xtext and Xtend depend on these projects both for the integration into Eclipse as well as in the LSP and standalone mode. We decided to follow suit to close a window of opportunity for hard to find bugs. Therefore, the version 2.24 of Xtext and Xtend which is due along with Eclipse 2020-12 will be the first release that depends on Java 11. Please feel encouraged to join the discussion in [https://github.com/eclipse/xtext/issues/1804](https://github.com/eclipse/xtext/issues/1804) if you have any concerns, general comments or other suggestions.
 
 ## Credits
 


### PR DESCRIPTION
[#1804] added hint about Java 11 move to release notes
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>