### PR TITLE
[#2720] use import package for args4j in manifest

### DIFF
--- a/org.eclipse.xtext.xtext.wizard/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.wizard/META-INF/MANIFEST.MF
@@ -9,11 +9,12 @@ Export-Package: gradlew;x-internal:=true,
  org.eclipse.xtext.xtext.wizard;x-friends:="org.eclipse.xtext.tests,org.eclipse.xtext.xtext.ui,org.eclipse.xtext.xtext.ui.tests",
  org.eclipse.xtext.xtext.wizard.cli;x-friends:="org.eclipse.xtext.tests",
  org.eclipse.xtext.xtext.wizard.ecore2xtext;x-friends:="org.eclipse.xtext.xtext.ui,org.eclipse.xtext.xtext.ui.tests"
-Import-Package: org.apache.log4j;version="1.2.24"
+Import-Package: org.apache.log4j;version="1.2.24",
+ org.kohsuke.args4j;version="2.33.0",
+ org.kohsuke.args4j.spi;version="2.33.0"
 Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.32.0",
  org.eclipse.xtend.lib;resolution:=optional,
  org.eclipse.xtext.util,
- org.eclipse.emf.ecore;bundle-version="2.26.0",
- org.kohsuke.args4j;bundle-version="2.33.0"
+ org.eclipse.emf.ecore;bundle-version="2.26.0"
 Automatic-Module-Name: org.eclipse.xtext.xtext.wizard
 Eclipse-SourceReferences: eclipseSourceReferences


### PR DESCRIPTION
[#2720] use import package for args4j in manifest

this wont solve the same problem in category.xml / targets / features