### PR TITLE
macOS failure in GitHub Actions

### DIFF
--- a/org.eclipse.xtext.common.types.tests/pom.xml
+++ b/org.eclipse.xtext.common.types.tests/pom.xml
@@ -41,11 +41,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
-			<artifactId>org.eclipse.emf.mwe2.language</artifactId>
+			<artifactId>org.eclipse.emf.mwe2.runtime</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.emf</groupId>
+			<artifactId>org.eclipse.emf.mwe2.language</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>


### PR DESCRIPTION
Closes #2229 

I think that listing transitive dependencies of mwe2 is a better approach, but I still think mwe2 POMs should be fixed under that respect