### PR TITLE
Avoid busy and possibly infinite loop in JavaEditorExtension

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/builder/JavaEditorExtension.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/builder/JavaEditorExtension.xtend
@@ -99,13 +99,25 @@ class JavaEditorExtension {
 					}
 				}
 			], eventMask)
+
 		producer.apply
-		while (!changed.get) {
-			if (Display.getCurrent() !== null) {
-				while (Display.getDefault().readAndDispatch()) {
-					// process queued ui events
+
+		var display = Display.getCurrent()
+		assertNotNull(display)
+
+		val stop = new AtomicBoolean()
+		display.timerExec(10000, [stop.set(true)])
+
+		while (!changed.get && !stop.get) {
+			if (!display.readAndDispatch()) {
+				if (VERBOSE) {
+					println("Display sleep...")
 				}
+				display.sleep();
 			}
+		}
+		if (!changed.get) {
+			throw new AssertionError("No event has been received")
 		}
 		if (VERBOSE) {
 			println('''end waiting for an element changed event: «eventMask»''')

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/builder/JavaEditorExtension.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/builder/JavaEditorExtension.java
@@ -134,13 +134,27 @@ public class JavaEditorExtension {
       };
       JavaCore.addElementChangedListener(_function, eventMask);
       producer.apply();
-      while ((!changed.get())) {
-        Display _current = Display.getCurrent();
-        boolean _tripleNotEquals = (_current != null);
-        if (_tripleNotEquals) {
-          while (Display.getDefault().readAndDispatch()) {
+      Display display = Display.getCurrent();
+      Assert.assertNotNull(display);
+      final AtomicBoolean stop = new AtomicBoolean();
+      final Runnable _function_1 = () -> {
+        stop.set(true);
+      };
+      display.timerExec(10000, _function_1);
+      while (((!changed.get()) && (!stop.get()))) {
+        boolean _readAndDispatch = display.readAndDispatch();
+        boolean _not = (!_readAndDispatch);
+        if (_not) {
+          if ((JavaEditorExtension.VERBOSE).booleanValue()) {
+            InputOutput.<String>println("Display sleep...");
           }
+          display.sleep();
         }
+      }
+      boolean _get = changed.get();
+      boolean _not = (!_get);
+      if (_not) {
+        throw new AssertionError("No event has been received");
       }
       String _xifexpression = null;
       if ((JavaEditorExtension.VERBOSE).booleanValue()) {


### PR DESCRIPTION
Maybe due to a bug in Platform not correctly closing or saving editors.

This avoids the busy waiting loop and getting into an infinite loop.
The idea is to sleep a bit, giving the listener some time to create the event. Moreover, it gives up after a few retries.

The test becomes flaky when the but above appears, but at least it doesn't exhaust the CI CPU and does not get stuck.

Locally, I haven't seen significant performance changes during the execution.

Closes #2895 