### PR TITLE
Xbase/Xtend refactoring

### DIFF
--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
@@ -576,20 +576,7 @@ public class XtendCompiler extends XbaseCompiler {
 		} else
 			return super.internalCanCompileToJavaExpression(expression, appendable);
 	}
-	
-	@Override
-	protected boolean isVariableDeclarationRequired(XExpression expr, ITreeAppendable b, boolean recursive) {
-		if (expr instanceof XConstructorCall) {
-			XConstructorCall constructorCall = (XConstructorCall) expr;
-			if (constructorCall.isAnonymousClassConstructorCall()) {
-				EObject container = expr.eContainer();
-				return isVariableDeclarationRequired((XExpression) container, b, recursive) &&
-					!canCompileToJavaAnonymousClass(constructorCall);
-			}
-		}
-		return super.isVariableDeclarationRequired(expr, b, recursive);
-	}
-	
+
 	@Override
 	/* @Nullable */
 	protected String getReferenceName(XExpression expr, ITreeAppendable b) {

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
@@ -357,7 +357,7 @@ public class XtendCompiler extends XbaseCompiler {
 	}
 	
 	@Override
-	public void doInternalToJavaStatement(XExpression obj, ITreeAppendable appendable, boolean isReferenced) {
+	protected void doInternalToJavaStatement(XExpression obj, ITreeAppendable appendable, boolean isReferenced) {
 		prependLocalTypesIfFieldInitializer(obj, appendable, isReferenced);
 		if(obj instanceof AnonymousClass) 
 			_toJavaStatement((AnonymousClass)obj, appendable, isReferenced);
@@ -374,7 +374,7 @@ public class XtendCompiler extends XbaseCompiler {
 		}
 	}
 	
-	public void _toJavaStatement(RichString richString, ITreeAppendable b, boolean isReferenced) {
+	private void _toJavaStatement(RichString richString, ITreeAppendable b, boolean isReferenced) {
 		LightweightTypeReference actualType = getLightweightType(richString);
 		b = b.trace(richString);
 		if (actualType.isType(StringConcatenationClient.class)) {
@@ -416,7 +416,7 @@ public class XtendCompiler extends XbaseCompiler {
 	}
 
 	@Override
-	public void internalToConvertedExpression(XExpression obj, ITreeAppendable appendable) {
+	protected void internalToConvertedExpression(XExpression obj, ITreeAppendable appendable) {
 		if (obj instanceof AnonymousClass)
 			_toJavaExpression((AnonymousClass) obj, appendable);
 		else if (obj instanceof RichString)
@@ -425,7 +425,7 @@ public class XtendCompiler extends XbaseCompiler {
 			super.internalToConvertedExpression(obj, appendable);
 	}
 	
-	protected void _toJavaExpression(AnonymousClass anonymousClass, ITreeAppendable b) {
+	private void _toJavaExpression(AnonymousClass anonymousClass, ITreeAppendable b) {
 		String varName = getReferenceName(anonymousClass, b);
 		if (varName != null) {
 			b.trace(anonymousClass, false).append(varName);
@@ -445,7 +445,7 @@ public class XtendCompiler extends XbaseCompiler {
 		}
 	}
 
-	protected void compileAnonymousClassBody(AnonymousClass anonymousClass, JvmDeclaredType type, ITreeAppendable b) {
+	private void compileAnonymousClassBody(AnonymousClass anonymousClass, JvmDeclaredType type, ITreeAppendable b) {
 		ITreeAppendable appendable = b.trace(anonymousClass, true);
 		appendable.append(" ");
 		appendable.openScope();
@@ -455,7 +455,7 @@ public class XtendCompiler extends XbaseCompiler {
 		appendable.closeScope();
 	}
 	
-	public void _toJavaExpression(RichString richString, ITreeAppendable b) {
+	private void _toJavaExpression(RichString richString, ITreeAppendable b) {
 		b.append(getVarName(richString, b));
 		if(getLightweightType(richString).isType(String.class))
 			b.append(".toString()");
@@ -468,7 +468,7 @@ public class XtendCompiler extends XbaseCompiler {
 		super.appendCatchClauseParameter(catchClause, parameterType, parameterName, appendable);
 	}
 
-	protected void appendExtensionAnnotation(JvmFormalParameter parameter, EObject context,
+	private void appendExtensionAnnotation(JvmFormalParameter parameter, EObject context,
 			ITreeAppendable appendable, boolean newLine) {
 		if (parameter instanceof XtendFormalParameter) {
 			XtendFormalParameter castedParameter = (XtendFormalParameter) parameter;
@@ -478,7 +478,7 @@ public class XtendCompiler extends XbaseCompiler {
 		}
 	}
 
-	protected void appendExtensionAnnotation(EObject context, ITreeAppendable appendable, boolean newLine) {
+	private void appendExtensionAnnotation(EObject context, ITreeAppendable appendable, boolean newLine) {
 		JvmType extension = findKnownTopLevelType(Extension.class, context);
 		if (extension != null) {
 			appendable.append("@");
@@ -538,8 +538,8 @@ public class XtendCompiler extends XbaseCompiler {
 	public void _toJavaStatement(final XStringLiteral expr, ITreeAppendable b, boolean isReferenced) {
 		toJavaStatement(expr, b, isReferenced, false);
 	}
-	
-	protected void _toJavaStatement(final AnonymousClass anonymousClass, ITreeAppendable b, final boolean isReferenced) {
+
+	private void _toJavaStatement(final AnonymousClass anonymousClass, ITreeAppendable b, final boolean isReferenced) {
 		_toJavaStatement(anonymousClass.getConstructorCall(), b, isReferenced);
 	}
 

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
@@ -374,7 +374,7 @@ public class XtendCompiler extends XbaseCompiler {
 		}
 	}
 	
-	private void _toJavaStatement(RichString richString, ITreeAppendable b, boolean isReferenced) {
+	protected void _toJavaStatement(RichString richString, ITreeAppendable b, boolean isReferenced) {
 		LightweightTypeReference actualType = getLightweightType(richString);
 		b = b.trace(richString);
 		if (actualType.isType(StringConcatenationClient.class)) {
@@ -425,7 +425,7 @@ public class XtendCompiler extends XbaseCompiler {
 			super.internalToConvertedExpression(obj, appendable);
 	}
 	
-	private void _toJavaExpression(AnonymousClass anonymousClass, ITreeAppendable b) {
+	protected void _toJavaExpression(AnonymousClass anonymousClass, ITreeAppendable b) {
 		String varName = getReferenceName(anonymousClass, b);
 		if (varName != null) {
 			b.trace(anonymousClass, false).append(varName);
@@ -445,7 +445,7 @@ public class XtendCompiler extends XbaseCompiler {
 		}
 	}
 
-	private void compileAnonymousClassBody(AnonymousClass anonymousClass, JvmDeclaredType type, ITreeAppendable b) {
+	protected void compileAnonymousClassBody(AnonymousClass anonymousClass, JvmDeclaredType type, ITreeAppendable b) {
 		ITreeAppendable appendable = b.trace(anonymousClass, true);
 		appendable.append(" ");
 		appendable.openScope();
@@ -455,7 +455,7 @@ public class XtendCompiler extends XbaseCompiler {
 		appendable.closeScope();
 	}
 	
-	private void _toJavaExpression(RichString richString, ITreeAppendable b) {
+	protected void _toJavaExpression(RichString richString, ITreeAppendable b) {
 		b.append(getVarName(richString, b));
 		if(getLightweightType(richString).isType(String.class))
 			b.append(".toString()");
@@ -468,7 +468,7 @@ public class XtendCompiler extends XbaseCompiler {
 		super.appendCatchClauseParameter(catchClause, parameterType, parameterName, appendable);
 	}
 
-	private void appendExtensionAnnotation(JvmFormalParameter parameter, EObject context,
+	protected void appendExtensionAnnotation(JvmFormalParameter parameter, EObject context,
 			ITreeAppendable appendable, boolean newLine) {
 		if (parameter instanceof XtendFormalParameter) {
 			XtendFormalParameter castedParameter = (XtendFormalParameter) parameter;
@@ -478,7 +478,7 @@ public class XtendCompiler extends XbaseCompiler {
 		}
 	}
 
-	private void appendExtensionAnnotation(EObject context, ITreeAppendable appendable, boolean newLine) {
+	protected void appendExtensionAnnotation(EObject context, ITreeAppendable appendable, boolean newLine) {
 		JvmType extension = findKnownTopLevelType(Extension.class, context);
 		if (extension != null) {
 			appendable.append("@");
@@ -539,7 +539,7 @@ public class XtendCompiler extends XbaseCompiler {
 		toJavaStatement(expr, b, isReferenced, false);
 	}
 
-	private void _toJavaStatement(final AnonymousClass anonymousClass, ITreeAppendable b, final boolean isReferenced) {
+	protected void _toJavaStatement(final AnonymousClass anonymousClass, ITreeAppendable b, final boolean isReferenced) {
 		_toJavaStatement(anonymousClass.getConstructorCall(), b, isReferenced);
 	}
 

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
@@ -584,10 +584,8 @@ public class XtendCompiler extends XbaseCompiler {
 			XConstructorCall constructorCall = (XConstructorCall) expr;
 			if (constructorCall.isAnonymousClassConstructorCall()) {
 				EObject container = expr.eContainer();
-				result = isVariableDeclarationRequired((XExpression) container, b, recursive);
-				if (result) {
-					return !canCompileToJavaAnonymousClass(constructorCall);
-				}
+				return isVariableDeclarationRequired((XExpression) container, b, recursive) &&
+					!canCompileToJavaAnonymousClass(constructorCall);
 			}
 		}
 		return result;

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
@@ -579,8 +579,7 @@ public class XtendCompiler extends XbaseCompiler {
 	
 	@Override
 	protected boolean isVariableDeclarationRequired(XExpression expr, ITreeAppendable b, boolean recursive) {
-		boolean result = super.isVariableDeclarationRequired(expr, b, recursive);
-		if (result && expr instanceof XConstructorCall) {
+		if (expr instanceof XConstructorCall) {
 			XConstructorCall constructorCall = (XConstructorCall) expr;
 			if (constructorCall.isAnonymousClassConstructorCall()) {
 				EObject container = expr.eContainer();
@@ -588,7 +587,7 @@ public class XtendCompiler extends XbaseCompiler {
 					!canCompileToJavaAnonymousClass(constructorCall);
 			}
 		}
-		return result;
+		return super.isVariableDeclarationRequired(expr, b, recursive);
 	}
 	
 	@Override

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
@@ -581,16 +581,12 @@ public class XtendCompiler extends XbaseCompiler {
 	protected boolean isVariableDeclarationRequired(XExpression expr, ITreeAppendable b, boolean recursive) {
 		boolean result = super.isVariableDeclarationRequired(expr, b, recursive);
 		if (result && expr instanceof XConstructorCall) {
-			EObject container = expr.eContainer();
-			if (container instanceof AnonymousClass) {
-				AnonymousClass anonymousClass = (AnonymousClass) container;
-				result = isVariableDeclarationRequired(anonymousClass, b, recursive);
+			XConstructorCall constructorCall = (XConstructorCall) expr;
+			if (constructorCall.isAnonymousClassConstructorCall()) {
+				EObject container = expr.eContainer();
+				result = isVariableDeclarationRequired((XExpression) container, b, recursive);
 				if (result) {
-					JvmConstructor constructor = anonymousClass.getConstructorCall().getConstructor();
-					JvmDeclaredType type = constructor.getDeclaringType();
-					if (((JvmGenericType) type).isAnonymous()) {
-						return false;
-					}
+					return !canCompileToJavaAnonymousClass(constructorCall);
 				}
 			}
 		}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
@@ -99,7 +99,6 @@ import org.eclipse.xtext.xbase.util.XbaseUsageCrossReferencer;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 
@@ -1133,12 +1132,12 @@ public class XbaseCompiler extends FeatureCallCompiler {
 
 	protected void appendConstructedTypeName(XConstructorCall constructorCall, ITreeAppendable typeAppendable) {
 		JvmDeclaredType type = constructorCall.getConstructor().getDeclaringType();
+		IResolvedTypes resolvedTypes = batchTypeResolver.resolveTypes(constructorCall);
+		LightweightTypeReference actualType = resolvedTypes.getActualType(constructorCall);
 		if (type instanceof JvmGenericType && ((JvmGenericType) type).isAnonymous()) {
-			typeAppendable.append(Iterables.getLast(type.getSuperTypes()).getType());
+			typeAppendable.append(actualType.getNamedType().getRawTypeReference());
 		} else {
-			IResolvedTypes resolvedTypes = batchTypeResolver.resolveTypes(constructorCall);
-			LightweightTypeReference actualType = resolvedTypes.getActualType(constructorCall).getRawTypeReference();
-			typeAppendable.append(actualType);
+			typeAppendable.append(actualType.getRawTypeReference());
 		}
 	}
 	

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
@@ -2177,6 +2177,13 @@ public class XbaseCompiler extends FeatureCallCompiler {
 				}
 			}
 		}
+		if (expr instanceof XConstructorCall) {
+			XConstructorCall constructorCall = (XConstructorCall) expr;
+			if (constructorCall.isAnonymousClassConstructorCall()) {
+				return isVariableDeclarationRequired((XExpression) container, b, recursive) &&
+					!canCompileToJavaAnonymousClass(constructorCall);
+			}
+		}
 		return super.isVariableDeclarationRequired(expr, b, recursive);
 	}
 	

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
@@ -1146,6 +1146,8 @@ public class XbaseCompiler extends FeatureCallCompiler {
 	 * @since 2.34
 	 */
 	protected boolean canCompileToJavaAnonymousClass(XConstructorCall constructorCall) {
+		if (!constructorCall.isAnonymousClassConstructorCall())
+			return false;
 		JvmDeclaredType type = constructorCall.getConstructor().getDeclaringType();
 		return type instanceof JvmGenericType && ((JvmGenericType) type).isAnonymous();
 	}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/XbaseCompiler.java
@@ -1105,7 +1105,9 @@ public class XbaseCompiler extends FeatureCallCompiler {
 		}
 		ITreeAppendable typeAppendable = appendableWithNewKeyword.trace(expr, XbasePackage.Literals.XCONSTRUCTOR_CALL__CONSTRUCTOR, 0);
 		appendConstructedTypeName(expr, typeAppendable);
-		if (hasTypeArguments || (expr.isAnonymousClassConstructorCall() && !explicitTypeArguments.isEmpty() && ((JvmGenericType) constructor.getDeclaringType()).isAnonymous())) {
+		if (hasTypeArguments ||
+				(!explicitTypeArguments.isEmpty() &&
+						canCompileToJavaAnonymousClass(expr))) {
 			if (typeArguments.isEmpty()) {
 				LightweightTypeReference createdType = resolvedTypes.getActualType(expr);
 				typeArguments = createdType.getNamedType().getTypeArguments();
@@ -1131,16 +1133,23 @@ public class XbaseCompiler extends FeatureCallCompiler {
 	}
 
 	protected void appendConstructedTypeName(XConstructorCall constructorCall, ITreeAppendable typeAppendable) {
-		JvmDeclaredType type = constructorCall.getConstructor().getDeclaringType();
 		IResolvedTypes resolvedTypes = batchTypeResolver.resolveTypes(constructorCall);
 		LightweightTypeReference actualType = resolvedTypes.getActualType(constructorCall);
-		if (type instanceof JvmGenericType && ((JvmGenericType) type).isAnonymous()) {
+		if (canCompileToJavaAnonymousClass(constructorCall)) {
 			typeAppendable.append(actualType.getNamedType().getRawTypeReference());
 		} else {
 			typeAppendable.append(actualType.getRawTypeReference());
 		}
 	}
-	
+
+	/**
+	 * @since 2.34
+	 */
+	protected boolean canCompileToJavaAnonymousClass(XConstructorCall constructorCall) {
+		JvmDeclaredType type = constructorCall.getConstructor().getDeclaringType();
+		return type instanceof JvmGenericType && ((JvmGenericType) type).isAnonymous();
+	}
+
 	/* @Nullable */
 	protected ILocationData getLocationWithNewKeyword(XConstructorCall call) {
 		final ICompositeNode startNode = NodeModelUtils.getNode(call);


### PR DESCRIPTION
This provides some general refactoring for Xbase and Xtend and as a preparation for https://github.com/eclipse/xtext/issues/2886, for which I'll also provide a PR soon.

The main focus is on the treatment of anonymous classes, which was originally split into Xbase and Xtend. In this PR, anonymous classes are handled by the XbaseCompiler completely, which now provides a new method https://github.com/eclipse/xtext/compare/main...LorenzoBettini:xtext:lb_xbase_cleanup-1?expand=1#diff-3c98e6c5688a98e8fc686a884a0462f80d32c824ea233925c42b813a15345743R1148 `canCompileToJavaAnonymousClasses`. This relies on the `JvmGenericType.isAnonymous`. This was done before by `XbaseCompiler`, though with some duplicated code. Now, `XbaseCompiler` consistently calls this method to treat other situations that in the past were customized in `XtendCompiler`.

For example, `isVariableDeclarationRequired` is now properly handled in the `XbaseCompiler` also for constructor calls, which possibly refer to an anonymous class and does not need to be customized by `XtendCompiler`.

Similarly, `_toJavaStatement(final XConstructorCall expr...` does not need to be redefined by the `XtendCompiler`, which only needs to redefine `constructorCallToJavaExpression` to handle the generation of its anonymous classes.

I also took the chance to restrict the visibility of a few methods in `XtendCompiler`, which are used only internally.

The build is green.