### PR TITLE
Fix maven deprecations in xtend-maven-plugin

### DIFF
--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendCompilerMojo.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendCompilerMojo.java
@@ -18,9 +18,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -162,12 +160,6 @@ public abstract class AbstractXtendCompilerMojo extends AbstractXtendMojo {
 	}
 
 	protected abstract String getTempDirectory();
-
-	protected void addDependencies(Set<String> classPath, List<Artifact> dependencies) {
-		for (Artifact artifact : dependencies) {
-			classPath.add(artifact.getFile().getAbsolutePath());
-		}
-	}
 
 	protected void readXtendEclipseSetting(String sourceDirectory, Procedure1<String> fieldSetter) {
 		if (propertiesFileLocation != null) {

--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendCompile.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendCompile.java
@@ -68,7 +68,6 @@ public class XtendCompile extends AbstractXtendCompilerMojo {
 		compile(classPath, compileSourceRoots, outputDirectory);
 	}
 
-	@SuppressWarnings("deprecation")
 	protected List<String> getClassPath() {
 		Set<String> classPath = Sets.newLinkedHashSet();
 		classPath.add(project.getBuild().getSourceDirectory());
@@ -77,7 +76,6 @@ public class XtendCompile extends AbstractXtendCompilerMojo {
 		} catch (DependencyResolutionRequiredException e) {
 			throw new WrappedException(e);
 		}
-		addDependencies(classPath, project.getCompileArtifacts());
 		classPath.remove(project.getBuild().getOutputDirectory());
 		return newArrayList(filter(classPath, FILE_EXISTS));
 	}

--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendTestCompile.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendTestCompile.java
@@ -67,7 +67,6 @@ public class XtendTestCompile extends AbstractXtendCompilerMojo {
 		compile(testClassPath, testCompileSourceRoots, testOutputDirectory);
 	}
 
-	@SuppressWarnings("deprecation")
 	protected List<String> getTestClassPath() {
 		Set<String> classPath = Sets.newLinkedHashSet();
 		classPath.add(project.getBuild().getTestSourceDirectory());
@@ -76,7 +75,6 @@ public class XtendTestCompile extends AbstractXtendCompilerMojo {
 		} catch (DependencyResolutionRequiredException e) {
 			throw new WrappedException(e);
 		}
-		addDependencies(classPath, project.getTestArtifacts());
 		classPath.remove(project.getBuild().getTestOutputDirectory());
 		return newArrayList(filter(classPath, FILE_EXISTS));
 	}


### PR DESCRIPTION
Closes #2332 

We were using the deprecated `getCompileArtifacts` and `getTestArtifacts` and they would add nothing to what we already retrieved for the classpath with `getCompileClasspathElements` and `getTestClasspathElements`; by the way, the latter already return strings, while the former returned `Artifact` that then we turned into strings.

Having a look at the Maven sources of `MavenProject` you can see that:

```java
    public List<String> getCompileClasspathElements()
        throws DependencyResolutionRequiredException
    {
        List<String> list = new ArrayList<>( getArtifacts().size() + 1 );

        String d = getBuild().getOutputDirectory();
        if ( d != null )
        {
            list.add( d );
        }

        for ( Artifact a : getArtifacts() )
        {
            if ( a.getArtifactHandler().isAddedToClasspath() )
            {
                // TODO let the scope handler deal with this
                if ( Artifact.SCOPE_COMPILE.equals( a.getScope() ) || Artifact.SCOPE_PROVIDED.equals( a.getScope() )
                    || Artifact.SCOPE_SYSTEM.equals( a.getScope() ) )
                {
                    addArtifactPath( a, list );
                }
            }
        }

        return list;
    }
```

and the old deprecated one is:

```java
    @Deprecated
    public List<Artifact> getCompileArtifacts()
    {
        List<Artifact> list = new ArrayList<>( getArtifacts().size() );

        for ( Artifact a : getArtifacts() )
        {
            // TODO classpath check doesn't belong here - that's the other method
            if ( a.getArtifactHandler().isAddedToClasspath() )
            {
                // TODO let the scope handler deal with this
                if ( Artifact.SCOPE_COMPILE.equals( a.getScope() ) || Artifact.SCOPE_PROVIDED.equals( a.getScope() )
                    || Artifact.SCOPE_SYSTEM.equals( a.getScope() ) )
                {
                    list.add( a );
                }
            }
        }
        return list;
    }
```

And we were already removing the build output directory.

Similarly for the `getTestClasspathElements` and  `getTestArtifacts`.

Locally tests pass, let's see the CI.