### PR TITLE
[Xtend] put INCOMPATIBLE_RETURN_TYPE marker on field's type 

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.xtend
@@ -79,7 +79,7 @@ class AccessorsCompilerTest extends AbstractXtendCompilerTest {
 	
 	@Test
 	def void testCannotOverrideWithConflictingReturnType() {
-		file('''
+		val source = '''
 			import org.eclipse.xtend.lib.annotations.Accessors
 			class Foo {
 				def String getFoo() {"foo"}
@@ -88,7 +88,10 @@ class AccessorsCompilerTest extends AbstractXtendCompilerTest {
 			class Bar extends Foo {
 				@Accessors int foo
 			}
-		''').assertError(XtendPackage.Literals.XTEND_FIELD, org.eclipse.xtext.xbase.validation.IssueCodes.INCOMPATIBLE_RETURN_TYPE, "incompatible", "getFoo")
+		'''
+		file(source).assertError(XtendPackage.Literals.XTEND_FIELD, org.eclipse.xtext.xbase.validation.IssueCodes.INCOMPATIBLE_RETURN_TYPE,
+			source.indexOf("@Accessors int foo"), "@Accessors int foo".length,
+			"incompatible", "getFoo")
 	}
 	
 	@Test

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.xtend
@@ -62,7 +62,7 @@ class AccessorsCompilerTest extends AbstractXtendCompilerTest {
 	
 	@Test
 	def void testCannotOverrideFinalGetter() {
-		file('''
+		val source = '''
 			import org.eclipse.xtend.lib.annotations.Accessors
 			class Fizz {
 				def final String getFoo() {"foo"}
@@ -71,7 +71,10 @@ class AccessorsCompilerTest extends AbstractXtendCompilerTest {
 			class Buzz extends Fizz {
 				@Accessors String foo
 			}
-		''').assertError(XtendPackage.Literals.XTEND_FIELD, IssueCodes.OVERRIDDEN_FINAL, "final", "getFoo")
+		'''
+		file(source).assertError(XtendPackage.Literals.XTEND_FIELD, IssueCodes.OVERRIDDEN_FINAL,
+			source.lastIndexOf("foo"), "foo".length,
+			"final", "getFoo")
 	}
 	
 	@Test
@@ -158,7 +161,7 @@ class AccessorsCompilerTest extends AbstractXtendCompilerTest {
 
 	@Test
 	def void testCannotOverrideFinalSetter() {
-		file('''
+		val source = '''
 			import org.eclipse.xtend.lib.annotations.Accessors
 			class Foo {
 				def final void setFoo(String foo) {}
@@ -167,7 +170,10 @@ class AccessorsCompilerTest extends AbstractXtendCompilerTest {
 			class Bar extends Foo {
 				@Accessors String foo
 			}
-		''').assertError(XtendPackage.Literals.XTEND_FIELD, IssueCodes.OVERRIDDEN_FINAL, "setFoo(String)", "final")
+		'''
+		file(source).assertError(XtendPackage.Literals.XTEND_FIELD, IssueCodes.OVERRIDDEN_FINAL,
+			source.lastIndexOf("foo"), "foo".length,
+			"setFoo(String)", "final")
 	}
 
 	@Test

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.xtend
@@ -90,7 +90,7 @@ class AccessorsCompilerTest extends AbstractXtendCompilerTest {
 			}
 		'''
 		file(source).assertError(XtendPackage.Literals.XTEND_FIELD, org.eclipse.xtext.xbase.validation.IssueCodes.INCOMPATIBLE_RETURN_TYPE,
-			source.indexOf("@Accessors int foo"), "@Accessors int foo".length,
+			source.indexOf("int"), "int".length,
 			"incompatible", "getFoo")
 	}
 	

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
@@ -1030,8 +1030,11 @@ public class OverrideValidationTest extends AbstractXtendTestCase {
 	}
 	
 	@Test public void testSynchronized_1() throws Exception{
-		XtendClass xtendClass = clazz("class Foo extends Bar { override myMethod() {1} } class Bar { def synchronized int myMethod() {0} }");
-		helper.assertWarning(xtendClass, XTEND_FUNCTION, MISSING_SYNCHRONIZED);
+		var source = "class Foo extends Bar { override myMethod() {1} } class Bar { def synchronized int myMethod() {0} }";
+		XtendClass xtendClass = clazz(source);
+		helper.assertWarning(xtendClass, XTEND_FUNCTION, MISSING_SYNCHRONIZED,
+				source.indexOf("myMethod"), "myMethod".length(),
+				"The overridden method is synchronized, the current one is not synchronized");
 	}
 	
 	@Test public void testSynchronized_2() throws Exception{

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
@@ -442,8 +442,11 @@ public class OverrideValidationTest extends AbstractXtendTestCase {
 	}
 
 	@Test public void testOverrideFinalMethod() throws Exception {
-		XtendClass xtendClass = clazz("class Foo extends test.ClassWithFinalMembers { def foo() {} }");
-		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, OVERRIDDEN_FINAL, "override", "final");
+		var source = "class Foo extends test.ClassWithFinalMembers { def foo() {} }";
+		XtendClass xtendClass = clazz(source);
+		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, OVERRIDDEN_FINAL,
+				source.indexOf("foo"), "foo".length(),
+				"override", "final");
 	}
 
 	@Test public void testOverrideSameVisibility() throws Exception {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
@@ -476,8 +476,10 @@ public class OverrideValidationTest extends AbstractXtendTestCase {
 	}
 
 	@Test public void testIncompatibleThrowsClause() throws Exception {
-		XtendClass xtendClass = clazz("class Foo extends test.ExceptionThrowing { override ioException() throws Exception {} }");
+		var source = "class Foo extends test.ExceptionThrowing { override ioException() throws Exception {} }";
+		XtendClass xtendClass = clazz(source);
 		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_THROWS_CLAUSE,
+				source.lastIndexOf("Exception"), "Exception".length(),
 				"Exception", "not", "compatible", "throws", "clause");
 	}
 	

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
@@ -460,15 +460,19 @@ public class OverrideValidationTest extends AbstractXtendTestCase {
 	}
 
 	@Test public void testOverrideHides() throws Exception {
-		XtendClass xtendClass = clazz("class Foo extends test.Visibilities { override protected publicMethod() {} }");
-		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, OVERRIDE_REDUCES_VISIBILITY, "reduce",
-				"visibility");
+		var source = "class Foo extends test.Visibilities { override protected publicMethod() {} }";
+		XtendClass xtendClass = clazz(source);
+		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, OVERRIDE_REDUCES_VISIBILITY,
+				source.indexOf("publicMethod"), "publicMethod".length(),
+				"reduce", "visibility");
 	}
 
 	@Test public void testDispatchHides() throws Exception {
-		XtendClass xtendClass = clazz("class Foo extends test.Visibilities { def protected dispatch publicMethod() {} }");
-		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, OVERRIDE_REDUCES_VISIBILITY, "reduce",
-				"visibility");
+		var source = "class Foo extends test.Visibilities { def protected dispatch publicMethod() {} }";
+		XtendClass xtendClass = clazz(source);
+		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, OVERRIDE_REDUCES_VISIBILITY,
+				source.indexOf("protected"), "protected".length(),
+				"reduce", "visibility");
 	}
 
 	@Test public void testIncompatibleThrowsClause() throws Exception {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
@@ -805,8 +805,11 @@ public class OverrideValidationTest extends AbstractXtendTestCase {
 	}
 
 	@Test public void testInterfaceIncompatibleReturnType_0() throws Exception {
-		XtendInterface xtendInterface = interfaze("interface Foo extends test.SuperInterface { override Boolean string() }");
-		helper.assertError(xtendInterface.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_RETURN_TYPE);
+		var source = "interface Foo extends test.SuperInterface { override Boolean string() }";
+		XtendInterface xtendInterface = interfaze(source);
+		helper.assertError(xtendInterface.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_RETURN_TYPE,
+				source.indexOf("Boolean"), "Boolean".length(),
+				"return type is incompatible with", "string()");
 	}
 
 	@Test public void testInterfaceIncompatibleReturnType_1() throws Exception {
@@ -815,8 +818,11 @@ public class OverrideValidationTest extends AbstractXtendTestCase {
 	}
 
 	@Test public void testInterfaceIncompatibleReturnType_2() throws Exception {
-		XtendInterface xtendInterface = interfaze("interface Foo extends test.SomeInterface { override void foo() }");
-		helper.assertError(xtendInterface.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_RETURN_TYPE);
+		var source = "interface Foo extends test.SomeInterface { override void foo() }";
+		XtendInterface xtendInterface = interfaze(source);
+		helper.assertError(xtendInterface.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_RETURN_TYPE,
+				source.indexOf("void"), "void".length(),
+				"return type is incompatible with", "foo()");
 	}
 
 	@Test public void testInterfaceIncompatibleGenericReturnType_0() throws Exception {
@@ -825,8 +831,10 @@ public class OverrideValidationTest extends AbstractXtendTestCase {
 	}
 
 	@Test public void testInterfaceIncompatibleGenericReturnType_1() throws Exception {
-		XtendInterface xtendInterface = interfaze("interface Foo extends test.SuperInterface { override java.util.List<Object> returnsListString() }");
-		helper.assertError(xtendInterface.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_RETURN_TYPE);
+		var source = "interface Foo extends test.SuperInterface { override java.util.List<Object> returnsListString() }";
+		XtendInterface xtendInterface = interfaze(source);
+		helper.assertError(xtendInterface.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_RETURN_TYPE,
+				source.indexOf("java.util.List<Object>"), "java.util.List<Object>".length());
 	}
 
 	@Test public void testInterfaceIncompatibleGenericReturnType_2() throws Exception {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
@@ -480,7 +480,7 @@ public class OverrideValidationTest extends AbstractXtendTestCase {
 		XtendClass xtendClass = clazz(source);
 		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_THROWS_CLAUSE,
 				source.lastIndexOf("Exception"), "Exception".length(),
-				"Exception", "not", "compatible", "throws", "clause");
+				"Exception", "is not", "compatible", "throws", "clause");
 	}
 	
 	@Test public void testIncompatibleThrowsClause_01() throws Exception {
@@ -512,7 +512,19 @@ public class OverrideValidationTest extends AbstractXtendTestCase {
 		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_THROWS_CLAUSE,
 				"Exception", "FileNotFoundException", "not", "compatible", "throws", "clause");
 	}
-	
+
+	/**
+	 * Two incompatible exceptions; the marker is on the first one
+	 */
+	@Test public void testIncompatibleThrowsClause_06() throws Exception {
+		var source = "class Foo extends test.ExceptionThrowing { override nullPointerException() throws java.io.IOException, java.io.FileNotFoundException {} }";
+		XtendClass xtendClass = clazz(source);
+		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_THROWS_CLAUSE,
+				source.indexOf("java.io.IOException"), "java.io.IOException".length(),
+				"declared exceptions", "IOException", "FileNotFoundException",
+				"are not", "compatible", "throws", "clause");
+	}
+
 	@Test public void testCompatibleThrowsClause() throws Exception {
 		XtendClass xtendClass = clazz("class Foo extends test.ExceptionThrowing { override ioException() throws java.io.FileNotFoundException {} }");
 		helper.assertNoError(xtendClass.getMembers().get(0), INCOMPATIBLE_THROWS_CLAUSE);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.java
@@ -172,7 +172,7 @@ public class AccessorsCompilerTest extends AbstractXtendCompilerTest {
       _builder.newLine();
       final String source = _builder.toString();
       this._validationTestHelper.assertError(this.file(source), XtendPackage.Literals.XTEND_FIELD, org.eclipse.xtext.xbase.validation.IssueCodes.INCOMPATIBLE_RETURN_TYPE, 
-        source.indexOf("@Accessors int foo"), "@Accessors int foo".length(), 
+        source.indexOf("int"), "int".length(), 
         "incompatible", "getFoo");
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.java
@@ -140,7 +140,10 @@ public class AccessorsCompilerTest extends AbstractXtendCompilerTest {
       _builder.newLine();
       _builder.append("}");
       _builder.newLine();
-      this._validationTestHelper.assertError(this.file(_builder.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.OVERRIDDEN_FINAL, "final", "getFoo");
+      final String source = _builder.toString();
+      this._validationTestHelper.assertError(this.file(source), XtendPackage.Literals.XTEND_FIELD, IssueCodes.OVERRIDDEN_FINAL, 
+        source.lastIndexOf("foo"), "foo".length(), 
+        "final", "getFoo");
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -323,7 +326,10 @@ public class AccessorsCompilerTest extends AbstractXtendCompilerTest {
       _builder.newLine();
       _builder.append("}");
       _builder.newLine();
-      this._validationTestHelper.assertError(this.file(_builder.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.OVERRIDDEN_FINAL, "setFoo(String)", "final");
+      final String source = _builder.toString();
+      this._validationTestHelper.assertError(this.file(source), XtendPackage.Literals.XTEND_FIELD, IssueCodes.OVERRIDDEN_FINAL, 
+        source.lastIndexOf("foo"), "foo".length(), 
+        "setFoo(String)", "final");
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AccessorsCompilerTest.java
@@ -170,7 +170,10 @@ public class AccessorsCompilerTest extends AbstractXtendCompilerTest {
       _builder.newLine();
       _builder.append("}");
       _builder.newLine();
-      this._validationTestHelper.assertError(this.file(_builder.toString()), XtendPackage.Literals.XTEND_FIELD, org.eclipse.xtext.xbase.validation.IssueCodes.INCOMPATIBLE_RETURN_TYPE, "incompatible", "getFoo");
+      final String source = _builder.toString();
+      this._validationTestHelper.assertError(this.file(source), XtendPackage.Literals.XTEND_FIELD, org.eclipse.xtext.xbase.validation.IssueCodes.INCOMPATIBLE_RETURN_TYPE, 
+        source.indexOf("@Accessors int foo"), "@Accessors int foo".length(), 
+        "incompatible", "getFoo");
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
@@ -883,6 +883,8 @@ public class XtendValidator extends XbaseWithAnnotationsValidator {
 	protected EStructuralFeature returnTypeFeature(EObject member) {
 		if (member instanceof XtendFunction) 
 			return XTEND_FUNCTION__RETURN_TYPE;
+		else if (member instanceof XtendField) // e.g., for an active annotation like @Accessors
+			return XTEND_FIELD__TYPE;
 		else
 			return null;
 	}


### PR DESCRIPTION
While working on #2349 I discovered that Xtend puts an INCOMPATIBLE_RETURN_TYPE marker on the whole field; this happens, e.g., when an active annotation like `Accessors` is put on a field in a subclass of another class; the `Accessors` creates a getter or setter that might conflict with an inherited getter or setter:

![image](https://github.com/eclipse/xtext/assets/1202254/dfc1741c-24bd-42b7-8b19-2010ea2dba66)

This PR, independently from #2349, allows the marker to be put on the incompatible type, just like it happens for overridden methods:

![image](https://github.com/eclipse/xtext/assets/1202254/7d8a951f-52f3-49aa-9bf3-a8c6fb23a3e4)


This PR also improves a few other Xtend tests checking also the position of the error marker. The relevant change in Xtend is this one: https://github.com/eclipse/xtext/compare/main...LorenzoBettini:lb_xtend_validation_tests?expand=1#diff-7eccd6f746520f0ceab7a1355467b7ca7009462eec0d4efa65b4e23749e40f95R886