### PR TITLE
https://github.com/eclipse/xtext/issues/1862 Guava 30.1.0

### DIFF
--- a/xtend-website/_config.yml
+++ b/xtend-website/_config.yml
@@ -40,6 +40,6 @@ src:
 
 javadoc:
   java: "http://docs.oracle.com/javase/8/docs/api"
-  guava: "https://guava.dev/releases/27.1-jre/api/docs/"
+  guava: "https://guava.dev/releases/30.1-jre/api/docs/"
 
 edit-repo : "https://github.com/eclipse/xtext/edit/website-published/xtend-website/"


### PR DESCRIPTION
Update Google Guava version from 27.1.0 to 30.1.0

Signed-off-by: miklossy <miklossy@itemis.de>