### PR TITLE
Rename releng projects in Domainmodel example

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/feature/.project
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/feature/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>feature</name>
+	<name>org.eclipse.xtext.example.domainmodel.feature</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/repository/.project
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/repository/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>repository</name>
+	<name>org.eclipse.xtext.example.domainmodel.repository</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/.project
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>tp</name>
+	<name>org.eclipse.xtext.example.domainmodel.tp</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
Note that I renamed only the projects' names, not the directories, so from the Maven point of view nothing changes. Moreover, we only zip the releng project with its contents in the examples, so the ant script for zipping the examples doesn't need to be changed

Closes #2166