### PR TITLE
Collect outgoing siblings for UnorderedGroup

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/grammaranalysis/impl/AbstractNFAState.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/grammaranalysis/impl/AbstractNFAState.java
@@ -170,7 +170,7 @@ public class AbstractNFAState<S extends INFAState<S, T>, T extends INFATransitio
 					} else {
 						AbstractElement next = siblings.get(i + 1);
 						addOutgoing(next, visited, isRuleCall, loopCenter);
-						if (GrammarUtil.isOptionalCardinality(next))
+						if (GrammarUtil.isOptionalCardinality(next) || container instanceof UnorderedGroup)
 							collectOutgoingByContainer(next, visited, isRuleCall, loopCenter);
 					}
 					break;
@@ -182,7 +182,7 @@ public class AbstractNFAState<S extends INFAState<S, T>, T extends INFATransitio
 					} else {
 						AbstractElement next = siblings.get(i - 1);
 						addOutgoing(next, visited, isRuleCall, loopCenter);
-						if (GrammarUtil.isOptionalCardinality(next))
+						if (GrammarUtil.isOptionalCardinality(next) || container instanceof UnorderedGroup)
 							collectOutgoingByContainer(next, visited, isRuleCall, loopCenter);
 					}
 					break;


### PR DESCRIPTION
CollectOutgoingByContainer will stop collecting the next siblings if the next to it is mandatory, because it is expected to appear in that order. Handle unordered groups as well to collect all of the outgoing siblings.