### PR TITLE
Added getter for workingCopyOwner and toBeBuiltComputer with protected

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/XtextBuilder.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/XtextBuilder.java
@@ -807,5 +807,12 @@ public class XtextBuilder extends IncrementalProjectBuilder {
 		}
 		return installedCoreResourcesVersion.compareTo(version) >= 0;
 	}
+	
+	/**
+	 * @since 2.32
+	 */
+	protected ToBeBuiltComputer getToBeBuiltComputer() {
+		return toBeBuiltComputer;
+	}
 
 }

--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtTypeProvider.java
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtTypeProvider.java
@@ -685,5 +685,12 @@ public class JdtTypeProvider extends AbstractJvmTypeProvider implements IJdtType
 	public JdtBasedTypeFactory getJdtBasedTypeFactory() {
 		return typeFactory;
 	}
+	
+	/**
+	 * @since 2.32
+	 */
+	protected WorkingCopyOwner getWorkingCopyOwner() {
+		return workingCopyOwner;
+	}
 
 }


### PR DESCRIPTION
 Added getter for workingCopyOwner and toBeBuiltComputer with protected access for https://github.com/eclipse/xtext/issues/2756
Signed-off-by: Shashwat Anand <shashwat.work@gmail.com>