### PR TITLE
[#2318] Clean AllAssociation when removing field

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AnnotationPropertyRemoveTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AnnotationPropertyRemoveTest.xtend
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2023 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.macro
+
+import java.io.ByteArrayOutputStream
+import java.lang.annotation.Target
+import java.util.List
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtend.lib.macro.AbstractClassProcessor
+import org.eclipse.xtend.lib.macro.Active
+import org.eclipse.xtend.lib.macro.RegisterGlobalsContext
+import org.eclipse.xtend.lib.macro.TransformationContext
+import org.eclipse.xtend.lib.macro.declaration.ClassDeclaration
+import org.eclipse.xtend.lib.macro.declaration.MutableClassDeclaration
+import org.eclipse.xtend.lib.macro.declaration.MutableFieldDeclaration
+import org.eclipse.xtext.resource.persistence.StorageAwareResource
+import org.eclipse.xtext.xbase.resource.BatchLinkableResourceStorageWritable
+import org.junit.Test
+
+/**
+ * @author Didier Vojtisek - Initial contribution and API
+ */
+class AnnotationPropertyRemoveTest extends AbstractActiveAnnotationTest {
+
+	@Test def void testAnnotationPropertyRemove_01() {
+		'''
+			@org.eclipse.xtend.core.tests.macro.RemoveUnderscoreAnnotation()
+			class TestClass {
+				public String foo
+				
+				public String _ba 
+			}
+		'''.assertCompilesTo('''
+			import org.eclipse.xtend.core.tests.macro.RemoveUnderscoreAnnotation;
+			
+			@RemoveUnderscoreAnnotation
+			@SuppressWarnings("all")
+			public class TestClass {
+			  public String foo;
+			}
+		''')
+	}
+
+	@Test def void testresourceStorageWrite() {
+		val contents = '''
+			@org.eclipse.xtend.core.tests.macro.RemoveUnderscoreAnnotation()
+			class AnnotationPropertyRemoveTestClass {
+				public String foo
+				
+				public String _ba 
+			}
+		'''
+
+		val file = file(contents)
+		new BatchLinkableResourceStorageWritable(new ByteArrayOutputStream, false) {
+			override String getFragment(EObject obj) {
+				assertTrue(obj.toString + " is not contained in any resource ", obj.eResource() !== null)
+				return super.getFragment(obj)
+			}
+		}.writeResource(file.eResource as StorageAwareResource)
+
+	}
+}
+
+@Active(RemoveUnderscoreAnnotationProcessor)
+@Target(TYPE)
+annotation RemoveUnderscoreAnnotation {
+}
+
+class RemoveUnderscoreAnnotationProcessor extends AbstractClassProcessor {
+
+	override doRegisterGlobals(ClassDeclaration annotatedClass, extension RegisterGlobalsContext context) {
+		super.doRegisterGlobals(annotatedClass, context)
+	}
+
+	override doTransform(MutableClassDeclaration annotatedClass, extension TransformationContext context) {
+		super.doTransform(annotatedClass, context)
+		val List<MutableFieldDeclaration> toRemove = newArrayList
+		// remove fields starting with "_"
+		for (f : annotatedClass.declaredFields) {
+			if (f.simpleName.startsWith("_")) {
+				toRemove.add(f)
+			}
+		}
+		toRemove.forEach[f|f.remove]
+	}
+
+}

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AnnotationPropertyRemoveTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AnnotationPropertyRemoveTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2023 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.xtend.core.tests.macro;
+
+import java.io.ByteArrayOutputStream;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtend.core.xtend.XtendFile;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.resource.persistence.StorageAwareResource;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.resource.BatchLinkableResourceStorageWritable;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Didier Vojtisek - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class AnnotationPropertyRemoveTest extends AbstractActiveAnnotationTest {
+  @Test
+  public void testAnnotationPropertyRemove_01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("@org.eclipse.xtend.core.tests.macro.RemoveUnderscoreAnnotation()");
+    _builder.newLine();
+    _builder.append("class TestClass {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("public String foo");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("public String _ba ");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.eclipse.xtend.core.tests.macro.RemoveUnderscoreAnnotation;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@RemoveUnderscoreAnnotation");
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class TestClass {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public String foo;");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this._xtendCompilerTester.assertCompilesTo(_builder, _builder_1);
+  }
+
+  @Test
+  public void testresourceStorageWrite() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("@org.eclipse.xtend.core.tests.macro.RemoveUnderscoreAnnotation()");
+      _builder.newLine();
+      _builder.append("class AnnotationPropertyRemoveTestClass {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("public String foo");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("public String _ba ");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final String contents = _builder.toString();
+      final XtendFile file = this.file(contents);
+      ByteArrayOutputStream _byteArrayOutputStream = new ByteArrayOutputStream();
+      Resource _eResource = file.eResource();
+      new BatchLinkableResourceStorageWritable(_byteArrayOutputStream, false) {
+        @Override
+        public String getFragment(final EObject obj) {
+          String _string = obj.toString();
+          String _plus = (_string + " is not contained in any resource ");
+          Resource _eResource = obj.eResource();
+          boolean _tripleNotEquals = (_eResource != null);
+          Assert.assertTrue(_plus, _tripleNotEquals);
+          return super.getFragment(obj);
+        }
+      }.writeResource(((StorageAwareResource) _eResource));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/JvmBasedDeclarations.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/JvmBasedDeclarations.xtend
@@ -1320,6 +1320,8 @@ class JvmFieldDeclarationImpl extends JvmMemberDeclarationImpl<JvmField> impleme
 	}
 	
 	override remove() {
+		compilationUnit.jvmModelAssociator.removeAllAssociation(delegate.type)
+		compilationUnit.jvmModelAssociator.removeAllAssociation(delegate)
 		compilationUnit.jvmModelAssociator.removeLogicalChildAssociation(delegate)
 		super.remove()
 	}


### PR DESCRIPTION
This PR contributes to https://github.com/eclipse/xtext/issues/2318

- adds a test highlighting the issue  (the test `testresourceStorageWrite` fails if the fix below isn't applied)
- applies the suggested correction in `org/eclipse/xtend/core/macro/declaration/JvmBasedDeclarations.xtend` 
