### PR TITLE
Update `XtextFormattingTokenSerializer` references in JavaDocs

### DIFF
--- a/org.eclipse.xtext.testlanguages/src/org/eclipse/xtext/testlanguages/backtracking/formatting/BeeLangTestLanguageFormatter.java
+++ b/org.eclipse.xtext.testlanguages/src/org/eclipse/xtext/testlanguages/backtracking/formatting/BeeLangTestLanguageFormatter.java
@@ -17,7 +17,7 @@ import org.eclipse.xtext.formatting.impl.FormattingConfig;
  * See https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#formatting
  * on how and when to use it.
  * 
- * Also see {@link org.eclipse.xtext.xtext.XtextFormattingTokenSerializer} as an example
+ * Also see {@link org.eclipse.xtext.xtext.XtextFormatter} as an example
  */
 public class BeeLangTestLanguageFormatter extends AbstractDeclarativeFormatter {
 	

--- a/org.eclipse.xtext.testlanguages/src/org/eclipse/xtext/testlanguages/backtracking/formatting/ExBeeLangTestLanguageFormatter.java
+++ b/org.eclipse.xtext.testlanguages/src/org/eclipse/xtext/testlanguages/backtracking/formatting/ExBeeLangTestLanguageFormatter.java
@@ -17,7 +17,7 @@ import org.eclipse.xtext.formatting.impl.FormattingConfig;
  * See https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#formatting
  * on how and when to use it.
  * 
- * Also see {@link org.eclipse.xtext.xtext.XtextFormattingTokenSerializer} as an example
+ * Also see {@link org.eclipse.xtext.xtext.XtextFormatter} as an example
  */
 public class ExBeeLangTestLanguageFormatter extends AbstractDeclarativeFormatter {
 	

--- a/org.eclipse.xtext.testlanguages/src/org/eclipse/xtext/testlanguages/backtracking/formatting/SimpleBeeLangTestLanguageFormatter.java
+++ b/org.eclipse.xtext.testlanguages/src/org/eclipse/xtext/testlanguages/backtracking/formatting/SimpleBeeLangTestLanguageFormatter.java
@@ -17,7 +17,7 @@ import org.eclipse.xtext.formatting.impl.FormattingConfig;
  * See https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#formatting
  * on how and when to use it.
  * 
- * Also see {@link org.eclipse.xtext.xtext.XtextFormattingTokenSerializer} as an example
+ * Also see {@link org.eclipse.xtext.xtext.XtextFormatter} as an example
  */
 public class SimpleBeeLangTestLanguageFormatter extends AbstractDeclarativeFormatter {
 	

--- a/org.eclipse.xtext.ui.codetemplates/src/org/eclipse/xtext/ui/codetemplates/formatting/CodetemplatesFormatter.java
+++ b/org.eclipse.xtext.ui.codetemplates/src/org/eclipse/xtext/ui/codetemplates/formatting/CodetemplatesFormatter.java
@@ -17,7 +17,7 @@ import org.eclipse.xtext.formatting.impl.FormattingConfig;
  * See https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#formatting
  * on how and when to use it.
  * 
- * Also see {@link org.eclipse.xtext.xtext.XtextFormattingTokenSerializer} as an example
+ * Also see {@link org.eclipse.xtext.xtext.XtextFormatter} as an example
  */
 public class CodetemplatesFormatter extends AbstractDeclarativeFormatter {
 	

--- a/org.eclipse.xtext.ui.codetemplates/src/org/eclipse/xtext/ui/codetemplates/formatting/TemplatesFormatter.java
+++ b/org.eclipse.xtext.ui.codetemplates/src/org/eclipse/xtext/ui/codetemplates/formatting/TemplatesFormatter.java
@@ -17,7 +17,7 @@ import org.eclipse.xtext.formatting.impl.FormattingConfig;
  * See https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#formatting
  * on how and when to use it.
  * 
- * Also see {@link org.eclipse.xtext.xtext.XtextFormattingTokenSerializer} as an example
+ * Also see {@link org.eclipse.xtext.xtext.XtextFormatter} as an example
  */
 public class TemplatesFormatter extends AbstractDeclarativeFormatter {
 	

--- a/org.eclipse.xtext.web/src/test/java/org/eclipse/xtext/web/server/test/languages/formatting/StatemachineFormatter.java
+++ b/org.eclipse.xtext.web/src/test/java/org/eclipse/xtext/web/server/test/languages/formatting/StatemachineFormatter.java
@@ -21,7 +21,7 @@ import com.google.inject.Inject;
  * https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#formatting
  * on how and when to use it.
  * 
- * Also see {@link org.eclipse.xtext.xtext.XtextFormattingTokenSerializer} as an
+ * Also see {@link org.eclipse.xtext.xtext.XtextFormatter} as an
  * example
  */
 public class StatemachineFormatter extends AbstractDeclarativeFormatter {


### PR DESCRIPTION
The `XtextFormattingTokenSerializer` referred to in JavaDocs no longer exists and it seems to have been refactored into the [`XtextFormatter`](https://github.com/eclipse/xtext/blob/main/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextFormatter.java).