### PR TITLE
xtend-maven-plugin-version 2.31.0.M0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
 		This is the version of the currently released latest version of the xtend-maven-plugin that we
 		use during the Maven builds for processing Xtend files.
 		-->
-		<xtend-maven-plugin-version>2.30.0</xtend-maven-plugin-version>
+		<xtend-maven-plugin-version>2.31.0.M0</xtend-maven-plugin-version>
 
 		<root-dir>${basedir}/..</root-dir>
 		<JENKINS_URL>https://ci.eclipse.org/xtext</JENKINS_URL>


### PR DESCRIPTION
While waiting for https://github.com/eclipse/xtext/pull/2205 to be merged, I cherry picked the commit for bootstrapping against 2.31.0.M0