### PR TITLE
For flaky tests: -Dsurefire.rerunFailingTestsCount=2

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,12 +39,12 @@ jobs:
           mvn -version
 
       - name: Build and test (headless with xvfb in Linux)
-        run: xvfb-run mvn clean verify -PuseJenkinsSnapshots -Dsurefire.rerunFailingTestsCount=2
+        run: xvfb-run mvn clean verify -PuseJenkinsSnapshots -Dsurefire.rerunFailingTestsCount=3
         if: matrix.os == 'ubuntu-latest'
         working-directory: org.eclipse.xtext.full.releng
 
       - name: Build and test (in other OSes)
-        run: mvn clean verify -PuseJenkinsSnapshots -Dsurefire.rerunFailingTestsCount=2
+        run: mvn clean verify -PuseJenkinsSnapshots -Dsurefire.rerunFailingTestsCount=3
         if: matrix.os != 'ubuntu-latest'
         working-directory: org.eclipse.xtext.full.releng
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,12 +39,12 @@ jobs:
           mvn -version
 
       - name: Build and test (headless with xvfb in Linux)
-        run: xvfb-run mvn clean verify -PuseJenkinsSnapshots
+        run: xvfb-run mvn clean verify -PuseJenkinsSnapshots -Dsurefire.rerunFailingTestsCount=2
         if: matrix.os == 'ubuntu-latest'
         working-directory: org.eclipse.xtext.full.releng
 
       - name: Build and test (in other OSes)
-        run: mvn clean verify -PuseJenkinsSnapshots
+        run: mvn clean verify -PuseJenkinsSnapshots -Dsurefire.rerunFailingTestsCount=2
         if: matrix.os != 'ubuntu-latest'
         working-directory: org.eclipse.xtext.full.releng
 

--- a/full-build.sh
+++ b/full-build.sh
@@ -55,7 +55,7 @@ while [ "$1" != "" ]; do
 done
 
 MVN_ARGS+=(-PuseJenkinsSnapshots)
-MVN_ARGS+=(-Dsurefire.rerunFailingTestsCount=2)
+MVN_ARGS+=(-Dsurefire.rerunFailingTestsCount=3)
 
 echo mvn -B -f org.eclipse.xtext.full.releng ${MVN_ARGS[@]} $@
 

--- a/full-build.sh
+++ b/full-build.sh
@@ -55,6 +55,7 @@ while [ "$1" != "" ]; do
 done
 
 MVN_ARGS+=(-PuseJenkinsSnapshots)
+MVN_ARGS+=(-Dsurefire.rerunFailingTestsCount=2)
 
 echo mvn -B -f org.eclipse.xtext.full.releng ${MVN_ARGS[@]} $@
 


### PR DESCRIPTION
Closes #2199 

Looks like it's working as expected.
For example, in JIRO I see:

```
17:24:26  testUiTestBetweenTwoRuntimeTests(org.eclipse.xtext.ui.tests.InjectorProviderTest)  Time elapsed: 0.037 s
17:24:26  
17:24:26  Results:
17:24:26  
17:24:26  Flakes: 
17:24:26  org.eclipse.xtext.ui.tests.editor.occurrences.MarkOccurrencesTest.testMarkOccurrencesCrossFile(org.eclipse.xtext.ui.tests.editor.occurrences.MarkOccurrencesTest)
17:24:26    Run 1: MarkOccurrencesTest.testMarkOccurrencesCrossFile:132 » NullPointer
17:24:26    Run 2: PASS
17:24:26  
17:24:26  
17:24:26  Tests run: 1753, Failures: 0, Errors: 0, Skipped: 21, Flakes: 1
```

So it reran a failed test, the second time it passed, and it has been recorded in the log as "flake", as documented here https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#rerunFailingTestsCount (Tycho surefire delegates that to the standard surefire).

@cdietrich @szarnekow I'd merge this into master and see whether we get less red builds