### PR TITLE
Don't run 'Build' GH workflow when tags are pushed

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+    branches: ['*'] # Run on any pushed branch, but not on any pushed tag
     paths-ignore:
       - '**.md'
   pull_request:


### PR DESCRIPTION
As desribed in the [GH workflow docs for the push event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push), if one specifies the `branches` filter all non-matching refs are ignored by the workflow.
Consequently when running on any branch, all tags are excluded.

Tested it in my fork and it worked as expected.

Fixes https://github.com/eclipse/xtext/issues/2644