### PR TITLE
Continuous deployment of the main branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,21 @@ pipeline {
         }
       }// END steps
     } // END stage
+
+    stage('Trigger Snapshot Deployment') {
+      when {
+        allOf {
+          expression {
+            currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')
+          }
+          branch 'main'
+        }
+      }
+      steps {
+        build job: "xtext-monorepo-full-deploy-nightly", wait: false
+      }
+    }
+
   } // END stages
 
   post {

--- a/jenkins/nightly-deploy/Jenkinsfile
+++ b/jenkins/nightly-deploy/Jenkinsfile
@@ -7,11 +7,6 @@ pipeline {
     timeout(time: 120, unit: 'MINUTES')
   }
 
-  // https://jenkins.io/doc/book/pipeline/syntax/#triggers
-  triggers {
-    cron('50 21 * * *') // nightly at 21:50
-  }
-
   environment {
     DOWNLOAD_AREA = '/home/data/httpd/download.eclipse.org/modeling/tmf/xtext'
     REPOSITORY_PATH="${DOWNLOAD_AREA}/updates/nightly"


### PR DESCRIPTION
Closes #2669 

Instead of triggering the nightly deployment job nightly, we trigger it from the main Jenkinsfile when something is pushed to `main`. Note that the trigger takes place only for the `main` branch and when the main job is NOT triggered manually nor on schedule.

This also removes the nightly schedule from the nightly job.

Of course, maybe we could rename the nightly job since it's not nightly anymore ;)
Maybe in another PR?

I would not rename the URL of the nightly update site, though.