### PR TITLE
[Build] Extend GH workflow matrix for jdkVersion and targetPlatform

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,11 +11,17 @@ on:
 jobs:
   build:
     if: github.event_name != 'pull_request' || github.event.pull_request.base.repo.clone_url != github.event.pull_request.head.repo.clone_url
+    name: ${{ matrix.os }}, Java-${{ matrix.jdkVersion }}, Eclipse ${{ matrix.targetPlatform }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest' ] # 'windows-latest' too flaky
+        os: ['ubuntu', 'macos' ] # 'windows-latest' too flaky
+        jdkVersion: ['11', '17']
+        targetPlatform: ['r202203', 'latest'] # Only test latest and earliest platform
+        exclude: # Since Eclipse 2023-06 Java17 is required
+          - jdkVersion: 11
+            targetPlatform: latest
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
 
     steps:
       - name: 'Check out repository'
@@ -24,7 +30,9 @@ jobs:
       - name: 'Set up Java'
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: |
+            11
+            17
           distribution: 'temurin'
 
       - name: 'Cache Maven packages'
@@ -37,7 +45,8 @@ jobs:
       - name: Build and test
         uses: coactions/setup-xvfb@v1
         with: 
-          run: mvn clean verify -PuseJenkinsSnapshots
+          run: "mvn clean verify --batch-mode --toolchains ../releng/toolchains.xml -PuseJenkinsSnapshots,strict-release-jdk \
+            -Dtoolchain.jdk=${{ matrix.jdkVersion }} -Dtarget-platform-classifier=xtext-${{ matrix.targetPlatform }}"
           working-directory: org.eclipse.xtext.full.releng
 
   build-maven-artifacts:
@@ -62,5 +71,5 @@ jobs:
           restore-keys: ${{ runner.os }}-maven
 
       - name: Build Maven artifacts
-        run: mvn clean verify -PuseJenkinsSnapshots
+        run: mvn clean verify --batch-mode -PuseJenkinsSnapshots
         working-directory: org.eclipse.xtext.maven.releng

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
         xvnc(useXauthority: true) {
           sh """
             ./full-build.sh --tp=${selectedTargetPlatform()} \
-              ${javaVersion() == 17 ? '' : '--toolchains releng/toolchains.xml -Pstrict-release-jdk'}
+              --toolchains releng/toolchains.xml -Pstrict-release-jdk -Dtoolchain.jdk=${javaVersion()}
           """
         }
       }// END steps

--- a/pom.xml
+++ b/pom.xml
@@ -402,6 +402,10 @@
 		</profile>
 		<profile>
 			<id>strict-release-jdk</id>
+			<properties>
+				<!-- By default use running java version in test runtimes-->
+				<toolchain.jdk>${maven.compiler.release}</toolchain.jdk>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -419,7 +423,7 @@
 							<toolchains>
 								<jdk>
 									<!-- Toolchain selected by maven/tycho-compiler for compilation and maven/tycho-surefire as JRE of launched test-runtimes-->
-									<version>${maven.compiler.release}</version>
+									<version>${toolchain.jdk}</version>
 								</jdk>
 							</toolchains>
 						</configuration>


### PR DESCRIPTION

This PR extends the GH workflow matrix for Xtext with an axis for the `jdkVersion` and `targetPlatform` version. So that all selected combinations are always build.
In order to limit the number of combinations only the oldest and latest supported Eclipse TP are build.

The incompatible combination of Java-11 and Eclipse 2023-06 (aka latest), that [matrix cell is excluded](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations).

Because the `coactions/setup-xvfb` can only execute a single command I had to adjust the `strict-release-jdk` a bit so that the the jdk can be configured via an extra property. I didn't found a solution to use the same approach as in the Jenkins file.

I tried 
```
      - name: Build and test
        uses: coactions/setup-xvfb@v1
        with: 
          run: "(if [[ ${{ matrix.jdkVersion }} == 11 ]]; then toolchainArgs='--toolchains ../releng/toolchains.xml -Pstrict-release-jdk';fi && \
            mvn clean verify -PuseJenkinsSnapshots $toolchainArgs -Dtarget-platform-classifier=xtext-${{ matrix.targetPlatform }})"
```
But then setup-xvfb only tried to run the command if and failed.
Personally I also find the approach used now simpler to read.

`--toolchains releng/toolchains.xml -Pstrict-release-jdk -Dtoolchain.jdk=17` is actually a NoOp and not specifying has the same result since JAVA_HOME points to the same JDK as jdk-17 from the toolchain.
Since I found it simpler to read I applied the same approach in the Jenkins workflow, but if you prefer the previous way I'll revert that part. 

In order to make the job labels not too long I also adjusted the `os` axis values.

You can see the results in my fork at:
https://github.com/HannesWell/eclipse.xtext/actions/runs/4757063052

From https://github.com/eclipse/xtext/pull/2223#issuecomment-1516145445
> It would be nice to have such a matrix in this repository, but due to the limitations of the usage of GitHub Actions shared by all Eclipse repositories, it wouldn't be feasible. Maybe just for Ubuntu and not macOS... maybe just nightly. We can investigate that in the future.

AFAIK the workflow resource quota is per organization, so if Xtext would have its own GH-organisation more resources would probably be available.


