### PR TITLE
Replace dependency to org.eclipse.osgi.services

### DIFF
--- a/org.eclipse.xtend.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide/META-INF/MANIFEST.MF
@@ -29,9 +29,9 @@ Require-Bundle: org.eclipse.xtend.core,
  org.eclipse.xtext.xbase.lib;bundle-version="2.34.0",
  org.eclipse.jdt.core.manipulation;bundle-version="1.16.0";resolution:=optional,
  org.eclipse.e4.core.services,
- org.eclipse.osgi.services,
  org.eclipse.e4.ui.css.swt.theme;bundle-version="0.13.0"
-Import-Package: org.apache.log4j;version="1.2.24"
+Import-Package: org.apache.log4j;version="1.2.24",
+ org.osgi.service.event;version="[1.4.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Activator: org.eclipse.xtend.ide.XtendActivator
 Export-Package: org.eclipse.xtend.ide;x-internal:=true,


### PR DESCRIPTION
The bundle `o.e.osgi.services` is deprecated for removal as part of https://github.com/eclipse-equinox/equinox/issues/18 and already has been changed to be empty and only re-export the 'official' OSGi artifacts published to Maven-Central.

It should be replaced by imports of the desired org.osgi.service.* packages so that the runtime can choose a suitable provider independently of the bundle name.