### PR TITLE
Re-enable Windows GitHub Actions and use Maven Wrapper also for Maven plugins ITs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.base.repo.clone_url != github.event.pull_request.head.repo.clone_url
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest' ] # 'windows-latest' too flaky
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -35,10 +35,18 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/*.target') }}
           restore-keys: ${{ runner.os }}-m2
 
+      - name: Set Maven Home environment variable
+        run: echo "MAVEN_WRAPPER_HOME=$(./mvnw --version | grep "Maven home:" | cut -c 13-)" >> "$GITHUB_ENV"
+        if: runner.os != 'Windows'
+      - name: Set Maven Home environment variable on Windows
+        run: echo "MAVEN_WRAPPER_HOME=$(./mvnw --version | grep "Maven home:" | cut -c 13-)" | Out-File -FilePath $env:GITHUB_ENV -Append
+        # In Windows the syntax for setting environment variable is different
+        if: runner.os == 'Windows'
+
       - name: Build and test
         uses: coactions/setup-xvfb@v1
         with: 
-          run: ./mvnw clean verify -PuseJenkinsSnapshots -f org.eclipse.xtext.full.releng
+          run: ./mvnw clean verify "-Dmaven.home=${{ env.MAVEN_WRAPPER_HOME }}" -PuseJenkinsSnapshots -f org.eclipse.xtext.full.releng
 
   build-maven-artifacts:
     if: github.event_name != 'pull_request' || github.event.pull_request.base.repo.clone_url != github.event.pull_request.head.repo.clone_url
@@ -61,5 +69,8 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
           restore-keys: ${{ runner.os }}-maven
 
+      - name: Set Maven Home environment variable
+        run: echo "MAVEN_WRAPPER_HOME=$(./mvnw --version | grep "Maven home:" | cut -c 13-)" >> "$GITHUB_ENV"
+
       - name: Build Maven artifacts
-        run: ./mvnw clean verify -PuseJenkinsSnapshots -f org.eclipse.xtext.maven.releng
+        run: ./mvnw clean verify "-Dmaven.home=${{ env.MAVEN_WRAPPER_HOME }}" -PuseJenkinsSnapshots -f org.eclipse.xtext.maven.releng

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,6 @@ pipeline {
   }
 
   tools {
-     maven "apache-maven-3.9.2"
      jdk "temurin-jdk17-latest"
   }
 

--- a/full-build.sh
+++ b/full-build.sh
@@ -44,6 +44,8 @@ done
 
 MVN_ARGS+=(-PuseJenkinsSnapshots)
 
+MVN_ARGS+=("-Dmaven.home=$(./mvnw --version | grep "Maven home:" | cut -c 13-)")
+
 echo ./mvnw -B -f org.eclipse.xtext.full.releng ${MVN_ARGS[@]} $@
 
 #echo "Using target platform '$TARGET_PLATFORM'"

--- a/full-deploy.sh
+++ b/full-deploy.sh
@@ -44,6 +44,8 @@ done
 
 MVN_ARGS+=(-PuseJenkinsSnapshots)
 
+MVN_ARGS+=("-Dmaven.home=$(./mvnw --version | grep "Maven home:" | cut -c 13-)")
+
 echo ./mvnw -B -f org.eclipse.xtext.full.releng ${MVN_ARGS[@]} $@
 
 ./mvnw -B \

--- a/jenkins/milestone-deploy/Jenkinsfile
+++ b/jenkins/milestone-deploy/Jenkinsfile
@@ -25,7 +25,6 @@ pipeline {
   }
 
   tools {
-    maven "apache-maven-3.9.2"
     jdk "temurin-jdk17-latest"
   }
 

--- a/jenkins/nightly-deploy/Jenkinsfile
+++ b/jenkins/nightly-deploy/Jenkinsfile
@@ -13,7 +13,6 @@ pipeline {
   }
 
   tools {
-    maven "apache-maven-3.9.2"
     jdk "temurin-jdk17-latest"
   }
 

--- a/jenkins/release-deploy/Jenkinsfile
+++ b/jenkins/release-deploy/Jenkinsfile
@@ -21,7 +21,6 @@ pipeline {
   }
 
   tools {
-    maven "apache-maven-3.9.2"
     jdk "temurin-jdk17-latest"
   }
 

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/compiler/QuickDebugSourceInstallingCompilationParticipantTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/compiler/QuickDebugSourceInstallingCompilationParticipantTest.xtend
@@ -73,7 +73,8 @@ class QuickDebugSourceInstallingCompilationParticipantTest extends AbstractXtend
 							7:12
 							4:13,2
 							*E
-						'''.toString, debug)
+						'''.toString.replace("\r", ""),
+							debug.replace("\r", ""))
 						debugInfoFound.set(true)
 					}
 					super.visitSource(source, debug)

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/compiler/QuickDebugSourceInstallingCompilationParticipantTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/compiler/QuickDebugSourceInstallingCompilationParticipantTest.java
@@ -123,7 +123,8 @@ public class QuickDebugSourceInstallingCompilationParticipantTest extends Abstra
               _builder.newLine();
               _builder.append("*E");
               _builder.newLine();
-              Assert.assertEquals(_builder.toString(), debug);
+              Assert.assertEquals(_builder.toString().replace("\r", ""), 
+                debug.replace("\r", ""));
               debugInfoFound.set(true);
             }
             super.visitSource(source, debug);

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/filesystemaccess/src/main/java/myannotation/MyAnnotation.xtend
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/filesystemaccess/src/main/java/myannotation/MyAnnotation.xtend
@@ -61,12 +61,13 @@ class MyAnnotationProcessor extends AbstractClassProcessor {
 		assertTrue(
 			userCodeFile.toString.endsWith("/filesystemaccess-client/src/main/java/myusercode/UserCode.xtend"))
 
-		val userCodeContent = 
-			"package myusercode\n"
-			+ "\n"
-			+"@myannotation.MyAnnotation\n"
-			+"class MyClass {\n"
-			+"}\n"
+		val userCodeContent = '''
+			package myusercode
+			
+			@myannotation.MyAnnotation
+			class MyClass {
+			}
+		'''
 		
 		assertEquals(userCodeContent, userCodeFile.contents)
 		assertEquals(userCodeContent, CharStreams.toString(new InputStreamReader(userCodeFile.contentsAsStream)))

--- a/org.eclipse.xtext.maven.plugin/src/test/java/org/eclipse/xtext/maven/plugin/XtextGeneratorIT.java
+++ b/org.eclipse.xtext.maven.plugin/src/test/java/org/eclipse/xtext/maven/plugin/XtextGeneratorIT.java
@@ -49,6 +49,7 @@ public class XtextGeneratorIT {
 	static public void setUpOnce() throws IOException, VerificationException {
 		testDir = extractTestRoot();
 		if (fork) {
+			System.out.println("maven.home=" + System.getProperty("maven.home"));
 			File mvnExecutable = new File(new Verifier(testDir.getAbsolutePath()).getExecutable());
 			if (!mvnExecutable.exists()) {
 				String mavenHome = findMaven();


### PR DESCRIPTION
This contributes two main features:

- The Windows GitHub Actions workflow is re-enabled. It's slower than Linux but faster than macOS (about 1:10 instead of 1:30). Note that two tests had to be adjusted to deal with Windows eols
- By retrieving the home of the installed Maven wrapper, the same Maven wrapper installation is used to run all our Maven plugins ITs, enforcing consistency and reproducibility and allowing us to rely only on the wrapper instead of the possibly installed Maven (in Jenkins, I modified the workflows accordingly).