### PR TITLE
Removed usage of SybmolInformation from IDocumentSymbolServer and adapted other classes

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DocumentSymbolTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/DocumentSymbolTest.java
@@ -29,26 +29,74 @@ public class DocumentSymbolTest extends AbstractTestLangLanguageServerTest {
 			String expectedSymbols =
 					"symbol \"Foo\" {\n" +
 					"	kind: 7\n" +
-					"	location: MyModel.testlang [[0, 5] .. [0, 8]]\n" +
+					"    range: [[0, 0] .. [2, 1]]\n" +
+					"    selectionRange: [[0, 5] .. [0, 8]]\n" +
+					"    details: \n" +
+					"    deprecated: false\n" +
+					"    children: [\n" +		
+					"        symbol \"Foo.bar\" {\n" +
+					"            kind: 7\n" +
+					"            range: [[1, 1] .. [1, 8]]\n" +
+					"            selectionRange: [[1, 5] .. [1, 8]]\n" +
+					"            details: \n" +
+					"            deprecated: false\n" +
+					"            children: [\n" +
+					"                symbol \"Foo.bar.int\" {\n" +
+					"                    kind: 7\n" +
+					"                    range: [[1, 1] .. [1, 4]]\n" +
+					"                    selectionRange: [[1, 1] .. [1, 4]]\n" +
+					"                    details: \n" +
+					"                    deprecated: false\n" +
+					"                }\n" +
+					"            ]\n" +
+					"        }\n" +
+					"    ]\n" +
 					"}\n" +
 					"symbol \"Foo.bar\" {\n" +
-					"	kind: 7\n" +
-					"	location: MyModel.testlang [[1, 5] .. [1, 8]]\n" +
-					"	container: \"Foo\"\n" +
+					"    kind: 7\n" +
+					"    range: [[1, 1] .. [1, 8]]\n" +
+					"    selectionRange: [[1, 5] .. [1, 8]]\n" +
+					"    details: \n" +
+					"    deprecated: false\n" +
+					"    children: [\n" +
+					"        symbol \"Foo.bar.int\" {\n" +
+					"            kind: 7\n" +
+					"            range: [[1, 1] .. [1, 4]]\n" +
+					"            selectionRange: [[1, 1] .. [1, 4]]\n" +
+					"            details: \n" +
+					"            deprecated: false\n" +
+					"        }\n" +
+					"    ]\n" +
 					"}\n" +
 					"symbol \"Foo.bar.int\" {\n" +
-					"	kind: 7\n" +
-					"	location: MyModel.testlang [[1, 1] .. [1, 4]]\n" +
-					"	container: \"Foo.bar\"\n" +
+					"    kind: 7\n" +
+					"    range: [[1, 1] .. [1, 4]]\n" +
+					"    selectionRange: [[1, 1] .. [1, 4]]\n" +
+					"    details: \n" +
+					"    deprecated: false\n" +
 					"}\n" +
 					"symbol \"Bar\" {\n" +
-					"	kind: 7\n" +
-					"	location: MyModel.testlang [[3, 5] .. [3, 8]]\n" +
+					"    kind: 7\n" +
+					"    range: [[3, 0] .. [5, 1]]\n" +
+					"    selectionRange: [[3, 5] .. [3, 8]]\n" +
+					"    details: \n" +
+					"    deprecated: false\n" +
+					"    children: [\n" +
+					"        symbol \"Bar.foo\" {\n" +
+					"            kind: 7\n" +
+					"            range: [[4, 1] .. [4, 8]]\n" +
+					"            selectionRange: [[4, 5] .. [4, 8]]\n" +
+					"            details: \n" +
+					"            deprecated: false\n" +
+					"        }\n" +
+					"    ]\n" +
 					"}\n" +
 					"symbol \"Bar.foo\" {\n" +
-					"	kind: 7\n" +
-					"	location: MyModel.testlang [[4, 5] .. [4, 8]]\n" +
-					"	container: \"Bar\"\n" +
+					"    kind: 7\n" +
+					"    range: [[4, 1] .. [4, 8]]\n" +
+					"    selectionRange: [[4, 5] .. [4, 8]]\n" +
+					"    details: \n" +
+					"    deprecated: false\n" +
 					"}\n";
 			it.setExpectedSymbols(
 					expectedSymbols);

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolMapper.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/DocumentSymbolMapper.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.ide.server.symbol;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
@@ -16,6 +17,7 @@ import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.xtext.ide.server.DocumentExtensions;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.naming.QualifiedName;
@@ -185,6 +187,9 @@ public class DocumentSymbolMapper {
 			documentSymbol.setSelectionRange(objectSelectionRange);
 		}
 		documentSymbol.setDetail(detailsProvider.getDetails(object));
+		if (deprecationInfoProvider.isDeprecated(object)) {
+			documentSymbol.setTags(List.of(SymbolTag.Deprecated));
+		}
 		documentSymbol.setDeprecated(deprecationInfoProvider.isDeprecated(object));
 		documentSymbol.setChildren(new ArrayList<>());
 		return documentSymbol;

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/HierarchicalDocumentSymbolService.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/HierarchicalDocumentSymbolService.java
@@ -14,15 +14,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
-import org.eclipse.lsp4j.SymbolInformation;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.ide.server.Document;
 import org.eclipse.xtext.resource.XtextResource;
@@ -77,15 +75,14 @@ public class HierarchicalDocumentSymbolService implements IDocumentSymbolService
 	}
 
 	@Override
-	public List<Either<SymbolInformation, DocumentSymbol>> getSymbols(Document document, XtextResource resource,
+	public List<DocumentSymbol> getSymbols(Document document, XtextResource resource,
 			DocumentSymbolParams params, CancelIndicator cancelIndicator) {
 		return getSymbols(resource, cancelIndicator);
 	}
 
-	public List<Either<SymbolInformation, DocumentSymbol>> getSymbols(XtextResource resource,
-			CancelIndicator cancelIndicator) {
-		HashMap<EObject, DocumentSymbol> allSymbols = new HashMap<>();
-		ArrayList<DocumentSymbol> rootSymbols = new ArrayList<>();
+	public List<DocumentSymbol> getSymbols(XtextResource resource, CancelIndicator cancelIndicator) {
+		Map<EObject, DocumentSymbol> allSymbols = new HashMap<>();
+		List<DocumentSymbol> rootSymbols = new ArrayList<>();
 		Iterator<Object> itr = getAllContents(resource);
 		while (itr.hasNext()) {
 			operationCanceledManager.checkCanceled(cancelIndicator);
@@ -113,8 +110,7 @@ public class HierarchicalDocumentSymbolService implements IDocumentSymbolService
 				}
 			}
 		}
-		return rootSymbols.stream().map(symbol -> Either.<SymbolInformation, DocumentSymbol>forRight(symbol))
-				.collect(Collectors.toList());
+		return rootSymbols;
 	}
 
 	protected Iterator<Object> getAllContents(Resource resource) {

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/IDocumentSymbolService.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/IDocumentSymbolService.java
@@ -14,8 +14,6 @@ import java.util.List;
 
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
-import org.eclipse.lsp4j.SymbolInformation;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtext.ide.server.Document;
 import org.eclipse.xtext.ide.server.symbol.IDocumentSymbolService.Noop;
 import org.eclipse.xtext.resource.XtextResource;
@@ -40,13 +38,13 @@ import com.google.inject.ImplementedBy;
 @ImplementedBy(Noop.class)
 public interface IDocumentSymbolService {
 
-	List<Either<SymbolInformation, DocumentSymbol>> getSymbols(Document document, XtextResource resource,
+	List<DocumentSymbol> getSymbols(Document document, XtextResource resource,
 			DocumentSymbolParams params, CancelIndicator cancelIndicator);
 
 	public static class Noop implements IDocumentSymbolService {
 
 		@Override
-		public List<Either<SymbolInformation, DocumentSymbol>> getSymbols(Document document, XtextResource resource,
+		public List<DocumentSymbol> getSymbols(Document document, XtextResource resource,
 				DocumentSymbolParams params, CancelIndicator cancelIndicator) {
 
 			return emptyList();

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/WorkspaceSymbolService.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/symbol/WorkspaceSymbolService.java
@@ -8,20 +8,19 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.server.symbol;
 
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
-
 import java.util.LinkedList;
 import java.util.List;
-import org.eclipse.lsp4j.SymbolInformation;
+
 import org.eclipse.lsp4j.WorkspaceSymbol;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtext.findReferences.IReferenceFinder.IResourceAccess;
 import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
 import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.util.CancelIndicator;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 /**
  * @author kosyakov - Initial contribution and API
@@ -36,13 +35,13 @@ public class WorkspaceSymbolService {
 	@Inject
 	private OperationCanceledManager operationCanceledManager;
 
-	public Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>> getSymbols(
+	public List<? extends WorkspaceSymbol> getSymbols(
 		String query,
 		IResourceAccess resourceAccess,
 		IResourceDescriptions indexData,
 		CancelIndicator cancelIndicator
 	) {
-		List<SymbolInformation> result = new LinkedList<>();
+		List<WorkspaceSymbol> result = new LinkedList<>();
 		for (IResourceDescription resourceDescription : indexData.getAllResourceDescriptions()) {
 			operationCanceledManager.checkCanceled(cancelIndicator);
 			IResourceServiceProvider resourceServiceProvider = registry.getResourceServiceProvider(resourceDescription.getURI());
@@ -53,7 +52,7 @@ public class WorkspaceSymbolService {
 				}
 			}
 		}
-		return Either.forLeft(result);
+		return result;
 	}
 
 }

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/AbstractLanguageServerTest.xtend
@@ -653,7 +653,7 @@ abstract class AbstractLanguageServerTest implements Endpoint {
 		if (configuration.getAssertSymbols !== null) {
 			configuration.getAssertSymbols.apply(symbols)
 		} else {
-			val unwrappedSymbols = symbols.map[if (hierarchicalDocumentSymbolSupport) getRight else getLeft]
+			val unwrappedSymbols = symbols.map[getRight]
 			val String actualSymbols = unwrappedSymbols.toExpectation
 			assertEquals(getExpectedSymbols, actualSymbols)
 		}

--- a/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
+++ b/org.eclipse.xtext.testing/xtend-gen/org/eclipse/xtext/testing/AbstractLanguageServerTest.java
@@ -1331,16 +1331,10 @@ public abstract class AbstractLanguageServerTest implements Endpoint {
       if (_tripleNotEquals) {
         configuration.getAssertSymbols().apply(symbols);
       } else {
-        final Function1<Either<SymbolInformation, DocumentSymbol>, Object> _function = (Either<SymbolInformation, DocumentSymbol> it) -> {
-          Object _xifexpression = null;
-          if (this.hierarchicalDocumentSymbolSupport) {
-            _xifexpression = it.getRight();
-          } else {
-            _xifexpression = it.getLeft();
-          }
-          return _xifexpression;
+        final Function1<Either<SymbolInformation, DocumentSymbol>, DocumentSymbol> _function = (Either<SymbolInformation, DocumentSymbol> it) -> {
+          return it.getRight();
         };
-        final List<Object> unwrappedSymbols = ListExtensions.<Either<SymbolInformation, DocumentSymbol>, Object>map(symbols, _function);
+        final List<DocumentSymbol> unwrappedSymbols = ListExtensions.<Either<SymbolInformation, DocumentSymbol>, DocumentSymbol>map(symbols, _function);
         final String actualSymbols = this.toExpectation(unwrappedSymbols);
         this.assertEquals(configuration.getExpectedSymbols(), actualSymbols);
       }


### PR DESCRIPTION
I didn't add any new tests as all ide tests were green. Please let me know if I can add any tests for any missing coverage for this issue (https://github.com/eclipse/xtext/issues/2179).