### PR TITLE
Remove 'de.itemis.xtext.antlr.feature' from target files

### DIFF
--- a/org.eclipse.xtext.generator/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.generator/META-INF/MANIFEST.MF
@@ -59,7 +59,6 @@ Require-Bundle: org.eclipse.xtext.xtext.generator;visibility:=reexport,
  org.eclipse.xtend.typesystem.emf;bundle-version="2.2.0";visibility:=reexport,
  org.eclipse.emf.codegen.ecore;bundle-version="2.29.0";resolution:=optional;visibility:=reexport;x-installation:=greedy,
  org.eclipse.xtext;resolution:=optional;x-installation:=greedy,
- de.itemis.xtext.antlr;bundle-version="2.0.0";resolution:=optional;visibility:=reexport,
  org.eclipse.emf.ecore;bundle-version="2.26.0",
  org.eclipse.emf.common;bundle-version="2.24.0",
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
@@ -72,5 +71,6 @@ Require-Bundle: org.eclipse.xtext.xtext.generator;visibility:=reexport,
 Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.commons.logging;version="1.0.4";resolution:=optional;x-installation:=greedy,
  org.apache.log4j;version="1.2.24"
+DynamicImport-Package: de.itemis.xtext.antlr.toolrunner
 Automatic-Module-Name: org.eclipse.xtext.generator
 Eclipse-SourceReferences: eclipseSourceReferences

--- a/org.eclipse.xtext.xtext.generator/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.generator/META-INF/MANIFEST.MF
@@ -17,7 +17,6 @@ Require-Bundle: org.eclipse.xtext;x-installation:=greedy,
  org.eclipse.emf.mwe2.lib;bundle-version="2.14.0";resolution:=optional,
  org.eclipse.equinox.common;bundle-version="3.16.0",
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
- de.itemis.xtext.antlr;bundle-version="2.0.0";resolution:=optional;visibility:=reexport,
  org.eclipse.jdt.core;bundle-version="3.29.0";resolution:=optional
 Import-Package: org.apache.log4j;version="1.2.24"
 Export-Package: org.eclipse.xtext.xtext.generator,
@@ -62,5 +61,6 @@ Export-Package: org.eclipse.xtext.xtext.generator,
  org.eclipse.xtext.xtext.generator.validation,
  org.eclipse.xtext.xtext.generator.web,
  org.eclipse.xtext.xtext.generator.xbase
+DynamicImport-Package: de.itemis.xtext.antlr.toolrunner
 Automatic-Module-Name: org.eclipse.xtext.xtext.generator
 Eclipse-SourceReferences: eclipseSourceReferences

--- a/xtext-latest.target
+++ b/xtext-latest.target
@@ -38,10 +38,6 @@
 			<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.itemis.com/updates/releases/2.1.1"/>
-			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
 			<unit id="org.slf4j.api" version="0.0.0"/>

--- a/xtext-r202203.target
+++ b/xtext-r202203.target
@@ -43,10 +43,6 @@
 			<unit id="org.eclipse.xtext" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.itemis.com/updates/releases/2.1.1"/>
-			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/technology/swtbot/releases/2.6.0/" />

--- a/xtext-r202206.target
+++ b/xtext-r202206.target
@@ -42,10 +42,6 @@
 			<unit id="org.eclipse.xtext" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.itemis.com/updates/releases/2.1.1"/>
-			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/technology/swtbot/releases/2.6.0/" />

--- a/xtext-r202209.target
+++ b/xtext-r202209.target
@@ -40,10 +40,6 @@
 			<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.itemis.com/updates/releases/2.1.1"/>
-			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/technology/swtbot/releases/2.6.0/" />

--- a/xtext-r202212.target
+++ b/xtext-r202212.target
@@ -35,10 +35,6 @@
 			<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.itemis.com/updates/releases/2.1.1"/>
-			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/technology/swtbot/releases/2.6.0/" />

--- a/xtext-r202303.target
+++ b/xtext-r202303.target
@@ -35,10 +35,6 @@
 			<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.itemis.com/updates/releases/2.1.1"/>
-			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
 			<unit id="org.slf4j.api" version="0.0.0"/>


### PR DESCRIPTION
As discussed in https://github.com/eclipse/xtext/pull/2213#issuecomment-1506846616, the de.itemis.xtext.antlr.feature should not be in the target-files.
It is only used for developer convenience in the xText development workspace and already added to that by the Xtext Oomph-setup.