### PR TITLE
Fix incorrect encoding for URIs that contain escaped sequences and a fragment

### DIFF
--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/UriExtensionsTest.java
@@ -317,6 +317,12 @@ public class UriExtensionsTest {
 		assertSame(uriWithAuthority, uriExtensions.withEmptyAuthority(uriWithAuthority));
 	}
 
+	@Test
+	public void testEscapedSequenceWithFragment() throws Exception {
+		assertEquals(URI.createURI("file:///path/to%20the/resource#ABC"),
+				uriExtensions.toUri(("file:///path/to%20the/resource#ABC")));
+	}
+
 	private Path createTempDir(final String prefix) throws Exception {
 		return Files.createTempDirectory(getTempDirPath(), prefix);
 	}

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/UriExtensions.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/UriExtensions.java
@@ -101,7 +101,7 @@ public class UriExtensions {
 			query = URI.encodeQuery(URI.decode(query), false);
 		}
 		if (fragment != null) {
-			query = URI.encodeFragment(URI.decode(fragment), false);
+			fragment = URI.encodeFragment(URI.decode(fragment), false);
 		}
 		// Depending on the shape of the URI recreate it from the decomposed parts which are now
 		// correctly encoded in a minimal (only the strictly necessary but no optional escape sequences) way


### PR DESCRIPTION
Fix for #2963 