### PR TITLE
compiler release option

### DIFF
--- a/org.eclipse.xtext.common.types.edit/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.common.types.edit/.settings/org.eclipse.jdt.core.prefs
@@ -26,6 +26,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.common.types.shared.jdt38/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.common.types.shared.jdt38/.settings/org.eclipse.jdt.core.prefs
@@ -7,6 +7,7 @@ org.eclipse.jdt.core.compiler.annotation.nullanalysis=disabled
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.problem.annotationSuperInterface=warning
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.autoboxing=ignore

--- a/org.eclipse.xtext.common.types.shared/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.common.types.shared/.settings/org.eclipse.jdt.core.prefs
@@ -5,3 +5,4 @@ org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.release=enabled

--- a/org.eclipse.xtext.common.types.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.common.types.ui/.settings/org.eclipse.jdt.core.prefs
@@ -27,6 +27,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.junit4/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.junit4/.settings/org.eclipse.jdt.core.prefs
@@ -26,6 +26,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.m2e/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.m2e/.settings/org.eclipse.jdt.core.prefs
@@ -21,3 +21,4 @@ org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.source=11
 org.eclipse.jdt.core.incompatibleJDKLevel=ignore
 org.eclipse.jdt.core.incompleteClasspath=error
+org.eclipse.jdt.core.compiler.release=enabled

--- a/org.eclipse.xtext.ui.codemining/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.ui.codemining/.settings/org.eclipse.jdt.core.prefs
@@ -6,3 +6,4 @@ org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.release=enabled

--- a/org.eclipse.xtext.ui.codetemplates.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.ui.codetemplates.ide/.settings/org.eclipse.jdt.core.prefs
@@ -5,3 +5,4 @@ org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.release=enabled

--- a/org.eclipse.xtext.ui.codetemplates.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.ui.codetemplates.ui/.settings/org.eclipse.jdt.core.prefs
@@ -26,6 +26,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.ui.codetemplates/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.ui.codetemplates/.settings/org.eclipse.jdt.core.prefs
@@ -26,6 +26,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.ui.ecore/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.ui.ecore/.settings/org.eclipse.jdt.core.prefs
@@ -21,6 +21,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.ui.shared/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.ui.shared/.settings/org.eclipse.jdt.core.prefs
@@ -27,6 +27,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.ui.testing/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.ui.testing/.settings/org.eclipse.jdt.core.prefs
@@ -26,6 +26,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.ui/.settings/org.eclipse.jdt.core.prefs
@@ -26,6 +26,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.web/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.web/.settings/org.eclipse.jdt.core.prefs
@@ -14,3 +14,4 @@ org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
 org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.release=enabled

--- a/org.eclipse.xtext.xbase.junit/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.xbase.junit/.settings/org.eclipse.jdt.core.prefs
@@ -29,6 +29,7 @@ org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.xbase.ui.testing/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.xbase.ui.testing/.settings/org.eclipse.jdt.core.prefs
@@ -29,6 +29,7 @@ org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.xbase.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.xbase.ui/.settings/org.eclipse.jdt.core.prefs
@@ -29,6 +29,7 @@ org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.xbase.web/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.xbase.web/.settings/org.eclipse.jdt.core.prefs
@@ -14,3 +14,4 @@ org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
 org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.release=enabled

--- a/org.eclipse.xtext.xtext.ui.examples/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/.settings/org.eclipse.jdt.core.prefs
@@ -26,6 +26,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.xtext.ui.graph/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.xtext.ui.graph/.settings/org.eclipse.jdt.core.prefs
@@ -21,6 +21,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/org.eclipse.xtext.xtext.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xtext.xtext.ui/.settings/org.eclipse.jdt.core.prefs
@@ -26,6 +26,7 @@ org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
 org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
 
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.release>11</maven.compiler.release>
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 
 		<build-helper-maven-plugin-version>3.3.0</build-helper-maven-plugin-version>


### PR DESCRIPTION
Quoting from https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html

> The --release option ensures that the code is compiled following the rules of the programming language of the specified release, and that generated classes target the release as well as the public API of that release. This means that, unlike the [-source and -target options](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html), the compiler will detect and generate an error when using APIs that don't exist in previous releases of Java SE.

This means that we can forget about compiling with Java 11 and safely compile with Java 17 always. If we tried to use API not present in Java 11 we would get a compilation error.

This would allow us to switch to Tycho 3 for good (https://github.com/xtext/xtext-monorepo/issues/15)

I added the property in the parent POM. I did NOT remove the source and target options, which would be redundant, because as far as I know our Maven plugins read those properties and not the release property.

Most of our bundles already had `org.eclipse.jdt.core.compiler.release=enabled` in `org.eclipse.jdt.core.prefs`, so in Eclipse the option was already enabled. I add that option in the remaining bundles that we publish. I skipped the test bundles since I wouldn't worry about them concerning this issue.