### PR TITLE
Simplify JDK_VERSION parameter and make 17 the default value

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,15 +8,13 @@ pipeline {
   parameters {
     choice(name: 'TARGET_PLATFORM', choices: ['r202203', 'r202206', 'r202209', 'r202212', 'r202303', 'latest'], description: 'Which Target Platform should be used?')
     // see https://wiki.eclipse.org/Jenkins#JDK
-    choice(name: 'JDK_VERSION', description: 'Which JDK should be used?', choices: [
-       'temurin-jdk11-latest', 'temurin-jdk17-latest'
-    ])
+    choice(name: 'JDK_VERSION', choices: [ '11', '17' ], description: 'Which JDK version should be used?')
   }
 
   triggers {
     parameterizedCron(env.BRANCH_NAME == 'main' ? '''
-      H H(0-1) * * * %TARGET_PLATFORM=r202203;JDK_VERSION=temurin-jdk17-latest
-      H H(3-4) * * * %TARGET_PLATFORM=latest;JDK_VERSION=temurin-jdk17-latest
+      H H(0-1) * * * %TARGET_PLATFORM=r202203;JDK_VERSION=17
+      H H(3-4) * * * %TARGET_PLATFORM=latest;JDK_VERSION=17
       ''' : '')
   }
 
@@ -121,7 +119,7 @@ pipeline {
 
 /** return the Java version as Integer (8, 11, ...) */
 def javaVersion() {
-  return Integer.parseInt(params.JDK_VERSION.replaceAll(".*-jdk(\\d+).*", "\$1"))
+  return Integer.parseInt(params.JDK_VERSION)
 }
 
 /** returns true when this build was triggered by an upstream build */


### PR DESCRIPTION
Initially suggested in https://github.com/eclipse/xtext/pull/2223, but reverted to make that PR simpler to review, I now want to suggest again in a smaller scope to simplify the `JDK_VERSION` parameter of the Xtext's Jenkins pipeline.

Furthermore I assume that, although Xtext is compiled against Java-11 testing with Java-17 is often more interesting and therefore suggest to use 17 as default (and therefore as first). 
Or do you want to leave the Java-17 testing to the GH-workflows?

In the same sense it could also be considered to make the latest TP the default/first.