### PR TITLE
[2792] don't set marker.LOCATION and just set LINE_NUMBER

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/MarkerCreator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/MarkerCreator.java
@@ -42,17 +42,16 @@ public class MarkerCreator {
 		// Do this in one single setAttributes() call, as each set of an attribute is a workspace operation
 		Map<String, Object> attributes = new HashMap<>(16);
 
-		String lineNR = "";
 		if (issue.getLineNumber() != null) {
-			lineNR = "line: " + issue.getLineNumber() + " ";
+			attributes.put(IMarker.LINE_NUMBER, issue.getLineNumber());
+		} else {
+			attributes.put(IMarker.LOCATION, resource.getFullPath().toString());
 		}
-		attributes.put(IMarker.LOCATION, lineNR + resource.getFullPath().toString());
 		attributes.put(Issue.CODE_KEY, issue.getCode());		
 		attributes.put(IMarker.SEVERITY, getSeverity(issue));
 		attributes.put(IMarker.CHAR_START, issue.getOffset());
 		if(issue.getOffset() != null && issue.getLength() != null)
 			attributes.put(IMarker.CHAR_END, issue.getOffset()+issue.getLength());
-		attributes.put(IMarker.LINE_NUMBER, issue.getLineNumber());
 		attributes.put(Issue.COLUMN_KEY, issue.getColumn());
 		attributes.put(IMarker.MESSAGE, issue.getMessage());
 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/MarkerCreator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/MarkerCreator.java
@@ -44,8 +44,6 @@ public class MarkerCreator {
 
 		if (issue.getLineNumber() != null) {
 			attributes.put(IMarker.LINE_NUMBER, issue.getLineNumber());
-		} else {
-			attributes.put(IMarker.LOCATION, resource.getFullPath().toString());
 		}
 		attributes.put(Issue.CODE_KEY, issue.getCode());		
 		attributes.put(IMarker.SEVERITY, getSeverity(issue));

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/MarkerCreator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/MarkerCreator.java
@@ -42,14 +42,12 @@ public class MarkerCreator {
 		// Do this in one single setAttributes() call, as each set of an attribute is a workspace operation
 		Map<String, Object> attributes = new HashMap<>(16);
 
-		if (issue.getLineNumber() != null) {
-			attributes.put(IMarker.LINE_NUMBER, issue.getLineNumber());
-		}
 		attributes.put(Issue.CODE_KEY, issue.getCode());		
 		attributes.put(IMarker.SEVERITY, getSeverity(issue));
 		attributes.put(IMarker.CHAR_START, issue.getOffset());
 		if(issue.getOffset() != null && issue.getLength() != null)
 			attributes.put(IMarker.CHAR_END, issue.getOffset()+issue.getLength());
+		attributes.put(IMarker.LINE_NUMBER, issue.getLineNumber());
 		attributes.put(Issue.COLUMN_KEY, issue.getColumn());
 		attributes.put(IMarker.MESSAGE, issue.getMessage());
 


### PR DESCRIPTION
Closes #2792 

This allows the Problems View to be correctly sorted according to Location (line numbers).

The current situation wrongly sorts according to the location because we set it with a line number and the path of the resource:

![image](https://github.com/eclipse/xtext/assets/1202254/a20efcf5-46aa-40b0-96d5-d5b5ddc12b98)

with this patch, we get the correct behavior:

![image](https://github.com/eclipse/xtext/assets/1202254/9a0d62f8-1655-4804-9f75-378969cf5ded)
