### PR TITLE
harmonized maven-deploy-plugin

### DIFF
--- a/org.eclipse.xtend.maven.parent/pom.xml
+++ b/org.eclipse.xtend.maven.parent/pom.xml
@@ -55,22 +55,6 @@
 			</extension>
 		</extensions>
 		<plugins>
-			<!-- See https://jira.codehaus.org/browse/MINSTALL-102 -->
-			<plugin>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<configuration>
-					<bannedPlugins>
-						<excludes>
-							<exclude>org.apache.maven.plugins:maven-install-plugin</exclude>
-							<exclude>org.apache.maven.plugins:maven-deploy-plugin</exclude>
-						</excludes>
-						<includes>
-							<include>org.apache.maven.plugins:maven-install-plugin:2.5.2</include>
-							<include>org.apache.maven.plugins:maven-deploy-plugin:2.8.2</include>
-						</includes>
-					</bannedPlugins>
-				</configuration>
-			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
 				<executions>
@@ -107,13 +91,6 @@
 				<plugin>
 					<artifactId>maven-archetype-plugin</artifactId>
 					<version>3.0.1</version>
-				</plugin>
-				<plugin>
-					<artifactId>maven-deploy-plugin</artifactId>
-					<version>2.8.2</version>
-					<configuration>
-						<deployAtEnd>false</deployAtEnd>
-					</configuration>
 				</plugin>
 				<plugin>
 					<artifactId>maven-enforcer-plugin</artifactId>

--- a/org.eclipse.xtext.dev-bom/pom.xml
+++ b/org.eclipse.xtext.dev-bom/pom.xml
@@ -472,6 +472,18 @@
 		</dependencies>
 	</dependencyManagement>
 
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>3.0.0</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
 	<profiles>
 		<profile>
 			<id>sonatype-oss-release</id>

--- a/org.eclipse.xtext.maven.parent/pom.xml
+++ b/org.eclipse.xtext.maven.parent/pom.xml
@@ -36,22 +36,6 @@
 			</extension>
 		</extensions>
 		<plugins>
-			<!-- See https://jira.codehaus.org/browse/MINSTALL-102 -->
-			<plugin>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<configuration>
-					<bannedPlugins>
-						<excludes>
-							<exclude>org.apache.maven.plugins:maven-install-plugin</exclude>
-							<exclude>org.apache.maven.plugins:maven-deploy-plugin</exclude>
-						</excludes>
-						<includes>
-							<include>org.apache.maven.plugins:maven-install-plugin:2.5.2</include>
-							<include>org.apache.maven.plugins:maven-deploy-plugin:2.8.2</include>
-						</includes>
-					</bannedPlugins>
-				</configuration>
-			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
 				<executions>
@@ -84,13 +68,6 @@
 				<plugin>
 					<artifactId>maven-antrun-plugin</artifactId>
 					<version>3.1.0</version>
-				</plugin>
-				<plugin>
-					<artifactId>maven-deploy-plugin</artifactId>
-					<version>2.8.2</version>
-					<configuration>
-						<deployAtEnd>false</deployAtEnd>
-					</configuration>
 				</plugin>
 				<plugin>
 					<artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
This ensures that the `deploy-maven-plugin` is consistently used with the same version to avoid problems like https://github.com/eclipse/xtext/pull/2620#issuecomment-1550441789