### PR TITLE
Tycho 4

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.2/apache-maven-3.9.2-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/org.eclipse.xtend.lib.tests/.classpath
+++ b/org.eclipse.xtend.lib.tests/.classpath
@@ -12,5 +12,5 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="output" path="target/test-classes"/>
 </classpath>

--- a/org.eclipse.xtend.lib.tests/pom.xml
+++ b/org.eclipse.xtend.lib.tests/pom.xml
@@ -28,6 +28,21 @@
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<failIfNoTests>true</failIfNoTests>
+				</configuration>
+				<dependencies>
+					<!-- force to run with JUnit4 -->
+					<dependency>
+						<groupId>org.apache.maven.surefire</groupId>
+						<artifactId>surefire-junit47</artifactId>
+						<version>${maven-surefire-version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
@@ -15,7 +15,6 @@
 		<!-- The @...@ will be replaced during resource filtering with
 			the current version of our project -->
 		<xtext-version>@project.version@</xtext-version>
-		<tycho-version>2.7.5</tycho-version>
 		<eclipse-text-version>3.12.300</eclipse-text-version>
 		<core-resources-version>3.18.200</core-resources-version>
 		<core-runtime-version>3.26.100</core-runtime-version>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ17/mavenTychoJ17.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ17/mavenTychoJ17.parent/pom.xml
@@ -13,7 +13,7 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 		<!-- Tycho settings -->
-		<tycho-version>3.0.5</tycho-version>
+		<tycho-version>4.0.6</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->
 		<platformSystemProperties></platformSystemProperties>
 		<moduleProperties></moduleProperties>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J17/mavenTychoP2J17.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J17/mavenTychoP2J17.parent/pom.xml
@@ -13,7 +13,7 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 		<!-- Tycho settings -->
-		<tycho-version>3.0.5</tycho-version>
+		<tycho-version>4.0.6</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->
 		<platformSystemProperties></platformSystemProperties>
 		<moduleProperties></moduleProperties>

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/pom.xml
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/pom.xml
@@ -24,7 +24,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<!-- Tycho settings -->
-		<tycho-version>4.0.4</tycho-version>
+		<tycho-version>4.0.6</tycho-version>
 		<targetplatform.groupId>${project.groupId}</targetplatform.groupId>
 		<targetplatform.artifactId>${project.groupId}.tp</targetplatform.artifactId>
 		<targetplatform.version>${project.version}</targetplatform.version>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
@@ -70,7 +70,7 @@ class ParentProjectDescriptor extends ProjectDescriptor {
 	}
 
 	def String getTychoVersion() {
-		'3.0.5'
+		'4.0.6'
 	}
 	
 	def String getTychoVersionJ11() {

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
@@ -106,7 +106,7 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
   }
 
   public String getTychoVersion() {
-    return "3.0.5";
+    return "4.0.6";
   }
 
   public String getTychoVersionJ11() {

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
-		<tycho-version>3.0.5</tycho-version>
+		<tycho-version>4.0.6</tycho-version>
 
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -464,7 +464,7 @@
 							<configuration>
 								<rules>
 									<requireMavenVersion>
-										<version>3.9.2</version>
+										<version>3.9.6</version>
 									</requireMavenVersion>
 								</rules>
 							</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -521,8 +521,9 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven-surefire-version}</version>
 					<!--
-					This is not needed now, but will be needed when switching to Tycho 4.0.0
+					This is needed due to changes in Tycho 4.0.0
 					see https://github.com/eclipse-tycho/tycho/blob/master/RELEASE_NOTES.md#using-integrationplugin-tests-with-eclipse-plugin-packaging
+					-->
 					<executions>
 						<execution>
 							<id>execute-unit-tests</id>
@@ -531,7 +532,6 @@
 							</goals>
 						</execution>
 					</executions>
-					-->
 					<configuration>
 						<!--
 						The Surefire Plugin excludes nested classes by default: http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#excludes


### PR DESCRIPTION
Closes #2694

I've also taken the chance to update our Maven wrapper to 3.9.6

Note that I had to do a few adjustments concerning tests that must be executed with maven-surefire, since as documented, Tycho 4 does not automatically enable maven-surefire anymore.