### PR TITLE
use maven-bundle-plugin with extensions=true

### DIFF
--- a/org.eclipse.xtext.web.servlet/pom.xml
+++ b/org.eclipse.xtext.web.servlet/pom.xml
@@ -43,16 +43,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>5.1.8</version>
-				<executions>
-					<execution>
-						<id>bundle-manifest</id>
-						<phase>process-classes</phase>
-						<goals>
-							<goal>manifest</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/org.eclipse.xtext.web/pom.xml
+++ b/org.eclipse.xtext.web/pom.xml
@@ -166,16 +166,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>5.1.8</version>
-				<executions>
-					<execution>
-						<id>bundle-manifest</id>
-						<phase>process-classes</phase>
-						<goals>
-							<goal>manifest</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/org.eclipse.xtext.xbase.web/pom.xml
+++ b/org.eclipse.xtext.xbase.web/pom.xml
@@ -83,16 +83,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>5.1.8</version>
-				<executions>
-					<execution>
-						<id>bundle-manifest</id>
-						<phase>process-classes</phase>
-						<goals>
-							<goal>manifest</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -544,6 +544,24 @@
 					</configuration>
 				</plugin>
 				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<!-- extensions is crucial to avoid classloading problems
+						and API incompatibility when running in a Tycho build.
+						see https://github.com/eclipse/xtext/issues/2914 -->
+					<extensions>true</extensions>
+					<version>5.1.9</version>
+					<executions>
+						<execution>
+							<id>bundle-manifest</id>
+							<phase>process-classes</phase>
+							<goals>
+								<goal>manifest</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>3.3.0</version>


### PR DESCRIPTION
To avoid classloading problems
and API incompatibility when running in a Tycho build.

Closes https://github.com/eclipse/xtext/issues/2914