### PR TITLE
Plugin test projects should not use "target/test-classes" in .classpath

### DIFF
--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/XtextProjectCreator.java
@@ -117,7 +117,12 @@ public class XtextProjectCreator extends WorkspaceModifyOperation implements IPr
 		factory.addProjectNatures(JavaCore.NATURE_ID);
 		factory.addBuilderIds(JavaCore.BUILDER_ID);
 		for (SourceFolderDescriptor sourceFolder : descriptor.getSourceFolders()) {
-			String output = sourceFolder.isTest() ? (needsM2eIntegration(descriptor) ? "target/test-classes" : "test-bin") : null;
+			String output = sourceFolder.isTest() ?
+				(needsM2eIntegration(descriptor) ? 
+					(needsTychoIntegration(descriptor) ?
+						"target/classes" : // Tycho will generate into target/classes for eclipse-plugin-test projects
+						"target/test-classes")
+					: "test-bin") : null;
 			factory.addSourceFolder(sourceFolder.getPath(), output, sourceFolder.isTest());
 		}
 		factory.setJreContainerEntry(JREContainerProvider.getJREContainerEntry(descriptor.getBree()));
@@ -285,6 +290,10 @@ public class XtextProjectCreator extends WorkspaceModifyOperation implements IPr
 
 	private boolean needsM2eIntegration(ProjectDescriptor descriptor) {
 		return descriptor.isPartOfMavenBuild() && descriptor.getConfig().needsMavenBuild();
+	}
+
+	private boolean needsTychoIntegration(ProjectDescriptor descriptor) {
+		return descriptor.isPartOfMavenBuild() && descriptor.getConfig().needsTychoBuild();
 	}
 
 	private boolean needsBuildshipIntegration(ProjectDescriptor descriptor) {


### PR DESCRIPTION
https://github.com/eclipse/xtext/issues/2498

Closes #2498 

Note that our Cli tests do not use the XtextProjectCreator, so they don't generate .classpath.
So, I tested this manually.