### PR TITLE
Changed the link to the Typefox website 

### DIFF
--- a/xtext-website/_includes/header.html
+++ b/xtext-website/_includes/header.html
@@ -18,7 +18,7 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Support &amp; Trainings<span class="caret"></span></a>
               <ul class="dropdown-menu">
                 <li><a href="https://www.itemis.com/en/xtext/support-and-team/" target="_blank">itemis</a></li>
-                <li><a href="https://typefox.io/trainings-2" target="_blank">TypeFox</a></li>
+                <li><a href="https://www.typefox.io/language-engineering/" target="_blank">TypeFox</a></li>
               </ul>
             </li>
             <li ><a href="http://xtend-lang.org">Xtend</a></li>


### PR DESCRIPTION
The Typefox link in the training menu was old. 