### PR TITLE
Ignore NumberLiterals without CompositeNode in HighlightingCalculator

### DIFF
--- a/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/highlighting/XbaseHighlightingCalculator.java
+++ b/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/highlighting/XbaseHighlightingCalculator.java
@@ -379,8 +379,10 @@ public class XbaseHighlightingCalculator extends DefaultSemanticHighlightingCalc
 	
 	protected void highlightNumberLiterals(XNumberLiteral literal, IHighlightedPositionAcceptor acceptor) {
 		ICompositeNode node = NodeModelUtils.findActualNodeFor(literal);
-		ITextRegion textRegion = node.getTextRegion();
-		acceptor.addPosition(textRegion.getOffset(), textRegion.getLength(), NUMBER_ID);
+		if (node != null) {
+			ITextRegion textRegion = node.getTextRegion();
+			acceptor.addPosition(textRegion.getOffset(), textRegion.getLength(), NUMBER_ID);
+		}
 	}
 	
 	protected void highlightConstructorCall(XConstructorCall constructorCall, IHighlightedPositionAcceptor acceptor) {


### PR DESCRIPTION
We have a customized language where we inject extra objects into the AST that don't have a corresponding text node.
Consequently the node is null, which breaks the standard `XbaseHighlightingCalculator`. In all other cases null nodes are ignored too.