### PR TITLE
[eclipse/xtext#1861] update to MWE(2) 1.6.0/2.12.0

### DIFF
--- a/xtext-website/_posts/releasenotes/2020-12-01-version-2-24-0.md
+++ b/xtext-website/_posts/releasenotes/2020-12-01-version-2-24-0.md
@@ -16,6 +16,7 @@ As you might have recognized, the number of people contributing to Xtext on a re
 ## Upgrades
 
 * Eclipse Platform and JDT Maven dependencies were updated to the 4.17 / Eclipse 2020-09 versions.
+* MWE(2) was updated to 2.12.0/1.6.0.
 
 ## Credits
 

--- a/xtext-website/documentation/350_continuous_integration.md
+++ b/xtext-website/documentation/350_continuous_integration.md
@@ -116,7 +116,7 @@ The `pom.xml` for the language project contains information about how Maven shou
     <dependency>
       <groupId>org.eclipse.emf</groupId>
       <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-      <version>2.11.3</version>
+      <version>2.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.xtext</groupId>
@@ -247,7 +247,7 @@ To further speed up the p2 dependency resolution step, use the concrete build re
 
 | Xtext         | EMF           | MWE2/MWE    | Xpand       | Eclipse     | All included in |
 | ------------- | ------------- | ----------- | ----------- | ----------- | ----------- |
-| [2.24.0]({{page.upsite.xtext}}releases/2.24.0/)           | [2.24.0]({{page.upsite.eclipse}}modeling/emf/emf/builds/release/2.24) (2.20.0)     | [2.11.3]({{page.upsite.mwe}}releases/2.11.3/) (2.9.1) | [2.2.0]({{page.upsite.xpand}}releases/R201605260315) (1.4)  | [4.17.0]({{page.upsite.eclipse}}releases/2020-09) (4.7.3) | [2020-12]({{page.upsite.eclipse}}releases/2020-12)|
+| [2.24.0]({{page.upsite.xtext}}releases/2.24.0/)           | [2.24.0]({{page.upsite.eclipse}}modeling/emf/emf/builds/release/2.24) (2.20.0)     | [2.12.0]({{page.upsite.mwe}}releases/2.12.0/) (2.9.1) | [2.2.0]({{page.upsite.xpand}}releases/R201605260315) (1.4)  | [4.17.0]({{page.upsite.eclipse}}releases/2020-09) (4.7.3) | [2020-12]({{page.upsite.eclipse}}releases/2020-12)|
 | [2.23.0]({{page.upsite.xtext}}releases/2.23.0/)           | [2.23.0]({{page.upsite.eclipse}}modeling/emf/emf/builds/release/2.23) (2.20.0)     | [2.11.3]({{page.upsite.mwe}}releases/2.11.3/) (2.9.1) | [2.2.0]({{page.upsite.xpand}}releases/R201605260315) (1.4)  | [4.17.0]({{page.upsite.eclipse}}releases/2020-09) (4.7.3) | [2020-09]({{page.upsite.eclipse}}releases/2020-09)|
 | [2.22.0]({{page.upsite.xtext}}releases/2.22.0/)           | [2.22.0]({{page.upsite.eclipse}}modeling/emf/emf/builds/release/2.22) (2.20.0)     | [2.11.3]({{page.upsite.mwe}}releases/2.11.3/) (2.9.1) | [2.2.0]({{page.upsite.xpand}}releases/R201605260315) (1.4)  | [4.16.0]({{page.upsite.eclipse}}releases/2020-06) (4.7.3) | [2020-06]({{page.upsite.eclipse}}releases/2020-06)|
 | [2.21.0]({{page.upsite.xtext}}releases/2.21.0/)           | [2.21.0]({{page.upsite.eclipse}}modeling/emf/emf/builds/release/2.21) (2.20.0)     | [2.11.2]({{page.upsite.mwe}}releases/2.11.2/) (2.9.1) | [2.2.0]({{page.upsite.xpand}}releases/R201605260315) (1.4)  | [4.15.0]({{page.upsite.eclipse}}releases/2020-03) (4.7.3) | [2020-03]({{page.upsite.eclipse}}releases/2020-03)|


### PR DESCRIPTION
[eclipse/xtext#1861] update to MWE(2) 1.6.0/2.12.0
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>