### PR TITLE
Tycho 3 and parameterized Jenkins job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
       }
       steps {
         xvnc(useXauthority: true) {
-          sh "./full-build.sh --tp=${selectedTargetPlatform()}"
+          sh "./full-build.sh --tp=${selectedTargetPlatform()} ${javaVersionBasedProperties()}"
         }
       }// END steps
     } // END stage
@@ -159,6 +159,22 @@ def selectedTargetPlatform() {
         return 'r202203'
     } else {
         return tp
+    }
+}
+
+/**
+ * Tycho 3 requires Java 17.
+ * If the build uses Java version 11, we return the proper tycho-version override.
+ * Otherwise, we return an empty string.
+ */
+def javaVersionBasedProperties() {
+    def javaVersion = javaVersion()
+
+    if (javaVersion<17) {
+        println("Switching to Tycho 2.7.5 with Java ${javaVersion}")
+        return '-Dtycho-version=2.7.5'
+    } else {
+        return ''
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>	
-		<tycho-version>2.7.5</tycho-version>
+		<tycho-version>3.0.4</tycho-version>
 
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
@cdietrich @HannesWell I had a few spare time and I wanted to try my idea to deal with Tycho 3 on Java 17 and Tycho 2.7.5 on Java 11.

The parameterization of the Jenkinsfile is pretty simple, IMHO. Whether it works it's still under testing.

I've only tested it on my fork and GitHub actions with a dedicated job for Java 11, overriding `tycho-version` and it works like a charm.

This is a temporary workaround to switch to Tycho 3 until the toolchain stuff is ready.