### PR TITLE
Xtend: put an error marker on each incompatible exception in overridden method

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
@@ -514,15 +514,18 @@ public class OverrideValidationTest extends AbstractXtendTestCase {
 	}
 
 	/**
-	 * Two incompatible exceptions; the marker is on the first one
+	 * Three incompatible exceptions from different supertypes; the marker is on the first one
 	 */
 	@Test public void testIncompatibleThrowsClause_06() throws Exception {
-		var source = "class Foo extends test.ExceptionThrowing { override nullPointerException() throws java.io.IOException, java.io.FileNotFoundException {} }";
+		var source = "class Foo extends test.ExceptionThrowing implements test.ExceptionThrowingInterface, test.ExceptionThrowingInterface2 {"
+				+ "override nullPointerException() throws NullPointerException, java.io.IOException, java.io.FileNotFoundException {} "
+				+ "}";
 		XtendClass xtendClass = clazz(source);
 		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_THROWS_CLAUSE,
-				source.indexOf("java.io.IOException"), "java.io.IOException".length(),
+				source.indexOf("NullPointerException"), "NullPointerException".length(),
 				"declared exceptions", "IOException", "FileNotFoundException",
-				"are not", "compatible", "throws", "clause");
+				"are not compatible with throws clause in "
+				+ "ExceptionThrowing.nullPointerException(), ExceptionThrowingInterface.nullPointerException() and ExceptionThrowingInterface2.nullPointerException()");
 	}
 
 	@Test public void testCompatibleThrowsClause() throws Exception {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/OverrideValidationTest.java
@@ -514,18 +514,24 @@ public class OverrideValidationTest extends AbstractXtendTestCase {
 	}
 
 	/**
-	 * Three incompatible exceptions from different supertypes; the marker is on the first one
+	 * Three incompatible exceptions from different supertypes;
+	 * the marker is set on the offending exception
 	 */
 	@Test public void testIncompatibleThrowsClause_06() throws Exception {
 		var source = "class Foo extends test.ExceptionThrowing implements test.ExceptionThrowingInterface, test.ExceptionThrowingInterface2 {"
 				+ "override nullPointerException() throws NullPointerException, java.io.IOException, java.io.FileNotFoundException {} "
 				+ "}";
 		XtendClass xtendClass = clazz(source);
+		var expectedSuffix = " is not compatible with throws clause in "
+				+ "ExceptionThrowing.nullPointerException(), ExceptionThrowingInterface.nullPointerException() and ExceptionThrowingInterface2.nullPointerException()";
 		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_THROWS_CLAUSE,
-				source.indexOf("NullPointerException"), "NullPointerException".length(),
-				"declared exceptions", "IOException", "FileNotFoundException",
-				"are not compatible with throws clause in "
-				+ "ExceptionThrowing.nullPointerException(), ExceptionThrowingInterface.nullPointerException() and ExceptionThrowingInterface2.nullPointerException()");
+				source.indexOf("java.io.IOException"), "java.io.IOException".length(),
+				"declared exception IOException",
+				expectedSuffix);
+		helper.assertError(xtendClass.getMembers().get(0), XTEND_FUNCTION, INCOMPATIBLE_THROWS_CLAUSE,
+				source.indexOf("java.io.FileNotFoundException"), "java.io.FileNotFoundException".length(),
+				"declared exception FileNotFoundException",
+				expectedSuffix);
 	}
 
 	@Test public void testCompatibleThrowsClause() throws Exception {

--- a/org.eclipse.xtend.core.tests/testdata/test/ExceptionThrowingInterface2.java
+++ b/org.eclipse.xtend.core.tests/testdata/test/ExceptionThrowingInterface2.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2024 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test;
+
+/**
+ * @author Lorenzo Bettini - Initial contribution and API
+ */
+ interface ExceptionThrowingInterface2 {
+
+	 void nullPointerException() throws NullPointerException ;
+
+ }

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
@@ -1152,7 +1152,7 @@ public class XtendValidator extends XbaseWithAnnotationsValidator {
 		var suffixMessage = new StringBuilder();
 		suffixMessage.append(" not compatible with throws clause in ");
 
-		for(int i = 0; i < exceptionMismatch.size(); i++) {
+		for (int i = 0; i < exceptionMismatch.size(); i++) {
 			if (i != 0) {
 				if (i != exceptionMismatch.size() - 1)
 					suffixMessage.append(", ");
@@ -1166,10 +1166,9 @@ public class XtendValidator extends XbaseWithAnnotationsValidator {
 		}
 
 		List<LightweightTypeReference> resolvedExceptions = operation.getResolvedExceptions();
-		for(int i = 0; i < exceptions.size(); i++) {
+		for (LightweightTypeReference exception : exceptions) {
 			var message = new StringBuilder(100);
 			message.append("The declared exception ");
-			LightweightTypeReference exception = exceptions.get(i);
 			message.append(exception.getHumanReadableName());
 			message.append(" is");
 			message.append(suffixMessage);

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
@@ -872,14 +872,7 @@ public class XtendValidator extends XbaseWithAnnotationsValidator {
 		else
 			return null;
 	}
-	
-	protected EStructuralFeature exceptionsFeature(EObject member) {
-		if (member instanceof XtendExecutable) 
-			return XTEND_EXECUTABLE__EXCEPTIONS;
-		else
-			return null;
-	}
-	
+
 	protected EStructuralFeature returnTypeFeature(EObject member) {
 		if (member instanceof XtendFunction) 
 			return XTEND_FUNCTION__RETURN_TYPE;
@@ -1155,40 +1148,36 @@ public class XtendValidator extends XbaseWithAnnotationsValidator {
 	protected void createExceptionMismatchError(IResolvedOperation operation, EObject sourceElement,
 			List<IResolvedOperation> exceptionMismatch) {
 		List<LightweightTypeReference> exceptions = operation.getIllegallyDeclaredExceptions();
-		StringBuilder message = new StringBuilder(100);
-		message.append("The declared exception");
-		if (exceptions.size() > 1) {
-			message.append('s');
-		}
-		message.append(' ');
-		for(int i = 0; i < exceptions.size(); i++) {
-			if (i != 0) {
-				if (i != exceptions.size() - 1)
-					message.append(", ");
-				else
-					message.append(" and ");
-			}
-			message.append(exceptions.get(i).getHumanReadableName());
-		}
-		if (exceptions.size() > 1) {
-			message.append(" are");
-		} else {
-			message.append(" is");
-		}
-		message.append(" not compatible with throws clause in ");
+
+		var suffixMessage = new StringBuilder();
+		suffixMessage.append(" not compatible with throws clause in ");
+
 		for(int i = 0; i < exceptionMismatch.size(); i++) {
 			if (i != 0) {
 				if (i != exceptionMismatch.size() - 1)
-					message.append(", ");
+					suffixMessage.append(", ");
 				else
-					message.append(" and ");
+					suffixMessage.append(" and ");
 			}
 			IResolvedOperation resolvedOperation = exceptionMismatch.get(i);
-			message.append(getDeclaratorName(resolvedOperation));
-			message.append('.');
-			message.append(exceptionMismatch.get(i).getSimpleSignature());
+			suffixMessage.append(getDeclaratorName(resolvedOperation));
+			suffixMessage.append('.');
+			suffixMessage.append(exceptionMismatch.get(i).getSimpleSignature());
 		}
-		error(message.toString(), sourceElement, exceptionsFeature(sourceElement), INCOMPATIBLE_THROWS_CLAUSE);
+
+		List<LightweightTypeReference> resolvedExceptions = operation.getResolvedExceptions();
+		for(int i = 0; i < exceptions.size(); i++) {
+			var message = new StringBuilder(100);
+			message.append("The declared exception ");
+			LightweightTypeReference exception = exceptions.get(i);
+			message.append(exception.getHumanReadableName());
+			message.append(" is");
+			message.append(suffixMessage);
+			var exceptionIndex = resolvedExceptions.indexOf(exception);
+			error(message.toString(),
+				sourceElement, XTEND_EXECUTABLE__EXCEPTIONS,
+				exceptionIndex, INCOMPATIBLE_THROWS_CLAUSE);
+		}
 	}
 
 	protected EObject findPrimarySourceElement(IResolvedOperation operation) {


### PR DESCRIPTION
Closes #2912 

The PR also covers the suffix of the error message in case there are several supertypes (this was not covered before).

The markers now look like this:

<img width="635" alt="image" src="https://github.com/eclipse/xtext/assets/1202254/e724b4de-eada-4edb-a609-b099d4e3c551">

and the two error messages say

```
The declared exception IOException is not compatible with throws clause in ExceptionThrowing.nullPointerException(), ExceptionThrowingInterface.nullPointerException() and ExceptionThrowingInterface2.nullPointerException()

The declared exception FileNotFoundException is not compatible with throws clause in ExceptionThrowing.nullPointerException(), ExceptionThrowingInterface.nullPointerException() and ExceptionThrowingInterface2.nullPointerException()
```