### PR TITLE
[2807] avoid NPE in XtextPluginImages when initialized from non-UI thread

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/internal/XtextPluginImages.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/internal/XtextPluginImages.java
@@ -29,7 +29,7 @@ import org.eclipse.xtext.ui.editor.XtextEditor;
  * PDEPluginImages.
  * 
  * @author Peter Friese - Initial contribution and API
- * @author Dennis Hübner
+ * @author Dennis HÃ¼bner
  * 
  */
 public class XtextPluginImages {
@@ -199,6 +199,7 @@ public class XtextPluginImages {
 	}
 
 	public static Image manage(String key, ImageDescriptor desc) {
+		ensureInitialized();
 		if (PLUGIN_REGISTRY == null)
 			return null;
 		Image image = desc.createImage();

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/internal/XtextPluginImages.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/internal/XtextPluginImages.java
@@ -135,6 +135,8 @@ public class XtextPluginImages {
 
 	public static Image get(String key) {
 		ensureInitialized();
+		if (PLUGIN_REGISTRY == null)
+			return null;
 		return PLUGIN_REGISTRY.get(key);
 	}
 
@@ -197,6 +199,8 @@ public class XtextPluginImages {
 	}
 
 	public static Image manage(String key, ImageDescriptor desc) {
+		if (PLUGIN_REGISTRY == null)
+			return null;
 		Image image = desc.createImage();
 		PLUGIN_REGISTRY.put(key, image);
 		return image;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/internal/XtextPluginImages.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/internal/XtextPluginImages.java
@@ -139,7 +139,10 @@ public class XtextPluginImages {
 	}
 
 	private static void ensureInitialized() {
-		if (PLUGIN_REGISTRY == null)
+		if (PLUGIN_REGISTRY == null &&
+				// to avoid NPE in XtextPluginImages when initialized from non-UI thread
+				// https://github.com/eclipse/xtext/issues/2807
+				Display.getCurrent() != null)
 			initialize();
 	}
 	


### PR DESCRIPTION
Closes #2807 

I could only test it manually.

I reproduced the problem using the steps of #2807; with this patch, the NPE is not thrown, and the code minings are correctly shown.