### PR TITLE
[Xtend] check for duplicate interface specification

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/XtendValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/XtendValidationTest.java
@@ -977,7 +977,31 @@ public class XtendValidationTest extends AbstractXtendTestCase {
 		XtendInterface interfaze = interfaze("interface Foo extends Foo {}");
 		helper.assertError(interfaze, XTEND_INTERFACE, CYCLIC_INHERITANCE, "hierarchy", "cycles");
 	}
-	
+
+	@Test public void testDuplicateImplementedInterfaces() throws Exception {
+		var source = "import java.io.Serializable\n"
+				+ "class Foo implements Serializable, java.io.Serializable, Serializable {}";
+		XtendFile file = file(source);
+		helper.assertError(file, XTEND_CLASS, DUPLICATE_INTERFACE,
+				source.lastIndexOf("java.io.Serializable"), "java.io.Serializable".length(),
+				"Duplicate interface Serializable for the type Foo");
+		helper.assertError(file, XTEND_CLASS, DUPLICATE_INTERFACE,
+				source.lastIndexOf("Serializable"), "Serializable".length(),
+				"Duplicate interface Serializable for the type Foo");
+	}
+
+	@Test public void testDuplicateExtendedInterfaces() throws Exception {
+		var source = "import java.io.Serializable\n"
+				+ "interface Foo extends Serializable, java.io.Serializable, Serializable {}";
+		XtendFile file = file(source);
+		helper.assertError(file, XTEND_INTERFACE, DUPLICATE_INTERFACE,
+				source.lastIndexOf("java.io.Serializable"), "java.io.Serializable".length(),
+				"Duplicate interface Serializable for the type Foo");
+		helper.assertError(file, XTEND_INTERFACE, DUPLICATE_INTERFACE,
+				source.lastIndexOf("Serializable"), "Serializable".length(),
+				"Duplicate interface Serializable for the type Foo");
+	}
+
 	@Test public void testTypesUniqueNames() throws Exception {
 		XtendFile file = file("class Foo {} interface Foo {} annotation Foo {}");
 		helper.assertError(file, XTEND_INTERFACE, DUPLICATE_TYPE_NAME, "type", "already defined");

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/XtendValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/XtendValidationTest.java
@@ -980,7 +980,8 @@ public class XtendValidationTest extends AbstractXtendTestCase {
 
 	@Test public void testDuplicateImplementedInterfaces() throws Exception {
 		var source = "import java.io.Serializable\n"
-				+ "class Foo implements Serializable, java.io.Serializable, Serializable {}";
+				+ "class Foo implements "
+				+ "Serializable, java.io.Serializable, Cloneable, Serializable {}";
 		XtendFile file = file(source);
 		helper.assertError(file, XTEND_CLASS, DUPLICATE_INTERFACE,
 				source.lastIndexOf("java.io.Serializable"), "java.io.Serializable".length(),
@@ -992,7 +993,8 @@ public class XtendValidationTest extends AbstractXtendTestCase {
 
 	@Test public void testDuplicateExtendedInterfaces() throws Exception {
 		var source = "import java.io.Serializable\n"
-				+ "interface Foo extends Serializable, java.io.Serializable, Serializable {}";
+				+ "interface Foo extends "
+				+ "Serializable, java.io.Serializable, Cloneable, Serializable {}";
 		XtendFile file = file(source);
 		helper.assertError(file, XTEND_INTERFACE, DUPLICATE_INTERFACE,
 				source.lastIndexOf("java.io.Serializable"), "java.io.Serializable".length(),

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/IssueCodes.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/IssueCodes.java
@@ -121,4 +121,9 @@ public final class IssueCodes {
 	 * @since 2.18
 	 */
 	public static final String TERNARY_EXPRESSION_NOT_ALLOWED = ISSUE_CODE_PREFIX + "ternary_if_operator_is_not_allowed";
+	/**
+	 * @since 2.34
+	 */
+	public static final String DUPLICATE_INTERFACE = ISSUE_CODE_PREFIX + "duplicate_interface";
+
 }


### PR DESCRIPTION
Closes #2928 

The errors are now as follows (I took inspiration from JDT, which shows the error starting from the first duplicate on):

<img width="647" alt="image" src="https://github.com/eclipse/xtext/assets/1202254/109a8a82-208e-4338-bff9-d547103f62c0">
