### PR TITLE
don't retrieve the ImportManager by reflection

### DIFF
--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.xtend
@@ -804,7 +804,7 @@ class JvmModelGenerator implements IGenerator {
 				generateDocumentation(adapter.documentation, emptyList, appendable, config)
 			}
 		}
-	} 
+	}
 	
 	def addJavaDocImports(EObject it, ITreeAppendable appendable,List<INode> documentationNodes) {
 		for(node : documentationNodes){
@@ -839,12 +839,7 @@ class JvmModelGenerator implements IGenerator {
 	}
 
 	def getImportManager(ITreeAppendable appendable) {
-		val stateField = appendable.getClass.getDeclaredField("state")
-		stateField.setAccessible(true)
-		val stateValue = stateField.get(appendable)
-		val importManagerField = stateValue.getClass.getDeclaredField("importManager")
-		importManagerField.setAccessible(true)
-		importManagerField.get(stateValue) as ImportManager
+		(appendable as TreeAppendable).getImportManager()
 	}
 
 	def protected generateDocumentation(String text, List<INode> documentationNodes, ITreeAppendable appendable, GeneratorConfig config) {
@@ -886,7 +881,7 @@ class JvmModelGenerator implements IGenerator {
 				toJava(appendable, config)
 			])
 	}
-	 
+	
 	def void toJava(JvmAnnotationValue it, ITreeAppendable appendable, GeneratorConfig config) {
 		if (operation !== null) {
 			if (operation.simpleName === null) {
@@ -899,11 +894,11 @@ class JvmModelGenerator implements IGenerator {
 		}
 		toJavaLiteral(appendable, config)
 	}
-		
+	
 	def dispatch void toJavaLiteral(JvmAnnotationAnnotationValue value, ITreeAppendable appendable, GeneratorConfig config) {
 		appendable.forEachWithShortcut(value.values, [generateAnnotation(appendable, config)])
 	}
-		
+	
 	def dispatch void toJavaLiteral(JvmShortAnnotationValue it, ITreeAppendable appendable, GeneratorConfig config) {
 		appendable.forEachWithShortcut(values, [appendable.append(toString)])
 	}
@@ -955,12 +950,12 @@ class JvmModelGenerator implements IGenerator {
 			appendable.append('"' + doConvertToJavaString(toString) + '"')
 		])
 	}
-		
+	
 	def dispatch void toJavaLiteral(JvmTypeAnnotationValue it, ITreeAppendable appendable, GeneratorConfig config) {
 		appendable.forEachWithShortcut(values, [
 			appendable.append(type).append(".class")
 		])
-	} 
+	}
 	
 	def dispatch void toJavaLiteral(JvmEnumAnnotationValue it, ITreeAppendable appendable, GeneratorConfig config) {
 		appendable.forEachWithShortcut(values, [
@@ -968,13 +963,13 @@ class JvmModelGenerator implements IGenerator {
 			appendable.append(".")
 			appendable.append(simpleName.makeJavaIdentifier)
 		])
-	} 
-		
+	}
+	
 	def dispatch void toJavaLiteral(JvmBooleanAnnotationValue it, ITreeAppendable appendable, GeneratorConfig config) {
 		appendable.forEachWithShortcut(values, [
 			appendable.append(toString)			
 		])
-	} 
+	}
 	
 	def dispatch void toJavaLiteral(JvmCustomAnnotationValue it, ITreeAppendable appendable, GeneratorConfig config) {
 		if(values.isEmpty)
@@ -984,7 +979,7 @@ class JvmModelGenerator implements IGenerator {
 				compiler.toJavaExpression(it, appendable)
 			])
 	}
-		
+	
 	def TreeAppendable createAppendable(EObject context, ImportManager importManager, GeneratorConfig config) {
 		val cachingConverter = new ITraceURIConverter() {
 			

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/output/TreeAppendable.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/output/TreeAppendable.java
@@ -589,7 +589,10 @@ public class TreeAppendable implements ITreeAppendable, IAcceptor<String>, CharS
 		return state;
 	}
 	
-	ImportManager getImportManager() {
+	/**
+	 * @since 2.34
+	 */
+	public ImportManager getImportManager() {
 		return state.getImportManager();
 	}
 	

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/compiler/JvmModelGenerator.java
@@ -12,7 +12,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -1226,21 +1225,7 @@ public class JvmModelGenerator implements IGenerator {
   }
 
   public ImportManager getImportManager(final ITreeAppendable appendable) {
-    try {
-      ImportManager _xblockexpression = null;
-      {
-        final Field stateField = appendable.getClass().getDeclaredField("state");
-        stateField.setAccessible(true);
-        final Object stateValue = stateField.get(appendable);
-        final Field importManagerField = stateValue.getClass().getDeclaredField("importManager");
-        importManagerField.setAccessible(true);
-        Object _get = importManagerField.get(stateValue);
-        _xblockexpression = ((ImportManager) _get);
-      }
-      return _xblockexpression;
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+    return ((TreeAppendable) appendable).getImportManager();
   }
 
   protected ITreeAppendable generateDocumentation(final String text, final List<INode> documentationNodes, final ITreeAppendable appendable, final GeneratorConfig config) {


### PR DESCRIPTION
Since we already assume that the import manager is part of the appendable, which is a TreeAppendable, I think it's better to do the case and expose getImportManager in TreeAppendable than to call that method with two reflective calls.
This would also allow clients to provide a custom TreeAppendable; with the reflective call this latter use-case would not be supported