### PR TITLE
Build with Tycho 3.0.4 and set up Maven toolchains

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,14 +70,9 @@ pipeline {
             cat ~/.m2/toolchains.xml
           '''
           script {
-            def mavenSurfireJDKToolchain = params.JDK_VERSION
-            def tychoSurefireJDK = params.JDK_VERSION == '17' ? 'SYSTEM' : 'BREE'
+            def toolChainArgs = params.JDK_VERSION == '17' ? '' : '-Pstrict-jdk --toolchains releng/toolchains.xml'
             sh """
-              ./full-build.sh --tp=${selectedTargetPlatform()} \
-                -Pstrict-jdk
-                --toolchains releng/toolchains.xml
-                -Dmaven.surefire.runtimeJDK=${mavenSurfireJDKToolchain} \
-                -Dtycho.surefire.runtimeJDK=${tychoSurefireJDK}
+              ./full-build.sh --tp=${selectedTargetPlatform()} ${toolChainArgs}
             """
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
             echo 'JAVA_HOME_11_X64=${JAVA_HOME_11_X64}'
             echo 'JAVA_HOME_17_X64=${JAVA_HOME_17_X64}'
             echo 'Predefined Jenkins Toolchain content'
-            cat ~/.m2e/toolchains.xml
+            cat ~/.m2/toolchains.xml
           '''
           script {
             def mavenSurfireJDKToolchain = params.JDK_VERSION

--- a/jenkins/nightly-deploy/Jenkinsfile
+++ b/jenkins/nightly-deploy/Jenkinsfile
@@ -34,13 +34,17 @@ pipeline {
       }
     }
     stage('Maven Tycho Build, Sign, Deploy') {
+      environment {
+        JAVA_HOME_11_X64 = tool(type:'jdk', name:'temurin-jdk11-latest')
+        JAVA_HOME_17_X64 = tool(type:'jdk', name:'temurin-jdk17-latest')
+      }
       steps {
         withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
           sh 'gpg --batch --import "${KEYRING}"'
           sh 'for fpr in $(gpg --list-keys --with-colons | awk -F: \'/fpr:/ {print $10}\' | sort -u); do echo -e "5\ny\n" | gpg --batch --command-fd 0 --expert --edit-key ${fpr} trust; done'
         }
         sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-          sh './full-deploy.sh -Peclipse-sign,sonatype-oss-release,release-snapshot'
+          sh ' ./full-deploy.sh -Peclipse-sign,sonatype-oss-release,release-snapshot,strict-jdk --toolchains releng/toolchains.xml'
         }
       }
     }

--- a/jenkins/nightly-deploy/Jenkinsfile
+++ b/jenkins/nightly-deploy/Jenkinsfile
@@ -34,17 +34,13 @@ pipeline {
       }
     }
     stage('Maven Tycho Build, Sign, Deploy') {
-      environment {
-        JAVA_HOME_11_X64 = tool(type:'jdk', name:'temurin-jdk11-latest')
-        JAVA_HOME_17_X64 = tool(type:'jdk', name:'temurin-jdk17-latest')
-      }
       steps {
         withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
           sh 'gpg --batch --import "${KEYRING}"'
           sh 'for fpr in $(gpg --list-keys --with-colons | awk -F: \'/fpr:/ {print $10}\' | sort -u); do echo -e "5\ny\n" | gpg --batch --command-fd 0 --expert --edit-key ${fpr} trust; done'
         }
         sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-          sh ' ./full-deploy.sh -Peclipse-sign,sonatype-oss-release,release-snapshot,strict-jdk --toolchains releng/toolchains.xml'
+          sh './full-deploy.sh -Peclipse-sign,sonatype-oss-release,release-snapshot'
         }
       }
     }

--- a/org.eclipse.xtend.maven.parent/pom.xml
+++ b/org.eclipse.xtend.maven.parent/pom.xml
@@ -72,20 +72,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<compilerId>jdt</compilerId>
-					<optimize>true</optimize>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.eclipse.tycho</groupId>
-						<artifactId>tycho-compiler-jdt</artifactId>
-						<version>${tycho-version}</version>
-					</dependency>
-				</dependencies>
-			</plugin>
-			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
 				<executions>
 					<execution>

--- a/org.eclipse.xtend.maven.parent/pom.xml
+++ b/org.eclipse.xtend.maven.parent/pom.xml
@@ -123,10 +123,6 @@
 					<version>3.0.1</version>
 				</plugin>
 				<plugin>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.10.1</version>
-				</plugin>
-				<plugin>
 					<artifactId>maven-deploy-plugin</artifactId>
 					<version>2.8.2</version>
 					<configuration>

--- a/org.eclipse.xtext.maven.parent/pom.xml
+++ b/org.eclipse.xtext.maven.parent/pom.xml
@@ -53,20 +53,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<compilerId>jdt</compilerId>
-					<optimize>true</optimize>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.eclipse.tycho</groupId>
-						<artifactId>tycho-compiler-jdt</artifactId>
-						<version>${tycho-version}</version>
-					</dependency>
-				</dependencies>
-			</plugin>
-			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
 				<executions>
 					<execution>

--- a/org.eclipse.xtext.maven.parent/pom.xml
+++ b/org.eclipse.xtext.maven.parent/pom.xml
@@ -100,10 +100,6 @@
 					<version>3.1.0</version>
 				</plugin>
 				<plugin>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.10.1</version>
-				</plugin>
-				<plugin>
 					<artifactId>maven-deploy-plugin</artifactId>
 					<version>2.8.2</version>
 					<configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -473,6 +473,11 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.11.0</version>
+				</plugin>
+				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
 					<version>3.1.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -435,14 +435,14 @@
 							<groupId>org.eclipse.tycho</groupId>
 							<artifactId>tycho-compiler-plugin</artifactId>
 							<configuration>
-								<useJDK>BREE</useJDK>
+								<useJDK>SYSTEM</useJDK>
 							</configuration>
 						</plugin>
 						<plugin>
 							<groupId>org.eclipse.tycho</groupId>
 							<artifactId>tycho-surefire-plugin</artifactId>
 							<configuration>
-								<useJDK>BREE</useJDK>
+								<useJDK>SYSTEM</useJDK>
 							</configuration>
 						</plugin>
 						<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -186,11 +186,6 @@
 		<current-release-zip-directory>${releases-zip-directory}/${current-release-zip-subdirectory}</current-release-zip-directory>
 
 		<site.label>TMF Xtext Update Site</site.label>
-
-		<!-- By default use running java version in test runtimes-->
-		<maven.surefire.runtimeJDK>${java.specification.version}</maven.surefire.runtimeJDK>
-		<tycho.surefire.runtimeJDK>SYSTEM</tycho.surefire.runtimeJDK>
-
 	</properties>
 
 	<dependencyManagement>
@@ -406,7 +401,7 @@
 			</build>
 		</profile>
 		<profile>
-			<id>strict-jdk</id>
+			<id>strict-release-jdk</id>
 			<build>
 				<plugins>
 					<plugin>
@@ -423,48 +418,13 @@
 						<configuration>
 							<toolchains>
 								<jdk>
+									<!-- Toolchain selected by maven/tycho-compiler for compilation and maven/tycho-surefire as JRE of launched test-runtimes-->
 									<version>${maven.compiler.release}</version>
 								</jdk>
 							</toolchains>
 						</configuration>
 					</plugin>
 				</plugins>
-				<pluginManagement>
-					<plugins>
-						<plugin>
-							<groupId>org.eclipse.tycho</groupId>
-							<artifactId>tycho-compiler-plugin</artifactId>
-							<configuration>
-								<useJDK>SYSTEM</useJDK>
-							</configuration>
-						</plugin>
-						<plugin>
-							<groupId>org.eclipse.tycho</groupId>
-							<artifactId>tycho-surefire-plugin</artifactId>
-							<configuration>
-								<useJDK>SYSTEM</useJDK>
-							</configuration>
-						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-compiler-plugin</artifactId>
-							<configuration>
-								<jdkToolchain>
-									<version>${maven.compiler.release}</version>
-								</jdkToolchain>
-							</configuration>
-						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-surefire-plugin</artifactId>
-							<configuration>
-								<jdkToolchain>
-									<version>${maven.compiler.release}</version>
-								</jdkToolchain>
-							</configuration>
-						</plugin>
-					</plugins>
-				</pluginManagement>
 			</build>
 		</profile>
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,16 @@
 							<groupId>org.eclipse.tycho</groupId>
 							<artifactId>tycho-surefire-plugin</artifactId>
 							<configuration>
-								<useJDK>${tycho.surefire.runtimeJDK}</useJDK>
+								<useJDK>BREE</useJDK>
+							</configuration>
+						</plugin>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-compiler-plugin</artifactId>
+							<configuration>
+								<jdkToolchain>
+									<version>${maven.compiler.release}</version>
+								</jdkToolchain>
 							</configuration>
 						</plugin>
 						<plugin>
@@ -450,7 +459,7 @@
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
 								<jdkToolchain>
-									<version>${maven.surefire.runtimeJDK}</version>
+									<version>${maven.compiler.release}</version>
 								</jdkToolchain>
 							</configuration>
 						</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,11 @@
 		<current-release-zip-directory>${releases-zip-directory}/${current-release-zip-subdirectory}</current-release-zip-directory>
 
 		<site.label>TMF Xtext Update Site</site.label>
+
+		<!-- By default use running java version in test runtimes-->
+		<maven.surefire.runtimeJDK>${java.specification.version}</maven.surefire.runtimeJDK>
+		<tycho.surefire.runtimeJDK>SYSTEM</tycho.surefire.runtimeJDK>
+
 	</properties>
 
 	<dependencyManagement>
@@ -398,6 +403,59 @@
 						<artifactId>maven-javadoc-plugin</artifactId>
 					</plugin>
 				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>strict-jdk</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-toolchains-plugin</artifactId>
+						<version>3.1.0</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>toolchain</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<toolchains>
+								<jdk>
+									<version>${maven.compiler.release}</version>
+								</jdk>
+							</toolchains>
+						</configuration>
+					</plugin>
+				</plugins>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.eclipse.tycho</groupId>
+							<artifactId>tycho-compiler-plugin</artifactId>
+							<configuration>
+								<useJDK>BREE</useJDK>
+							</configuration>
+						</plugin>
+						<plugin>
+							<groupId>org.eclipse.tycho</groupId>
+							<artifactId>tycho-surefire-plugin</artifactId>
+							<configuration>
+								<useJDK>${tycho.surefire.runtimeJDK}</useJDK>
+							</configuration>
+						</plugin>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-surefire-plugin</artifactId>
+							<configuration>
+								<jdkToolchain>
+									<version>${maven.surefire.runtimeJDK}</version>
+								</jdkToolchain>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
 			</build>
 		</profile>
 	</profiles>

--- a/releng/toolchains.xml
+++ b/releng/toolchains.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains xmlns="https://maven.apache.org/TOOLCHAINS/1.1.0"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<id>JavaSE-11</id>
+			<version>11</version>
+		</provides>
+		<configuration>
+			<jdkHome>${env.JAVA_HOME_11_X64}</jdkHome>
+		</configuration>
+	</toolchain>
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<id>JavaSE-17</id>
+			<version>17</version>
+		</provides>
+		<configuration>
+			<jdkHome>${env.JAVA_HOME_17_X64}</jdkHome>
+		</configuration>
+	</toolchain>
+</toolchains>


### PR DESCRIPTION
This PR migrates the xtext Maven+Tycho build to use Tycho 3.0.4 and sets up Maven toolchains. By using Maven toolschains one can ensure that all Plugins that only require Java-11 are build with a Java-11 JDK while at the same time the build is running in a Java-17 JRE (which is required since Tycho 3).
To enable that the `toolchains.xml` specifies a list of available JDK installations, which java version they implement and where they are located. The maven-toolchain-plugin then reads that file and tells all toolchain aware plugins, like the `maven-compiler/surefire-plugin` or `tycho-compiler/surefire-plugin` (when configured accordingly), where to find the corresponding JDK installation.

With this change the `JDK_VERSION` parameter of Xtext's Jenkins-Pipeline only specifies the JDK version used in Test-runtimes (launched by the maven/tyhco-surefire-plugin). The compilation always happens with the Plugin's BREE (which is currently mainly Java-11).


General guide for Maven toolchains:
https://maven.apache.org/guides/mini/guide-using-toolchains.html
Using the Maven-Toolchain-Plugin and its 'toolchain' goal the maven-compiler-plugin is configured to use a JDK from the toolchain that matches the specified release version.

Configure the Tycho-Compiler-Plugin to use the JDK in the toolchain that matches the Bundle-RequiredExecutionEnvironment:
https://tycho.eclipseprojects.io/doc/3.0.4/tycho-compiler-plugin/compile-mojo.html#useJDK

Configure the Maven-Surefire-Plugin to use a specific JDK version from the toolchain to launch a test runtime:
https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jdkToolchain

Configure the Tycho-Surefire-Plugin to use a specific JDK version from the toolchain to launch a test runtime:
https://tycho.eclipseprojects.io/doc/3.0.4/tycho-surefire-plugin/test-mojo.html#useJDK

About the toolchains.xml generated by the setup-java Github action and the exported JAVA_HOME_ environment variables:
- https://github.com/actions/setup-java/#install-multiple-jdks
- https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Modifying-Maven-Toolchains

Fixes https://github.com/eclipse/xtext/issues/2216