### PR TITLE
Provide an abstract base class to be able to test the formatter.

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/AbstractXtendFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/AbstractXtendFormatterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,131 +8,62 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
-import com.google.inject.Inject
-import org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys
 import org.eclipse.xtend.core.tests.RuntimeInjectorProvider
+import org.eclipse.xtext.preferences.MapBasedPreferenceValues
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
-import org.eclipse.xtext.testing.formatter.FormatterTestHelper
-import org.eclipse.xtext.preferences.MapBasedPreferenceValues
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.eclipse.xtext.util.TextRegion
 import org.junit.runner.RunWith
 
-import static org.eclipse.xtext.formatting2.FormatterPreferenceKeys.*
+@RunWith(XtextRunner)
+@InjectWith(RuntimeInjectorProvider)
+abstract class AbstractXtendFormatterTest extends AbstractFormatterTest {
 
-@RunWith(typeof(XtextRunner))
-@InjectWith(typeof(RuntimeInjectorProvider))
-abstract class AbstractXtendFormatterTest {
-	@Inject protected FormatterTestHelper tester
-
-	def assertFormatted(CharSequence toBeFormatted) {
-		assertFormatted(toBeFormatted, toBeFormatted/* .parse.flattenWhitespace  */)
+	protected def String decode(CharSequence seq) {
+		seq.toString.replace("<<", "«").replace(">>", "»").replace("```", "'''")
 	}
 
-	def private toMember(CharSequence expression) '''
-		package foo
-		
-		class bar {
-			«expression»
-		}
-	'''
-
-	def assertFormattedExpression((MapBasedPreferenceValues)=>void cfg, CharSequence toBeFormatted) {
-		assertFormattedExpression(cfg, toBeFormatted, toBeFormatted)
-	}
-
-	def assertFormattedExpression(CharSequence toBeFormatted) {
+	protected def assertFormattedExpression(CharSequence toBeFormatted) {
 		assertFormattedExpression(null, toBeFormatted, toBeFormatted)
 	}
 
-	def assertFormattedExpression(String expectation, CharSequence toBeFormatted) {
+	protected def assertFormattedExpression(String expectation, CharSequence toBeFormatted) {
 		assertFormattedExpression(null, expectation, toBeFormatted)
 	}
 
-	def assertFormattedExpression((MapBasedPreferenceValues)=>void cfg, CharSequence expectation,
+	protected def assertFormattedExpression((MapBasedPreferenceValues)=>void cfg, CharSequence expectation,
 		CharSequence toBeFormatted) {
 		assertFormattedExpression(cfg, expectation, toBeFormatted, false)
 	}
 
-	def assertFormattedExpression((MapBasedPreferenceValues)=>void cfg, CharSequence expectation,
-		CharSequence toBeFormatted, boolean allowErrors) {
-		assertFormatted(
-			cfg,
-			expectation.toString.trim.replace("\n", "\n\t\t"),
-			toBeFormatted.toString.trim.replace("\n", "\n\t\t"),
-			"class bar {\n\tdef baz() {\n\t\t",
-			"\n\t}\n}",
-			allowErrors
-		)
-	}
-
-	def assertFormattedMember(String expectation, CharSequence toBeFormatted) {
-		assertFormatted(expectation.toMember, toBeFormatted.toMember)
-	}
-
-	def assertFormattedMember((MapBasedPreferenceValues)=>void cfg, String expectation, CharSequence toBeFormatted) {
-		assertFormatted(cfg, expectation.toMember, toBeFormatted.toMember)
-	}
-
-	def assertFormattedMember((MapBasedPreferenceValues)=>void cfg, String expectation) {
-		assertFormatted(cfg, expectation.toMember, expectation.toMember)
-	}
-
-	def assertFormattedMember(String expectation) {
-		assertFormatted(expectation.toMember, expectation.toMember)
-	}
-
-	def assertFormatted((MapBasedPreferenceValues)=>void cfg, CharSequence expectation) {
-		assertFormatted(cfg, expectation, expectation)
-	}
-
-	def assertFormatted(CharSequence expectation, CharSequence toBeFormatted) {
-		assertFormatted(null, expectation, toBeFormatted)
-	}
-
-	def assertFormatted((MapBasedPreferenceValues)=>void cfg, CharSequence expectation, CharSequence toBeFormatted) {
-		assertFormatted(cfg, expectation, toBeFormatted, "", "", false)
-	}
-
-	def assertFormatted(
-		(MapBasedPreferenceValues)=>void cfg,
-		CharSequence expectation,
-		CharSequence toBeFormatted,
-		String prefix,
-		String postfix,
-		boolean allowErrors
-	) {
-		tester.assertFormatted [
-			it.preferences = [
-				put(maxLineWidth, 80)
-				put(XtendFormatterPreferenceKeys.keepOneLineMethods, false)
-				cfg?.apply(it)
-			]
-			it.expectation = prefix + expectation + postfix
-			it.toBeFormatted = prefix + toBeFormatted + postfix
-			it.request.regions += new TextRegion(prefix.length, toBeFormatted.length)
-			it.allowSyntaxErrors = allowErrors
-		]
-	}
-
-	def protected String decode(CharSequence seq) {
-		seq.toString.replace("<<", "«").replace(">>", "»").replace("```", "'''")
-	}
-
-	def void assertFormattedRichStringExpression(CharSequence seq) {
+	protected def assertFormattedRichStringExpression(CharSequence seq) {
 		assertFormattedExpression(seq.decode)
 	}
 
-	def void assertFormattedRichString(CharSequence seq) {
-		assertFormatted(seq.decode)
-	}
-
-	def void assertFormattedRichStringExpression(CharSequence expected, CharSequence actual) {
+	protected def assertFormattedRichStringExpression(CharSequence expected, CharSequence actual) {
 		assertFormattedExpression(expected.decode, actual.decode)
 	}
 
-	def void assertFormattedRichStringExpressionWithErrors(CharSequence actual) {
+	protected def assertFormattedRichStringExpressionWithErrors(CharSequence actual) {
 		assertFormattedExpression(null, actual.decode, actual.decode, true)
 	}
 
+	private def assertFormattedExpression((MapBasedPreferenceValues)=>void cfg, CharSequence expectation,
+		CharSequence toBeFormatted, boolean allowErrors) {
+
+		val prefix = "class bar {\n\tdef baz() {\n\t\t"
+		val postfix = "\n\t}\n}" 
+
+		formatterTestHelper.assertFormatted [
+			it.preferences = [
+				cfg?.apply(it)
+			]
+			it.expectation = prefix + expectation.toString.trim.replace("\n", "\n\t\t") + postfix
+			it.toBeFormatted = prefix + toBeFormatted.toString.trim.replace("\n", "\n\t\t") + postfix
+			it.request.regions += new TextRegion(prefix.length, toBeFormatted.toString.trim.replace("\n", "\n\t\t").length)
+			it.allowSyntaxErrors = allowErrors
+		]
+
+	}
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/AnonymousClassFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/AnonymousClassFormatterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,29 +8,32 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.junit.Test
+import org.junit.runner.RunWith
 
 import static org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys.*
 
-class AnonymousClassFormatterTest extends AbstractXtendFormatterTest {
+@RunWith(XtextRunner)
+@InjectWith(RuntimeInjectorProvider)
+class AnonymousClassFormatterTest extends AbstractFormatterTest {
 
 	@Test def formatSingleMember() {
-		assertFormatted([
-			put(bracesInNewLine, false)
-		],'''
+		'''
 			class Foo {
 				val foo = new Runnable() {
 					override run() {
 					}
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, false)]
 	}
-	
+
 	@Test def formatMultiMember() {
-		assertFormatted([
-			put(bracesInNewLine, false)
-		],'''
+		'''
 			class Foo {
 				val foo = new Runnable() {
 					int bar
@@ -42,13 +45,11 @@ class AnonymousClassFormatterTest extends AbstractXtendFormatterTest {
 					}
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, false)]
 	}
 
 	@Test def formatTypeParam() {
-		assertFormatted([
-			put(bracesInNewLine, false)
-		],'''
+		'''
 			class Foo {
 				val foo = new Iterable<String>() {
 					override iterator() {
@@ -56,13 +57,11 @@ class AnonymousClassFormatterTest extends AbstractXtendFormatterTest {
 					}
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, false)]
 	}
 
 	@Test def formatNested() {
-		assertFormatted([
-			put(bracesInNewLine, false)
-		],'''
+		'''
 			import java.util.Iterator
 
 			class Foo {
@@ -72,17 +71,17 @@ class AnonymousClassFormatterTest extends AbstractXtendFormatterTest {
 							override hasNext() {
 								true
 							}
-			
+
 							override next() {
 								null
 							}
-			
+
 							override remove() {
 							}
 						}
 					}
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, false)]
 	}
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/TypeVariableFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/TypeVariableFormatterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,18 +8,18 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.junit.Test
+import org.junit.runner.RunWith
 
-class TypeVariableFormatterTest extends AbstractXtendFormatterTest {
-	def CharSequence refToFile(CharSequence string) '''
-		import java.util.*
-		
-		class Foo {
-			«string» x
-		}
-	'''
-
-	def CharSequence paramToFile(CharSequence string) '''
+@RunWith(XtextRunner)
+@InjectWith(RuntimeInjectorProvider)
+class TypeVariableFormatterTest extends AbstractFormatterTest {
+	
+	private def CharSequence paramToFile(CharSequence string) '''
 		import java.util.*
 		
 		class Foo«string» {
@@ -27,11 +27,11 @@ class TypeVariableFormatterTest extends AbstractXtendFormatterTest {
 	'''
 
 	def assertTypeParam(CharSequence toBeFormatted) {
-		assertFormatted(toBeFormatted.paramToFile)
+		toBeFormatted.paramToFile.assertUnformattedEqualsFormatted
 	}
 	
 	@Test def integration() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			import java.util.*
 			
 			class Foo<T extends Collection<?>, K extends Collection<?>> {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendAnnotationTypeFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendAnnotationTypeFormatterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,127 +8,122 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.junit.Ignore
 import org.junit.Test
+import org.junit.runner.RunWith
 
 import static org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys.*
 
-class XtendAnnotationTypeFormatterTest extends AbstractXtendFormatterTest {
+@RunWith(XtextRunner)
+@InjectWith(RuntimeInjectorProvider)
+class XtendAnnotationTypeFormatterTest extends AbstractFormatterTest {
+
 	@Test def formatPublic() {
-		assertFormatted([
-		],'''
+		'''
 			public annotation Bar {
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatAbstract() {
-		assertFormatted([
-		],'''
+		'''
 			abstract annotation Bar {
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatPublicAbstract() {
-		assertFormatted([
-		],'''
+		'''
 			public abstract annotation Bar {
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatField01() {
-		assertFormatted([
-		],'''
+		'''
 			annotation Bar {
 				int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatField02() {
-		assertFormatted([
-		],'''
+		'''
 			annotation Bar {
 				int foo
 				int baz
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Ignore
 	@Test def formatFieldInit01() {
-		assertFormatted([
-		],'''
+		'''
 			annotation Bar {
 				int foo = 1 + 1
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Ignore
 	@Test def formatFieldInit02() {
-		assertFormatted([
-		],'''
+		'''
 			annotation Bar {
 				int foo = 1 + 1
 				int baz = 1 + 1
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Ignore
 	@Test def formatFieldInit03() {
-		assertFormatted([
-		],'''
+		'''
 			annotation Bar {
 				val foo = 1 + 1
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Ignore
 	@Test def formatFieldInit04() {
-		assertFormatted([
-		],'''
+		'''
 			annotation Bar {
 				val foo = 1 + 1
 				val baz = 1 + 1
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatBraces_01() {
-		assertFormatted([
-			put(bracesInNewLine, false)
-		],'''
+		'''
 			package foo
 			
 			annotation Bar {
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, false)]
 	}
-	
+
 	@Test def formatBraces_02() {
-		assertFormatted([
-			put(bracesInNewLine, true)
-		],'''
+		'''
 			package foo
 			
 			annotation Bar
 			{
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, true)]
 	}
-	
+
 	@Test def formatFieldAnnotation() {
-		assertFormatted('''
+		'''
 			package foo
 			
 			annotation Bar {
 				@Deprecated int baz
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendAnnotationsFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendAnnotationsFormatterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,14 +8,23 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
+import org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider
+import org.eclipse.xtext.preferences.MapBasedPreferenceValues
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.junit.Ignore
 import org.junit.Test
+import org.junit.runner.RunWith
 
 import static org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys.*
 
-class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
-	
-	def protected toFile(CharSequence ann) '''
+@RunWith(XtextRunner)
+@InjectWith(RuntimeInjectorProvider)
+class XtendAnnotationsFormatterTest extends AbstractFormatterTest {
+
+	private def toFile(CharSequence ann) '''
 		package foo
 		
 		import java.lang.annotation.*
@@ -25,40 +34,40 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 		class bar {
 		}
 	'''
-	
-	def protected assertFormattedAnnotation(CharSequence expectation, CharSequence actual) {
-		assertFormatted(expectation.toFile, actual.toFile)
+
+	private def assertFormattedAnnotation(CharSequence expectation, CharSequence actual) {
+		actual.toFile.assertFormattedTo(expectation.toFile)
 	}
 	
 	@Test def formatClassSingleAnnotationSL() {
-		assertFormatted([
-			it.put(newLineAfterClassAnnotations, false)
-			it.put(preserveNewLines, true)
-		], '''
+		 '''
+			package foo @Deprecated class bar { }
+		'''.assertFormattedTo('''
 			package foo
 			
 			@Deprecated class bar {
 			}
-		''', '''
-			package foo @Deprecated class bar { }
-		''')	
-	}
-	
-	@Test def formatClassSingleAnnotationML1() {
-		assertFormatted([
+		''', [
 			put(newLineAfterClassAnnotations, false)
 			put(preserveNewLines, true)
-		],'''
+		])
+	}
+
+	@Test def formatClassSingleAnnotationML1() {
+		'''
 			package foo
 			
 			@Deprecated
 			class bar {
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[
+			put(newLineAfterClassAnnotations, false)
+			put(preserveNewLines, true)			
+		]	
 	}
-	
+
 	@Test def formatClassSingleAnnotationML11() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 			
 			@SuppressWarnings("restriction")
@@ -66,33 +75,33 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')	
 	}
-	
+
 	@Test def formatClassSingleAnnotationML2() {
-		assertFormatted([
-			it.put(newLineAfterClassAnnotations, true)
-			it.put(preserveNewLines, true)
-		],'''
+		'''
+			package foo @Deprecated class bar { }
+		'''.assertFormattedTo('''
 			package foo
 			
 			@Deprecated
 			class bar {
 			}
-		''', '''
-			package foo @Deprecated class bar { }
-		''')	
+		''', [
+			put(newLineAfterClassAnnotations, true)
+			put(preserveNewLines, true)
+		])
 	}
-	
+
 	@Test def formatClassTwoAnnotationsSL() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 			
 			@Override @Deprecated class bar {
 			}
 		''')	
 	}
-	
+
 	@Test def formatClassTwoAnnotationsML1() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 			
 			@Override
@@ -101,9 +110,9 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')	
 	}
-	
+
 	@Test def formatClassTwoAnnotationsML2() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 			
 			@Override @Deprecated
@@ -111,7 +120,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')	
 	}
-	
+
 	@Test def formatConstructorTwoAnnotations1() {
 		assertFormattedMember([
 			put(newLineAfterConstructorAnnotations, false)
@@ -123,7 +132,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')	
 	}
-	
+
 	@Test def formatConstructorTwoAnnotations2() {
 		assertFormattedMember([
 			put(newLineAfterConstructorAnnotations, true)
@@ -135,7 +144,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')	
 	}
-	
+
 	@Test def formatConstructorTwoAnnotationsSL1() {
 		assertFormattedMember([
 			put(newLineAfterConstructorAnnotations, false)
@@ -150,7 +159,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')	
 	}
-	
+
 	@Test def formatConstructorTwoAnnotationsSL2() {
 		assertFormattedMember([
 			put(newLineAfterConstructorAnnotations, false)
@@ -160,15 +169,15 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')	
 	}
-	
+
 	@Test def formatConstructorSingleAnnotations() {
-		assertFormattedMember('''
+		'''
 			@Deprecated
 			new() {
 			}
-		''')	
+		'''.toMember.assertUnformattedEqualsFormatted	
 	}
-	
+
 	@Test def formatConstructorParameterTwoAnnotations() {
 		assertFormattedMember('''
 			new(@Override @Deprecated String p) {
@@ -177,7 +186,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			new(  @Override  @Deprecated  String  p  ) {  }
 		''')	
 	}
-	
+
 	@Test def formatConstructorParameterSingleAnnotations() {
 		assertFormattedMember('''
 			new(@Deprecated String p) {
@@ -186,7 +195,6 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			new(  @Deprecated  String   p  ) {  }
 		''')	
 	}
-	
 	
 	@Test def formatFieldTwoAnnotations1() {
 		assertFormattedMember([
@@ -198,7 +206,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			int value
 		''')	
 	}
-	
+
 	@Test def formatFieldTwoAnnotations2() {
 		assertFormattedMember([
 			put(newLineAfterFieldAnnotations, false)
@@ -207,7 +215,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			@Override @Deprecated int value
 		''')	
 	}
-	
+
 	@Test def formatFieldSingleAnnotations1() {
 		assertFormattedMember([
 			put(newLineAfterFieldAnnotations, true)
@@ -217,7 +225,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			int value
 		''')	
 	}
-	
+
 	@Test def formatFieldSingleAnnotations2() {
 		assertFormattedMember([
 			put(newLineAfterFieldAnnotations, false)
@@ -226,7 +234,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			@Override int value
 		''')	
 	}
-	
+
 	@Test def formatMethodTwoAnnotations1() {
 		assertFormattedMember([
 			put(newLineAfterMethodAnnotations, true)
@@ -238,7 +246,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')	
 	}
-	
+
 	@Test def formatMethodTwoAnnotations2() {
 		assertFormattedMember([
 			put(newLineAfterMethodAnnotations, true)
@@ -262,9 +270,10 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')	
 	}
-	
+
 	@Test def formatMethodTwoAnnotations4() {
 		assertFormattedMember([
+			put(XtendFormatterPreferenceKeys.keepOneLineMethods, false)
 			put(newLineAfterMethodAnnotations, false)
 			put(preserveNewLines, false)
 		],'''
@@ -276,7 +285,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			def foo() {  }
 		''')	
 	}
-	
+
 	@Test def formatMethodSingleAnnotations() {
 		assertFormattedMember('''
 			@Deprecated
@@ -287,9 +296,10 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			def foo() {  }
 		''')	
 	}
-	
+
 	@Test def formatMethodParameterTwoAnnotations1() {
 		assertFormattedMember([
+			put(XtendFormatterPreferenceKeys.keepOneLineMethods, false)
 			put(newLineAfterParameterAnnotations, false)
 			put(preserveNewLines, true)
 		],'''
@@ -299,7 +309,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			def foo(  @Override  @Deprecated  String  p  ) {  }
 		''')	
 	}
-	
+
 	@Ignore @Test def formatMethodParameterTwoAnnotations2() {
 		assertFormattedMember([
 			put(newLineAfterParameterAnnotations, true)
@@ -314,7 +324,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			def foo(  @Override  @Deprecated  String  p  ) {  }
 		''')	
 	}
-	
+
 	@Test def formatMethodParameterSingleAnnotations() {
 		assertFormattedMember('''
 			def foo(@Deprecated String p) {
@@ -323,7 +333,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			def foo(  @Deprecated  String   p  ) {  }
 		''')	
 	}
-	
+
 	@Test def formatAnnotationSingeValue() {
 		assertFormattedAnnotation('''
 			@SuppressWarnings("all")
@@ -331,7 +341,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			@  SuppressWarnings  (  "all"  )
 		''')	
 	}
-	
+
 	@Test def formatAnnotationListValue3() {
 		assertFormattedAnnotation('''
 			@SuppressWarnings(#[])
@@ -339,7 +349,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			@SuppressWarnings(#  [  ]  )
 		''')	
 	}
-	
+
 	@Test def formatAnnotationListValue4() {
 		assertFormattedAnnotation('''
 			@SuppressWarnings(#["all"])
@@ -347,7 +357,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			@SuppressWarnings(  #  [  "all"  ]  )
 		''')	
 	}
-	
+
 	@Test def formatAnnotationListValue5() {
 		assertFormattedAnnotation('''
 			@SuppressWarnings(#["all", "access"])
@@ -355,7 +365,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			@SuppressWarnings( #   [  "all"  ,   "access"  ]  )
 		''')	
 	}
-	
+
 	@Test def formatAnnotationAssignedSingeValue() {
 		assertFormattedAnnotation('''
 			@SuppressWarnings(value="all")
@@ -363,7 +373,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			@SuppressWarnings(  value  =  "all"  )
 		''')	
 	}
-	
+
 	@Test def formatAnnotationAssignedListValue_1() {
 		assertFormattedAnnotation('''
 			@SuppressWarnings(value=#["all", "access"])
@@ -371,7 +381,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			@SuppressWarnings(  value  =#  [  "all"  ,   "access"  ]  )
 		''')	
 	}
-	
+
 	@Test def formatAnnotationMultiAssignments() {
 		assertFormattedAnnotation('''
 			@GwtCompatible(serializable=true, emulated=true)
@@ -379,7 +389,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			@GwtCompatible(  serializable  =  true,  emulated  =  true  )
 		''')	
 	}
-	
+
 	@Test def formatAnnotationEnumLiteral() {
 		assertFormattedAnnotation('''
 			@Retention(RetentionPolicy::CLASS)
@@ -387,7 +397,7 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 			@Retention(  RetentionPolicy::  CLASS  )
 		''')	
 	}
-	
+
 	@Ignore("https://bugs.eclipse.org/bugs/show_bug.cgi?id=393349")
 	@Test def formatAnnotationStringConcatenation() {
 		assertFormattedAnnotation('''
@@ -397,7 +407,23 @@ class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
 		''')	
 	}
 	
-	
+	private def assertFormattedMember(String expectation, CharSequence toBeFormatted) {
+		toBeFormatted.toMember.assertFormattedTo(expectation.toMember, [put(XtendFormatterPreferenceKeys.keepOneLineMethods, false)])
+	}
+
+	private def assertFormattedMember((MapBasedPreferenceValues)=>void cfg, String expectation, CharSequence toBeFormatted) {
+		toBeFormatted.toMember.assertFormattedTo(expectation.toMember, cfg)
+	}
+
+	private def assertFormattedMember((MapBasedPreferenceValues)=>void cfg, String expectation) {
+		expectation.toMember.assertUnformattedEqualsFormatted(cfg)
+	}
+
+	private def toMember(CharSequence expression) '''
+		package foo
 		
-	
+		class bar {
+			«expression»
+		}
+	'''
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendClassFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendClassFormatterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,67 +8,72 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.junit.Test
+import org.junit.runner.RunWith
 
+import static org.eclipse.xtext.formatting2.FormatterPreferenceKeys.*
 import static org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys.*
 
-class XtendClassFormatterTest extends AbstractXtendFormatterTest {
+@RunWith(XtextRunner)
+@InjectWith(RuntimeInjectorProvider)
+class XtendClassFormatterTest extends AbstractFormatterTest {
+
 	@Test def formatConstructor01() {
-		assertFormatted([
-			put(bracesInNewLine, false)
-		],'''
+		'''
 			class bar {
 				new() {
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, false)]
 	}
-	
+
 	@Test def formatConstructor02() {
-		assertFormatted([
-			put(bracesInNewLine, true)
-		],'''
+		'''
 			class bar
 			{
 				new()
 				{
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, true)]
 	}
-	
+
 	@Test def formatConstructor1() {
-		assertFormatted('''
+		'''
 			class bar {
 				new() {
 					super()
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatConstructor2() {
-		assertFormatted('''
+		'''
 			class bar {
 				new(String x) {
 					super(x)
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatConstructor3() {
-		assertFormatted('''
+		'''
 			class bar {
 				new(String x, String y) {
 					super(x, y)
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatConstructor4() {
-		assertFormatted('''
+		'''
 			package foo
 
 			class bar {
@@ -81,167 +86,146 @@ class XtendClassFormatterTest extends AbstractXtendFormatterTest {
 				) {
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
-	
-	
+
 	@Test def formatField01() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatField02() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				int foo
 				int baz
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldInit01() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				int foo = 1 + 1
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldInit02() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				int foo = 1 + 1
 				int baz = 1 + 1
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldVal() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				val int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldVar() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				var int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldStatic02() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				static int bar
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldStaticVal() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				static val int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldStaticVar() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				static var int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldExtension01() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				extension String
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldExtensionInit01() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				extension String = "a" + "b"
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldExtensionInit02() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				extension String = "a" + "b"
 				extension Integer = 1 + 2
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldExtensionVal01() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				extension val String
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldExtensionVar01() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				extension var String
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldExtension02() {
-		assertFormatted([
-		],'''
+		'''
 			class bar {
 				extension String
 				extension Integer
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatMethod01() {
-		assertFormatted([
-			put(bracesInNewLine, false)
-		],'''
+		'''
 			package foo
 			
 			class bar {
 				def baz() {
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, false)]
 	}
-	
+
 	@Test def formatMethod02() {
-		assertFormatted([
-			put(bracesInNewLine, true)
-		],'''
+		'''
 			package foo
 			
 			class bar
@@ -250,33 +234,33 @@ class XtendClassFormatterTest extends AbstractXtendFormatterTest {
 				{
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, true)]
 	}
-	
+
 	@Test def formatMethod1() {
-		assertFormatted('''
+		'''
 			package foo
 			
 			class bar {
 				def baz(String x) {
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatMethod2() {
-		assertFormatted('''
+		'''
 			package foo
 			
 			class bar {
 				def baz(String x, String y) {
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatMethod3() {
-		assertFormatted('''
+		'''
 			package foo
 
 			class bar {
@@ -285,11 +269,11 @@ class XtendClassFormatterTest extends AbstractXtendFormatterTest {
 					String p13, String p14) {
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(maxLineWidth, 80)]
 	}
-	
+
 	@Test def formatMethod4() {
-		assertFormatted('''
+		'''
 			package foo
 
 			class bar {
@@ -302,32 +286,39 @@ class XtendClassFormatterTest extends AbstractXtendFormatterTest {
 				) {
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatAbstractMethod1() {
-		assertFormatted('''
+		'''
 			abstract class bar {
 				def baz()
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatAbstractMethod2() {
-		assertFormatted('''
+		'''
 			abstract class bar {
 				def foo()
 
 				def baz()
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
-	
+
 	@Test def formatMethodMultiline() {
-		assertFormatted('''
+		'''
 			package foo
-			
+
+			class bar {
+				def baz(String x, String y
+				) {
+				}
+			}
+		'''.assertFormattedTo('''
+			package foo
+
 			class bar {
 				def baz(
 					String x,
@@ -335,26 +326,17 @@ class XtendClassFormatterTest extends AbstractXtendFormatterTest {
 				) {
 				}
 			}
-		''', '''
-			package foo
-			
-			class bar {
-				def baz(String x, String y
-				) {
-				}
-			}
-		''')	
+		''')
 	}
-	
-	
+
 	@Test def formatMethodAnnotation() {
-		assertFormatted('''
+		'''
 			package foo
 			
 			class bar {
 				@Deprecated def baz() {
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendCommentFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendCommentFormatterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,278 +8,286 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.junit.Ignore
 import org.junit.Test
+import org.junit.runner.RunWith
 
-class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
+@RunWith(XtextRunner)
+@InjectWith(RuntimeInjectorProvider)
+class XtendCommentFormatterTest extends AbstractFormatterTest {
+
 	@Test def formatMLCommentBeforePackage() {
-		assertFormatted('''
-			/***********
-			 * copyright
-			 ***********/
-			package foo
-			
-			class zonk {
-			}
-		''', '''
+		'''
 			/***********
 			 * copyright
 			 ***********/package foo
 			class zonk {}
-		''')	
+		'''.assertFormattedTo('''
+			/***********
+			 * copyright
+			 ***********/
+			package foo
+			
+			class zonk {
+			}
+		''')
 	}
-	
+
 	@Test def formatMLComment1() {
-		assertFormatted('''
+		'''
+			/***********
+			copyright
+			***********/
+			class zonk {}
+		'''.assertFormattedTo('''
 			/***********
 			 * copyright
 			 ***********/
 			class zonk {
 			}
-		''', '''
-			/***********
-			copyright
-			***********/
-			class zonk {}
-		''')	
+		''')
 	}
-	
+
 	@Test def formatSLCommentAfterStatement() {
-		assertFormatted('''
-			package foo // my comment
-			
-			class bar {
-			}
-		''', '''
+		'''
 			package foo // my comment
 			class bar{}
-		''')	
-	}
-	
-	@Test def formatSLCommentBeforeStatement1() {
-		assertFormatted('''
-			package foo
+		'''.assertFormattedTo('''
+			package foo // my comment
 			
-			// my comment
 			class bar {
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatSLCommentBeforeStatement1() {
+		'''
 			package foo 
 			// my comment
 			class bar{}
-		''')	
-	}
-	
-	@Test def formatSLCommentBeforeStatement2() {
-		assertFormatted('''
+		'''.assertFormattedTo('''
 			package foo
 			
-			import java.util.Map
-			
 			// my comment
 			class bar {
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatSLCommentBeforeStatement2() {
+		'''
 			package foo import java.util.Map 
-			
-			
-			
-			
+
+
+
+
 			// my comment
 			class bar{}
-		''')	
+		'''.assertFormattedTo('''
+			package foo
+
+			import java.util.Map
+
+			// my comment
+			class bar {
+			}
+		''')
 	}
-	
+
 	@Test def formatMLCommentAfterStatement() {
-		assertFormatted('''
+		'''
+			package foo /* my comment */
+			class bar{}
+		'''.assertFormattedTo('''
 			package foo /* my comment */
 			
 			class bar {
 			}
-		''', '''
-			package foo /* my comment */
-			class bar{}
-		''')	
+		''')
 	}
-	
+
 	@Test def formatSLCommentInStatement() {
-		assertFormatted('''
+		'''
+			package  /* my comment */  foo
+			class bar{}
+		'''.assertFormattedTo('''
 			package /* my comment */ foo
 			
 			class bar {
 			}
-		''', '''
-			package  /* my comment */  foo
-			class bar{}
-		''')	
+		''')
 	}
-	
+
 	@Test def formatMLCommentInStatement() {
-		assertFormatted('''
+		'''
+			package  /* my 
+			comment */  foo
+			class bar{}
+		'''.assertFormattedTo('''
 			package
 			/* my 
 			 comment */
 			foo
-			
+
 			class bar {
 			}
-		''', '''
-			package  /* my 
-			comment */  foo
-			class bar{}
-		''')	
+		''')
 	}
-	
+
 	@Test def formatMLCommentBeforeStatement1() {
-		assertFormatted('''
-			package foo
-			
-			/* my comment */
-			class bar {
-			}
-		''', '''
+		'''
 			package foo 
 			/* my comment */
 			class bar{}
-		''')	
-	}
-	
-	@Test def formatMLCommentBeforeStatement2() {
-		assertFormatted('''
-			import java.util.Map
-			
+		'''.assertFormattedTo('''
+			package foo
+
 			/* my comment */
 			class bar {
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatMLCommentBeforeStatement2() {
+		'''
 			import java.util.Map 
-			
-			
-			
-			
+
+
+
+
 			/* my comment */
 			class bar{}
-		''')	
-	}
-	
-	@Test def formatSLCommentAfterStatement2() {
-		assertFormatted('''
-			class bar { // my comment
+		'''.assertFormattedTo('''
+			import java.util.Map
+
+			/* my comment */
+			class bar {
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatSLCommentAfterStatement2() {
+		'''
 			class bar{    // my comment
 			}
-		''')	
-	}
-	
-	@Test def formatSLDocCommentInStatement21() {
-		assertFormatted('''
-			class bar {
-				// my comment
+		'''.assertFormattedTo('''
+			class bar { // my comment
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatSLDocCommentInStatement21() {
+		'''
 			class bar{
 			 //    my comment
 			}
-		''')	
-	}
-	
-	@Test def formatSLDocCommentInStatement22() {
-		assertFormatted('''
+		'''.assertFormattedTo('''
 			class bar {
-				//
+				// my comment
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatSLDocCommentInStatement22() {
+		'''
 			class bar{
 			 //    
 			}
-		''')	
-	}
-	
-	@Test def formatSLCodeCommentInStatement21() {
-		assertFormatted('''
+		'''.assertFormattedTo('''
 			class bar {
-			//    my comment
+				//
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatSLCodeCommentInStatement21() {
+		'''
 			class bar{
 			//    my comment
 			}
-		''')	
-	}
-	
-	@Test def formatMLCommentInBlock1() {
-		assertFormatted('''
+		'''.assertFormattedTo('''
 			class bar {
-				/*
-				 * my comment
-				 */
+			//    my comment
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatMLCommentInBlock1() {
+		'''
 			class bar{
 			/*
 			my comment
 			*/
 			}
-		''')	
-	}
-	
-	@Test def formatMLCommentInBlock2() {
-		assertFormatted('''
+		'''.assertFormattedTo('''
 			class bar {
 				/*
 				 * my comment
 				 */
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatMLCommentInBlock2() {
+		'''
 			class bar{
 					/*
 					my comment
 					*/
 			}
-		''')	
-	}
-	
-	@Test def formatMLCommentInBlock3() {
-		assertFormatted('''
+		'''.assertFormattedTo('''
 			class bar {
 				/*
 				 * my comment
 				 */
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatMLCommentInBlock3() {
+		'''
 			class bar{
 					/*
 							*my comment
 					*/
 			}
-		''')	
-	}
-	
-	@Test def formatMLCommentAfterStatement2() {
-		assertFormatted('''
-			class bar { /* my comment */
+		'''.assertFormattedTo('''
+			class bar {
+				/*
+				 * my comment
+				 */
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatMLCommentAfterStatement2() {
+		'''
 			class bar{   /* my comment */ 
 			}
-		''')	
-	}
-	
-	@Test def formatMLCommentBeforeStatement21() {
-		assertFormatted('''
-			class bar {
-				/* my comment */
+		'''.assertFormattedTo('''
+			class bar { /* my comment */
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatMLCommentBeforeStatement21() {
+		'''
 			class bar{
 			/* my comment */
 			}
-		''')	
+		'''.assertFormattedTo('''
+			class bar {
+				/* my comment */
+			}
+		''')
 	}
-	
+
 	@Test def formatMLCommentBeforeStatement22() {
-		assertFormatted('''
+		'''
 			class AATest {
 			
 				/**
@@ -288,27 +296,27 @@ class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
 				def foo() {
 				}
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Ignore("see https://bugs.eclipse.org/bugs/show_bug.cgi?id=415950")
 	@Test def formatSLCommentAtEndOfClass() {
-		assertFormatted('''
+		'''
 			class bar {
 				val i = 0
 				/* my comment */
 			}
-		''', '''
+		'''.assertFormattedTo('''
 			class bar{
 			val i = 0
 			/* my comment */
 			}
-		''')	
+		''')
 	}
-	
+
 	@Ignore("see https://bugs.eclipse.org/bugs/show_bug.cgi?id=415950")
 	@Test def formatSLCommentAtEndOfMethod() {
-		assertFormatted('''
+		'''
 			class FormatterIssue {
 				def method() {
 					val i = 0
@@ -316,18 +324,18 @@ class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
 					// comment
 				}
 			}
-		''')
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Ignore("see https://github.com/eclipse/xtext-xtend/issues/77")
 	@Test def formatSLCommentAfterCode() {
-		assertFormatted('''
+		'''
 			class bar {
 				def method() { // comment
 				
 					val i = 0
 				}
 			}
-		''')
+		'''.assertUnformattedEqualsFormatted
 	}
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendEnumFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendEnumFormatterTest.xtend
@@ -8,45 +8,46 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.junit.Test
+import org.junit.runner.RunWith
 
-import static org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys.*
 import static org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys.*
 
-class XtendEnumFormatterTest extends AbstractXtendFormatterTest {
+@RunWith(XtextRunner)
+@InjectWith(RuntimeInjectorProvider)
+class XtendEnumFormatterTest extends AbstractFormatterTest {
 	
 	@Test def formatPublic() {
-		assertFormatted([
-		],'''
+		'''
 			public enum Bar {
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted	
 	}
 	
 	@Test def formatLiteral01() {
-		assertFormatted([
-		],'''
+		'''
 			enum Bar {
 				FOO
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
 	
 	@Test def formatLiteral02() {
-		assertFormatted([
-		],'''
+		'''
 			enum Bar {
 				FOO,
 				BAR,
 				BAZ
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted	
 	}
 	
 	@Test def formatLiteral03() {
-		assertFormatted([
-			put(blankLinesBetweenEnumLiterals, 1)
-		],'''
+		'''
 			enum Bar {
 				FOO,
 			
@@ -54,29 +55,25 @@ class XtendEnumFormatterTest extends AbstractXtendFormatterTest {
 			
 				BAZ
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted	
 	}
 	
 	@Test def formatBraces_01() {
-		assertFormatted([
-			put(bracesInNewLine, false)
-		],'''
+		'''
 			package foo
 			
 			enum Bar {
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
 	
 	@Test def formatBraces_02() {
-		assertFormatted([
-			put(bracesInNewLine, true)
-		],'''
+		'''
 			package foo
 			
 			enum Bar
 			{
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, true)]	
 	}
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendFileFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendFileFormatterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,80 +8,83 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
+import org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.junit.Test
+import org.junit.runner.RunWith
 
+import static org.eclipse.xtext.formatting2.FormatterPreferenceKeys.*
 import static org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys.*
 
-class XtendFileFormatterTest extends AbstractXtendFormatterTest {
-	
+@RunWith(XtextRunner)
+@InjectWith(RuntimeInjectorProvider)
+class XtendFileFormatterTest extends AbstractFormatterTest {
+
 	@Test def formatClass11() {
-		assertFormatted([
-			put(bracesInNewLine, false)
-		],'''
+		'''
 			package foo
 			
 			class bar {
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, false)]
 	}
-	
+
 	@Test def formatClass12() {
-		assertFormatted([
-			put(bracesInNewLine, true)
-		],'''
+		'''
 			package foo
 			
 			class bar
 			{
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, true)]
 	}
-	
+
 	@Test def formatClass112() {
-		assertFormatted([
-			put(bracesInNewLine, false)
-		],'''
+		'''
 			package foo
 			
 			class bar {
 				int member1
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, false)]
 	}
-	
+
 	@Test def formatClass122() {
-		assertFormatted([
-			put(bracesInNewLine, true)
-		],'''
+		'''
 			package foo
 			
 			class bar
 			{
 				int member1
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, true)]
 	}
-	
+
 	@Test def formatClass111() {
-		assertFormatted('''
+		'''   package  foo  class  bar  {  }'''.assertFormattedTo('''
 			package foo
 			
 			class bar {
 			}
-			''', '''   package  foo  class  bar  {  }''')	
+		''')
 	}
-	
+
 	@Test def formatClass2() {
-		assertFormatted('''
+		'''
+			class bar{}
+		'''.assertFormattedTo('''
 			class bar {
 			}
-		''', '''
-			class bar{}
-		''')	
+		''')
 	}
-	
+
 	@Test def formatClass3() {
-		assertFormatted('''
+		'''
+			class bar{ int member1 int member2 def meth1() {} def meth2(){} int member3 }
+		'''.assertFormattedTo('''
 			class bar {
 				int member1
 				int member2
@@ -94,20 +97,11 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 			
 				int member3
 			}
-		''', '''
-			class bar{ int member1 int member2 def meth1() {} def meth2(){} int member3 }
-		''')	
+		''', [put(XtendFormatterPreferenceKeys.keepOneLineMethods, false)])
 	}
-	
+
 	@Test def formatClass31() {
-		assertFormatted('''
-			class bar {
-			
-				def meth1() {
-				}
-			
-			}
-		''', '''
+		'''
 			class bar{
 			
 
@@ -115,26 +109,18 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 
 
 			}
-		''')	
-	}
-	
-	@Test def formatClass4() {
-		assertFormatted('''
+		'''.assertFormattedTo('''
 			class bar {
-
-				int member1
-
-				int member2
 			
 				def meth1() {
 				}
 			
-				def meth2() {
-				}
-			
-				int member3
 			}
-		''', '''
+		''', [put(XtendFormatterPreferenceKeys.keepOneLineMethods, false)])
+	}
+
+	@Test def formatClass4() {
+		'''
 			class bar{
 				
 				
@@ -152,25 +138,28 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 				
 				int member3
 			}
-		''')	
+		'''.assertFormattedTo('''
+			class bar {
+
+				int member1
+
+				int member2
+			
+				def meth1() {
+				}
+			
+				def meth2() {
+				}
+			
+				int member3
+			}
+		''', [put(XtendFormatterPreferenceKeys.keepOneLineMethods, false)])
 	}
-	
+
 	@Test def formatClasses1() {
-		assertFormatted('''
-			package foo
-			
-			class bar {
-			}
-			
-			class baz {
-			}
-		''', '''
+		'''
 			package foo class bar{} class baz{}
-		''')	
-	}
-	
-	@Test def formatClasses2() {
-		assertFormatted('''
+		'''.assertFormattedTo('''
 			package foo
 			
 			class bar {
@@ -178,7 +167,11 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 			
 			class baz {
 			}
-		''', '''
+		''')
+	}
+
+	@Test def formatClasses2() {
+		'''
 			package foo 
 			
 			
@@ -188,11 +181,19 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 			
 			
 			class baz{}
-		''')	
+		'''.assertFormattedTo('''
+			package foo
+			
+			class bar {
+			}
+			
+			class baz {
+			}
+		''')
 	}
-	
+
 	@Test def formatImports1() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 			
 			import java.util.Map
@@ -202,20 +203,11 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 				def baz() {
 				}
 			}
-		''')	
+		''')
 	}
-	
+
 	@Test def formatImports2() {
-		assertFormatted('''
-			package foo
-			
-			import java.util.Map
-			
-			import java.util.Set
-			
-			class bar {
-			}
-		''', '''
+		'''
 			package foo
 			
 			import java.util.Map
@@ -227,11 +219,20 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 			
 			class bar {
 			}
-		''')	
+		'''.assertFormattedTo('''
+			package foo
+			
+			import java.util.Map
+			
+			import java.util.Set
+			
+			class bar {
+			}
+		''')
 	}
-	
+
 	@Test def formatPreferencesExample() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			class Movies {
 				def settings(XtendFormatterConfig config) {
 					val List<FormatterSetting> settings = newArrayList()
@@ -248,11 +249,11 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 					return settings
 				}
 			}
-		''')	
+		''', [put(maxLineWidth, 80)])
 	}
-	
+
 	@Test def formatPreferencesExample_02() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			class Movies {
 				def settings(XtendFormatterConfig config) {
 					val List<FormatterSetting> settings = newArrayList()
@@ -269,11 +270,11 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 					return settings
 				}
 			}
-		''')	
+		''', [put(maxLineWidth, 80)])
 	}
 
 	@Test def formatAssignment_01() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			class C {
 				int i
 			
@@ -281,11 +282,11 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 					this.i = 5
 				}
 			}
-		''')	
+		''')
 	}
 
 	@Test def formatAssignment_02() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			class C {
 				static int i
 			
@@ -293,16 +294,16 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 					C::i = 5
 				}
 			}
-		''')	
+		''')
 	}
-	
+
 	@Test def typeReferenceIntegration() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			import java.util.*
-			
+
 			abstract class Foo extends AbstractMap<String, Collection<?>> implements List<String>, Map<String, Collection<?>> {
 				String[] field
-			
+
 				def String[] methode(String[] param) {
 					val String[] valTypes = null
 					val featureCall1 = <String>newArrayList
@@ -324,5 +325,5 @@ class XtendFileFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')
 	} 
-	
+
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
+import org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys
 import org.eclipse.xtext.formatting2.FormatterPreferenceKeys
 import org.junit.Ignore
 import org.junit.Test
@@ -16,7 +17,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 	
 	@Test
 	def testCoreIssue527_01() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 		class test {
 			val static SUPER_LONG_LIST_TO_TEST_IF_FORMATTING_WORKS_HERE_AND_SUCH = #[]
 		
@@ -30,7 +31,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 	}
 	@Test
 	def testtestCoreIssue527_02() {
-		tester.assertFormatted [
+		formatterTestHelper.assertFormatted [
 			preferences[
 				put(FormatterPreferenceKeys.maxLineWidth, 80)
 			]
@@ -62,7 +63,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 
 	@Test
 	def testBug402917_01() {
-		assertFormatted(
+		assertUnformattedEqualsFormatted(
 			'''
 			package foo
 			
@@ -84,28 +85,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 
 	@Test
 	def testBug402917_02() {
-		assertFormatted(
-			'''
-			package foo
-			
-			class Dully {
-			
-				@Deprecated
-				extension IntegerExtensions y
-				@Deprecated extension IntegerExtensions x
-			
-				def all(@Deprecated extension IntegerExtensions x) {
-					val extension IntegerExtensions foo = null
-					val c = [ extension IntegerExtensions p |
-						123.bitwiseAnd(1)
-					]
-				}
-			
-				def all2(extension @Deprecated IntegerExtensions x) {
-				}
-			}
-			''',
-			'''
+		'''
 			package foo
 			
 			class Dully {
@@ -124,13 +104,49 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 				def all2(   extension  @Deprecated  IntegerExtensions x) {
 				}	
 			}
-			'''
-		)
+		'''.assertFormattedTo('''
+			package foo
+			
+			class Dully {
+			
+				@Deprecated
+				extension IntegerExtensions y
+				@Deprecated extension IntegerExtensions x
+			
+				def all(@Deprecated extension IntegerExtensions x) {
+					val extension IntegerExtensions foo = null
+					val c = [ extension IntegerExtensions p |
+						123.bitwiseAnd(1)
+					]
+				}
+			
+				def all2(extension @Deprecated IntegerExtensions x) {
+				}
+			}
+		''')
 	}
 
 	@Test
 	def testBug398718(){
-		assertFormatted('''
+		'''
+			package foo
+			class bar {
+				def testVisibilityOfDispatchMethods() {
+					```
+					package foo;
+
+					import java.util.Arrays;
+
+					@SuppressWarnings("all")
+					public class NoSuchElementException {
+
+					  }
+					}
+					```
+
+					}
+			}
+		'''.decode.assertFormattedTo('''
 			package foo
 
 			class bar {
@@ -149,30 +165,12 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 
 				}
 			}
-		'''.decode, '''
-			package foo
-			class bar {
-				def testVisibilityOfDispatchMethods() {
-					```
-					package foo;
-
-					import java.util.Arrays;
-
-					@SuppressWarnings("all")
-					public class NoSuchElementException {
-
-					  }
-					}
-					```
-
-					}
-			}
 		'''.decode)
 	}
 
 	@Test
 	def testBug434976(){
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			class Foo {
 				def bar() {
 					new Baz[]
@@ -183,7 +181,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 	
 	@Test
 	def testBug398625(){
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 			
 			class bar {
@@ -193,11 +191,11 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 					setExceptions("42", [])
 				}
 			}
-		''')	
+		''', [put(FormatterPreferenceKeys.maxLineWidth, 80)])	
 	}
 	@Test
 	def testBug398625_2(){
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 			
 			class bar {
@@ -207,12 +205,12 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 					setExceptions("42")[]
 				}
 			}
-		''')	
+		''', [put(FormatterPreferenceKeys.maxLineWidth, 80)])	
 	}
 	
 	@Test
 	def testBug398625_3(){
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 
 			class bar {
@@ -230,12 +228,12 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 					]
 				}
 			}
-		''')	
+		''', [put(FormatterPreferenceKeys.maxLineWidth, 80)])	
 	}
 
 	@Test
 	def testBug400030(){
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 		class Foo {
 
 			/** foo */
@@ -274,7 +272,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 
 	@Test
 	def testBug400025_2(){
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 		class bar {
 			// foo
 		}
@@ -296,7 +294,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 
 	@Test
 	def testBug400024(){
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 		class Foo {
 
 			def bar() {
@@ -312,7 +310,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 
 	@Test
 	def testBug400024_1(){
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 		class Foo {
 
 			def bar() {
@@ -328,7 +326,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 	
 	@Test
 	def testBug_xtext_xtend_194(){
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			class Foo {
 			
 				static val SOME_MULTI_LINE_THINGY = new StringBuilder('a').append('b').
@@ -338,21 +336,23 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 				var bar = new Object
 			
 			}
-		''')
+		''', [put(FormatterPreferenceKeys.maxLineWidth, 80)])
 	}
 	
 	@Test
 	def testBug455582() {
-		assertFormatted('''
-		abstract package class XtendTest {
-			static final def void foo() {
+		'''
+			  abstract  package  class  XtendTest  {  static  final  def  void  foo  (  )  {  }  }
+		'''.assertFormattedTo('''
+			abstract package class XtendTest {
+				static final def void foo() {
+				}
 			}
-		}
-		''', '''  abstract  package  class  XtendTest  {  static  final  def  void  foo  (  )  {  }  }''')
+		''', [put(XtendFormatterPreferenceKeys.keepOneLineMethods, false)])
 	}
 	
 	@Test def bug462628() {
-		tester.assertFormatted [
+		formatterTestHelper.assertFormatted [
 			preferences[
 				put(FormatterPreferenceKeys.maxLineWidth, 120)
 			]
@@ -368,7 +368,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 	}
 	
 	@Test def bug403823() {
-		tester.assertFormatted [
+		formatterTestHelper.assertFormatted [
 			preferences[
 				put(FormatterPreferenceKeys.maxLineWidth, 120)
 			]
@@ -386,7 +386,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 	}
 	
 	@Test def bug403823_1() {
-		tester.assertFormatted [
+		formatterTestHelper.assertFormatted [
 			preferences[
 				put(FormatterPreferenceKeys.maxLineWidth, 120)
 			]
@@ -401,7 +401,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 	}
 	
 	@Test def bug403340() {
-		tester.assertFormatted [
+		formatterTestHelper.assertFormatted [
 			preferences[
 				put(FormatterPreferenceKeys.maxLineWidth, 120)
 			]
@@ -419,7 +419,7 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 	}
 	
 	@Test def bug403340_1() {
-		tester.assertFormatted [
+		formatterTestHelper.assertFormatted [
 			preferences[
 				put(FormatterPreferenceKeys.maxLineWidth, 120)
 			]

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendInterfaceFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendInterfaceFormatterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,195 +8,183 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.junit.Test
+import org.junit.runner.RunWith
 
+import static org.eclipse.xtext.formatting2.FormatterPreferenceKeys.*
 import static org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys.*
 
-class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
-	
+@RunWith(XtextRunner)
+@InjectWith(RuntimeInjectorProvider)
+class XtendInterfaceFormatterTest extends AbstractFormatterTest {
+
 	@Test def formatField01() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatField02() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				int foo
 				int baz
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldInit01() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				int foo = 1 + 1
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldInit02() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				int foo = 1 + 1
 				int baz = 1 + 1
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldVal() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				val int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldFinal() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				final int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldPublicFinal() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				public final int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldStatic02() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				static int bar
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldStatic03() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				public static int bar
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldStaticVal() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				static val int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldStaticFinal() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				static final int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatFieldPublicStaticFinal() {
-		assertFormatted([
-		],'''
+		'''
 			interface bar {
 				public static final int foo
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatMethod01() {
-		assertFormatted([
-			put(bracesInNewLine, false)
-		],'''
+		'''
 			package foo
 			
 			interface bar {
 				def baz()
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted
 	}
-	
+
 	@Test def formatMethod02() {
-		assertFormatted([
-			put(bracesInNewLine, true)
-		],'''
+		'''
 			package foo
 			
 			interface bar
 			{
 				def baz()
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, true)]
 	}
-	
+
 	@Test def formatMethod03() {
-		assertFormatted([
-			put(bracesInNewLine, true)
-		],'''
+		'''
 			package foo
 			
 			interface bar
 			{
 				abstract def baz()
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, true)]
 	}
-	
+
 	@Test def formatMethod04() {
-		assertFormatted([
-			put(bracesInNewLine, true)
-		],'''
+		'''
 			package foo
 			
 			interface bar
 			{
 				public abstract def baz()
 			}
-		''')	
+		'''.assertUnformattedEqualsFormatted[put(bracesInNewLine, true)]
 	}
-	
+
 	@Test def formatMethod1() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 			
 			interface bar {
 				def baz(String x)
 			}
-		''')	
+		''')
 	}
-	
+
 	@Test def formatMethod2() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 			
 			interface bar {
 				def baz(String x, String y)
 			}
-		''')	
+		''')
 	}
-	
+
 	@Test def formatMethod3() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 
 			interface bar {
@@ -204,22 +192,28 @@ class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
 					String p7, String p8, String p9, String p10, String p11, String p12,
 					String p13, String p14)
 			}
-		''')	
+		''', [put(maxLineWidth, 80)])
 	}
-		
+
 	@Test def formatMethod4() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			abstract interface bar {
 				def foo()
 
 				def baz()
 			}
-		''')	
+		''')
 	}
-	
-	
+
 	@Test def formatMethodMultiline() {
-		assertFormatted('''
+		'''
+			package foo
+			
+			interface bar {
+				def baz(String x, String y
+				)
+			}
+		'''.assertFormattedTo('''
 			package foo
 			
 			interface bar {
@@ -228,24 +222,16 @@ class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
 					String y
 				)
 			}
-		''', '''
-			package foo
-			
-			interface bar {
-				def baz(String x, String y
-				)
-			}
-		''')	
+		''')
 	}
-	
-	
+
 	@Test def formatMethodAnnotation() {
-		assertFormatted('''
+		assertUnformattedEqualsFormatted('''
 			package foo
 			
 			interface bar {
 				@Deprecated def baz()
 			}
-		''')	
+		''')
 	}
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendOnelinersFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendOnelinersFormatterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,77 +8,66 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.formatting
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.junit.Ignore
 import org.junit.Test
+import org.junit.runner.RunWith
 
 import static org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys.*
 
-class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
-	
-	@Test def void formatEmptyMethod1() {
-		assertFormatted('''
+@RunWith(XtextRunner)
+@InjectWith(RuntimeInjectorProvider)
+class XtendOnelinersFormatterTest extends AbstractFormatterTest {
+
+	@Test def formatEmptyMethod1() {
+		assertUnformattedEqualsFormatted('''
 			class C {
 				def m() {
 				}
 			}
 		''')
 	}
-	
-	@Test def void formatEmptyMethod2() {
-		assertFormatted([
-			put(keepOneLineMethods, true)
-		],'''
+
+	@Test def formatEmptyMethod2() {
+		'''
 			class C {
 				def m() {
 				}
 			}
-		''')
+		'''.assertUnformattedEqualsFormatted[put(keepOneLineMethods, true)]
 	}
-	
-	@Test def void formatEmptyMethod3() {
-		assertFormatted('''
-			class C {
-				def m() {
-				}
-			}
-		''',
+
+	@Test def formatEmptyMethod3() {
 		'''
 			class C {
 				def m() {}
 			}
-		''')
-	}
-	
-	@Test def void formatEmptyMethod4() {
-		assertFormatted([
-			put(keepOneLineMethods, true)
-		]
-		,'''
+		'''.assertFormattedTo(
+		'''
 			class C {
-				def m() {}
+				def m() {
+				}
 			}
-		''',
+		''', [put(keepOneLineMethods, false)])
+	}
+
+	@Test def formatEmptyMethod4() {
 		'''
 			class C {
 				def m() {          }
 			}
-		''')
-	}
-	
-	@Test def void formatMethodWithJustAComment1() {
-	assertFormatted('''
-		class C {
-			def m() {
-				/*foo*/
+		'''.assertFormattedTo('''
+			class C {
+				def m() {}
 			}
-		}
-	''')
+		''', [put(keepOneLineMethods, true)])
 	}
-	
-	@Test def void formatMethodWithJustAComment2() {
-		assertFormatted([
-			put(keepOneLineMethods, true)
-		],'''
+
+	@Test def formatMethodWithJustAComment1() {
+		assertUnformattedEqualsFormatted('''
 			class C {
 				def m() {
 					/*foo*/
@@ -86,40 +75,47 @@ class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')
 	}
-	
+
+	@Test def formatMethodWithJustAComment2() {
+		'''
+			class C {
+				def m() {
+					/*foo*/
+				}
+			}
+		'''.assertUnformattedEqualsFormatted[put(keepOneLineMethods, true)]
+	}
+
 	@Ignore("Another manifestation of Bug 415950")
-	@Test def void formatMethodWithJustAComment3() {
-		assertFormatted('''
-			class C {
-				def m() {
-					/*foo*/
-				}
-			}
-		''',
+	@Test def formatMethodWithJustAComment3() {
 		'''
 			class C {
 				def m() { /*foo*/ }
 			}
+		'''.assertFormattedTo(
+		'''
+			class C {
+				def m() {
+					/*foo*/
+				}
+			}
 		''')
 	}
-	
-	@Test def void formatMethodWithJustAComment4() {
-		assertFormatted([
-			put(keepOneLineMethods, true)
-		]
-		,'''
-			class C {
-				def m() { /*foo*/ }
-			}
-		''','''
+
+	@Test def formatMethodWithJustAComment4() {
+		'''
 			class C {
 				def m() {     /*foo*/          }
 			}
-		''')
+		'''.assertFormattedTo('''
+			class C {
+				def m() { /*foo*/ }
+			}
+		''', [put(keepOneLineMethods, true)])
 	}
-	
-	@Test def void formatMethodWithOneExpression1() {
-		assertFormatted('''
+
+	@Test def formatMethodWithOneExpression1() {
+		assertUnformattedEqualsFormatted('''
 			class C {
 				def m() {
 					"Foo"
@@ -127,54 +123,49 @@ class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')
 	}
-	
-	@Test def void formatMethodWithOneExpression2() {
-		assertFormatted([
-			put(keepOneLineMethods, true)
-		],'''
+
+	@Test def formatMethodWithOneExpression2() {
+		'''
 			class C {
 				def m() {
 					"Foo"
 				}
 			}
-		''')
+		'''.assertUnformattedEqualsFormatted[put(keepOneLineMethods, true)]
 	}
-	
-	@Test def void formatMethodWithOneExpression3() {
-		assertFormatted('''
-			class C {
-				def m() {
-					"Foo"
-				}
-			}
-		''',
+
+	@Test def formatMethodWithOneExpression3() {
 		'''
 			class C {
 				def m() {"Foo"}
 			}
-		''')
-	}
-	
-	@Test def void formatMethodWithOneExpression4() {
-		assertFormatted([
-			put(keepOneLineMethods, true)
-		]
-		,'''
+		'''.assertFormattedTo('''
 			class C {
-				def m() { "Foo" }
+				def m() {
+					"Foo"
+				}
 			}
-		''','''
+		''', [put(keepOneLineMethods, false)])
+	}
+
+	@Test def formatMethodWithOneExpression4() {
+		'''
 			class C {
 				def m() {       "Foo"     }
 			}
-		''')
+		'''.assertFormattedTo('''
+			class C {
+				def m() { "Foo" }
+			}
+		''', [put(keepOneLineMethods, true)])
 	}
-	
-	@Test def void formatMethodWithTryCatchExpression() {
-		assertFormatted([
-			put(keepOneLineMethods, true)
-		]
-		,'''
+
+	@Test def formatMethodWithTryCatchExpression() {
+		'''
+			class C {
+				def m() {try{"Foo"} catch (Exception e) {"Bar"} }
+			}
+		'''.assertFormattedTo('''
 			class C {
 				def m() {
 					try {
@@ -184,15 +175,11 @@ class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
 					}
 				}
 			}
-		''','''
-			class C {
-				def m() {try{"Foo"} catch (Exception e) {"Bar"} }
-			}
-		''')
+		''', [put(keepOneLineMethods, true)])
 	}
-	
-	@Test def void formatMethodWithTwoExpressions1() {
-		assertFormatted('''
+
+	@Test def formatMethodWithTwoExpressions1() {
+		assertUnformattedEqualsFormatted('''
 			class C {
 				def m() {
 					println(this)
@@ -201,52 +188,45 @@ class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')
 	}
-	
-	@Test def void formatMethodWithTwoExpressions2() {
-		assertFormatted([
-			put(keepOneLineMethods, true)
-		],'''
+
+	@Test def formatMethodWithTwoExpressions2() {
+		'''
 			class C {
 				def m() {
 					println(this)
 					"Foo"
 				}
 			}
-		''')
+		'''.assertUnformattedEqualsFormatted[put(keepOneLineMethods, true)]
 	}
-	
-	@Test def void formatMethodWithTwoExpressions3() {
-		assertFormatted('''
-			class C {
-				def m() {
-					println(this)
-					"Foo"
-				}
-			}
-		''',
+
+	@Test def formatMethodWithTwoExpressions3() {
 		'''
 			class C {
 				def m() {println(this) "Foo"}
 			}
-		''')
-	}
-	
-	@Test def void formatMethodWithTwoExpressions4() {
-		assertFormatted([
-			put(keepOneLineMethods, true)
-		]
-		,'''
+		'''.assertFormattedTo('''
 			class C {
 				def m() {
 					println(this)
 					"Foo"
 				}
 			}
-		''',
+		''')
+	}
+
+	@Test def formatMethodWithTwoExpressions4() {
 		'''
 			class C {
 				def m() {     println(this)      "Foo"     }
 			}
-		''')
+		'''.assertFormattedTo('''
+		class C {
+			def m() {
+				println(this)
+				"Foo"
+			}
+		}
+		''', [put(keepOneLineMethods, true)])
 	}
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendRichStringFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendRichStringFormatterTest.xtend
@@ -12,19 +12,19 @@ import org.junit.Ignore
 import org.junit.Test
 
 class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
-	
+
 	@Test def testSimple() {
 		assertFormattedRichStringExpression('''
 			val x = ```foo```;
 		''')
 	}
-	
+
 	@Test def testSimpleVar() {
 		assertFormattedRichStringExpression('''
 			val x = ```foo<<newArrayList()>>>bar```
 		''')
 	}
-	
+
 	@Test def testIndentation1() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -36,7 +36,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testIndentation2() {
 		assertFormattedRichStringExpression('''
 			val x = ```x
@@ -44,7 +44,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testIndentation3() {
 		assertFormattedRichStringExpression('''
 			val x = ```x
@@ -52,7 +52,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testIndentation4() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -60,7 +60,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			x```
 		''')
 	}
-	
+
 	@Test def testIf1() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -78,7 +78,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testIf2() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -98,7 +98,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testIfElse() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -120,7 +120,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testIfElseIfElse() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -146,7 +146,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testIfElseIfElseInline() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -158,7 +158,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testIfNested() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -182,7 +182,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testForLoop() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -192,7 +192,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testForLoopInline() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -200,7 +200,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testForLoopNested() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -213,7 +213,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testForLoopParams() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -232,7 +232,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testForSyntaxErrors() {
 		assertFormattedRichStringExpressionWithErrors('''
 			val x = ```
@@ -240,7 +240,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testIrregularIndentation() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -251,7 +251,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def testIrregularIndentation2() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -266,10 +266,9 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
-	@Test
+
 	@Ignore("indentation increases every time the formatter runs")
-	def prefixedForLoop() {
+	@Test def prefixedForLoop() {
 		assertFormattedRichStringExpression('''
 			val x = ```
 				return <<FOR field : cls.persistentState SEPARATOR "&&">>
@@ -278,7 +277,7 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def smokeTest() {
 		assertFormattedRichStringExpression('''
 			val x = ```
@@ -297,9 +296,9 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			```
 		''')
 	}
-	
+
 	@Test def bug450458() {
-		assertFormattedRichString('''
+		'''
 			class Foo {
 				@Test def testDefaultPackageLeadingWhitespace() {
 					```
@@ -313,11 +312,21 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 					```)
 				}
 			}
-		''')
+		'''.decode.assertUnformattedEqualsFormatted
 	}
 
 	@Test def indentThreeTabsLineInIf() {
-		assertFormatted('''
+		'''
+			class Generator {
+				def generate() {
+					```
+						<<IF true>>
+						
+						<<ENDIF>>
+					```
+				}
+			}
+		'''.decode.assertFormattedTo('''
 			class Generator {
 				def generate() {
 					```
@@ -327,35 +336,15 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 					```
 				}
 			}
-		'''.decode, '''
-			class Generator {
-				def generate() {
-					```
-						<<IF true>>
-						
-						<<ENDIF>>
-					```
-				}
-			}
 		'''.decode)
 	}
-	
+
 	// TODO this test case is not 100% correct ... one additional tab should be generated for the blank line.
 	// But the formatter code is to complicated. Was not able to generate the correct indentation. But as it is now
 	// the test at least ensures that there is no exception generated.
 	// See: https://github.com/eclipse/xtext-core/issues/710
 	@Test def indentEmptyLineInIf() {
-		assertFormatted('''
-			class Generator {
-				def generate() {
-					```
-						<<IF true>>
-						
-						<<ENDIF>>
-					```
-				}
-			}
-		'''.decode, '''
+		'''
 			class Generator {
 				def generate() {
 					```
@@ -365,8 +354,17 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 					```
 				}
 			}
+		'''.decode.assertFormattedTo('''
+			class Generator {
+				def generate() {
+					```
+						<<IF true>>
+						
+						<<ENDIF>>
+					```
+				}
+			}
 		'''.decode)
 	}
-	
+
 }
-	 

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/AbstractXtendFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/AbstractXtendFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,16 +8,12 @@
  */
 package org.eclipse.xtend.core.tests.formatting;
 
-import com.google.inject.Inject;
 import java.util.Collection;
-import org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys;
 import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
-import org.eclipse.xtend2.lib.StringConcatenation;
-import org.eclipse.xtext.formatting2.FormatterPreferenceKeys;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
-import org.eclipse.xtext.testing.formatter.FormatterTestHelper;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.eclipse.xtext.testing.formatter.FormatterTestRequest;
 import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.util.TextRegion;
@@ -27,120 +23,60 @@ import org.junit.runner.RunWith;
 @RunWith(XtextRunner.class)
 @InjectWith(RuntimeInjectorProvider.class)
 @SuppressWarnings("all")
-public abstract class AbstractXtendFormatterTest {
-  @Inject
-  protected FormatterTestHelper tester;
-
-  public void assertFormatted(final CharSequence toBeFormatted) {
-    this.assertFormatted(toBeFormatted, toBeFormatted);
+public abstract class AbstractXtendFormatterTest extends AbstractFormatterTest {
+  protected String decode(final CharSequence seq) {
+    return seq.toString().replace("<<", "«").replace(">>", "»").replace("```", "\'\'\'");
   }
 
-  private CharSequence toMember(final CharSequence expression) {
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package foo");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append(expression, "\t");
-    _builder.newLineIfNotEmpty();
-    _builder.append("}");
-    _builder.newLine();
-    return _builder;
-  }
-
-  public void assertFormattedExpression(final Procedure1<? super MapBasedPreferenceValues> cfg, final CharSequence toBeFormatted) {
-    this.assertFormattedExpression(cfg, toBeFormatted, toBeFormatted);
-  }
-
-  public void assertFormattedExpression(final CharSequence toBeFormatted) {
+  protected void assertFormattedExpression(final CharSequence toBeFormatted) {
     this.assertFormattedExpression(null, toBeFormatted, toBeFormatted);
   }
 
-  public void assertFormattedExpression(final String expectation, final CharSequence toBeFormatted) {
+  protected void assertFormattedExpression(final String expectation, final CharSequence toBeFormatted) {
     this.assertFormattedExpression(null, expectation, toBeFormatted);
   }
 
-  public void assertFormattedExpression(final Procedure1<? super MapBasedPreferenceValues> cfg, final CharSequence expectation, final CharSequence toBeFormatted) {
+  protected void assertFormattedExpression(final Procedure1<? super MapBasedPreferenceValues> cfg, final CharSequence expectation, final CharSequence toBeFormatted) {
     this.assertFormattedExpression(cfg, expectation, toBeFormatted, false);
   }
 
-  public void assertFormattedExpression(final Procedure1<? super MapBasedPreferenceValues> cfg, final CharSequence expectation, final CharSequence toBeFormatted, final boolean allowErrors) {
-    this.assertFormatted(cfg, 
-      expectation.toString().trim().replace("\n", "\n\t\t"), 
-      toBeFormatted.toString().trim().replace("\n", "\n\t\t"), 
-      "class bar {\n\tdef baz() {\n\t\t", 
-      "\n\t}\n}", allowErrors);
+  protected void assertFormattedRichStringExpression(final CharSequence seq) {
+    this.assertFormattedExpression(this.decode(seq));
   }
 
-  public void assertFormattedMember(final String expectation, final CharSequence toBeFormatted) {
-    this.assertFormatted(this.toMember(expectation), this.toMember(toBeFormatted));
+  protected void assertFormattedRichStringExpression(final CharSequence expected, final CharSequence actual) {
+    this.assertFormattedExpression(this.decode(expected), this.decode(actual));
   }
 
-  public void assertFormattedMember(final Procedure1<? super MapBasedPreferenceValues> cfg, final String expectation, final CharSequence toBeFormatted) {
-    this.assertFormatted(cfg, this.toMember(expectation), this.toMember(toBeFormatted));
+  protected void assertFormattedRichStringExpressionWithErrors(final CharSequence actual) {
+    this.assertFormattedExpression(null, this.decode(actual), this.decode(actual), true);
   }
 
-  public void assertFormattedMember(final Procedure1<? super MapBasedPreferenceValues> cfg, final String expectation) {
-    this.assertFormatted(cfg, this.toMember(expectation), this.toMember(expectation));
-  }
-
-  public void assertFormattedMember(final String expectation) {
-    this.assertFormatted(this.toMember(expectation), this.toMember(expectation));
-  }
-
-  public void assertFormatted(final Procedure1<? super MapBasedPreferenceValues> cfg, final CharSequence expectation) {
-    this.assertFormatted(cfg, expectation, expectation);
-  }
-
-  public void assertFormatted(final CharSequence expectation, final CharSequence toBeFormatted) {
-    this.assertFormatted(null, expectation, toBeFormatted);
-  }
-
-  public void assertFormatted(final Procedure1<? super MapBasedPreferenceValues> cfg, final CharSequence expectation, final CharSequence toBeFormatted) {
-    this.assertFormatted(cfg, expectation, toBeFormatted, "", "", false);
-  }
-
-  public void assertFormatted(final Procedure1<? super MapBasedPreferenceValues> cfg, final CharSequence expectation, final CharSequence toBeFormatted, final String prefix, final String postfix, final boolean allowErrors) {
+  private void assertFormattedExpression(final Procedure1<? super MapBasedPreferenceValues> cfg, final CharSequence expectation, final CharSequence toBeFormatted, final boolean allowErrors) {
+    final String prefix = "class bar {\n\tdef baz() {\n\t\t";
+    final String postfix = "\n\t}\n}";
     final Procedure1<FormatterTestRequest> _function = (FormatterTestRequest it) -> {
       final Procedure1<MapBasedPreferenceValues> _function_1 = (MapBasedPreferenceValues it_1) -> {
-        it_1.<Integer>put(FormatterPreferenceKeys.maxLineWidth, Integer.valueOf(80));
-        it_1.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(false));
         if (cfg!=null) {
           cfg.apply(it_1);
         }
       };
       it.preferences(_function_1);
-      it.setExpectation(((prefix + expectation) + postfix));
-      it.setToBeFormatted(((prefix + toBeFormatted) + postfix));
+      String _replace = expectation.toString().trim().replace("\n", "\n\t\t");
+      String _plus = (prefix + _replace);
+      String _plus_1 = (_plus + postfix);
+      it.setExpectation(_plus_1);
+      String _replace_1 = toBeFormatted.toString().trim().replace("\n", "\n\t\t");
+      String _plus_2 = (prefix + _replace_1);
+      String _plus_3 = (_plus_2 + postfix);
+      it.setToBeFormatted(_plus_3);
       Collection<ITextRegion> _regions = it.getRequest().getRegions();
       int _length = prefix.length();
-      int _length_1 = toBeFormatted.length();
+      int _length_1 = toBeFormatted.toString().trim().replace("\n", "\n\t\t").length();
       TextRegion _textRegion = new TextRegion(_length, _length_1);
       _regions.add(_textRegion);
       it.setAllowSyntaxErrors(allowErrors);
     };
-    this.tester.assertFormatted(_function);
-  }
-
-  protected String decode(final CharSequence seq) {
-    return seq.toString().replace("<<", "«").replace(">>", "»").replace("```", "\'\'\'");
-  }
-
-  public void assertFormattedRichStringExpression(final CharSequence seq) {
-    this.assertFormattedExpression(this.decode(seq));
-  }
-
-  public void assertFormattedRichString(final CharSequence seq) {
-    this.assertFormatted(this.decode(seq));
-  }
-
-  public void assertFormattedRichStringExpression(final CharSequence expected, final CharSequence actual) {
-    this.assertFormattedExpression(this.decode(expected), this.decode(actual));
-  }
-
-  public void assertFormattedRichStringExpressionWithErrors(final CharSequence actual) {
-    this.assertFormattedExpression(null, this.decode(actual), this.decode(actual), true);
+    this.formatterTestHelper.assertFormatted(_function);
   }
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/AnonymousClassFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/AnonymousClassFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,19 +8,23 @@
  */
 package org.eclipse.xtend.core.tests.formatting;
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(XtextRunner.class)
+@InjectWith(RuntimeInjectorProvider.class)
 @SuppressWarnings("all")
-public class AnonymousClassFormatterTest extends AbstractXtendFormatterTest {
+public class AnonymousClassFormatterTest extends AbstractFormatterTest {
   @Test
   public void formatSingleMember() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -38,14 +42,14 @@ public class AnonymousClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatMultiMember() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -74,14 +78,14 @@ public class AnonymousClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatTypeParam() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -102,14 +106,14 @@ public class AnonymousClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatNested() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("import java.util.Iterator");
     _builder.newLine();
@@ -162,6 +166,9 @@ public class AnonymousClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/TypeVariableFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/TypeVariableFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,28 +8,19 @@
  */
 package org.eclipse.xtend.core.tests.formatting;
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(XtextRunner.class)
+@InjectWith(RuntimeInjectorProvider.class)
 @SuppressWarnings("all")
-public class TypeVariableFormatterTest extends AbstractXtendFormatterTest {
-  public CharSequence refToFile(final CharSequence string) {
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("import java.util.*");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("class Foo {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append(string, "\t");
-    _builder.append(" x");
-    _builder.newLineIfNotEmpty();
-    _builder.append("}");
-    _builder.newLine();
-    return _builder;
-  }
-
-  public CharSequence paramToFile(final CharSequence string) {
+public class TypeVariableFormatterTest extends AbstractFormatterTest {
+  private CharSequence paramToFile(final CharSequence string) {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("import java.util.*");
     _builder.newLine();
@@ -44,7 +35,7 @@ public class TypeVariableFormatterTest extends AbstractXtendFormatterTest {
   }
 
   public void assertTypeParam(final CharSequence toBeFormatted) {
-    this.assertFormatted(this.paramToFile(toBeFormatted));
+    this.assertUnformattedEqualsFormatted(this.paramToFile(toBeFormatted));
   }
 
   @Test
@@ -71,7 +62,7 @@ public class TypeVariableFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendAnnotationTypeFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendAnnotationTypeFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,55 +8,54 @@
  */
 package org.eclipse.xtend.core.tests.formatting;
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(XtextRunner.class)
+@InjectWith(RuntimeInjectorProvider.class)
 @SuppressWarnings("all")
-public class XtendAnnotationTypeFormatterTest extends AbstractXtendFormatterTest {
+public class XtendAnnotationTypeFormatterTest extends AbstractFormatterTest {
   @Test
   public void formatPublic() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("public annotation Bar {");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatAbstract() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("abstract annotation Bar {");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatPublicAbstract() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("public abstract annotation Bar {");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatField01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("annotation Bar {");
     _builder.newLine();
@@ -65,13 +64,11 @@ public class XtendAnnotationTypeFormatterTest extends AbstractXtendFormatterTest
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatField02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("annotation Bar {");
     _builder.newLine();
@@ -83,14 +80,12 @@ public class XtendAnnotationTypeFormatterTest extends AbstractXtendFormatterTest
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Ignore
   @Test
   public void formatFieldInit01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("annotation Bar {");
     _builder.newLine();
@@ -99,14 +94,12 @@ public class XtendAnnotationTypeFormatterTest extends AbstractXtendFormatterTest
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Ignore
   @Test
   public void formatFieldInit02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("annotation Bar {");
     _builder.newLine();
@@ -118,14 +111,12 @@ public class XtendAnnotationTypeFormatterTest extends AbstractXtendFormatterTest
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Ignore
   @Test
   public void formatFieldInit03() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("annotation Bar {");
     _builder.newLine();
@@ -134,14 +125,12 @@ public class XtendAnnotationTypeFormatterTest extends AbstractXtendFormatterTest
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Ignore
   @Test
   public void formatFieldInit04() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("annotation Bar {");
     _builder.newLine();
@@ -153,14 +142,11 @@ public class XtendAnnotationTypeFormatterTest extends AbstractXtendFormatterTest
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatBraces_01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -169,14 +155,14 @@ public class XtendAnnotationTypeFormatterTest extends AbstractXtendFormatterTest
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatBraces_02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -187,7 +173,10 @@ public class XtendAnnotationTypeFormatterTest extends AbstractXtendFormatterTest
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -203,6 +192,6 @@ public class XtendAnnotationTypeFormatterTest extends AbstractXtendFormatterTest
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendAnnotationsFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendAnnotationsFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,16 +8,24 @@
  */
 package org.eclipse.xtend.core.tests.formatting;
 
+import org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys;
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(XtextRunner.class)
+@InjectWith(RuntimeInjectorProvider.class)
 @SuppressWarnings("all")
-public class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
-  protected CharSequence toFile(final CharSequence ann) {
+public class XtendAnnotationsFormatterTest extends AbstractFormatterTest {
+  private CharSequence toFile(final CharSequence ann) {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -36,36 +44,32 @@ public class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
     return _builder;
   }
 
-  protected void assertFormattedAnnotation(final CharSequence expectation, final CharSequence actual) {
-    this.assertFormatted(this.toFile(expectation), this.toFile(actual));
+  private void assertFormattedAnnotation(final CharSequence expectation, final CharSequence actual) {
+    this.assertFormattedTo(this.toFile(actual), this.toFile(expectation));
   }
 
   @Test
   public void formatClassSingleAnnotationSL() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo @Deprecated class bar { }");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package foo");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@Deprecated class bar {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
     final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
       it.<Boolean>put(XbaseFormatterPreferenceKeys.newLineAfterClassAnnotations, Boolean.valueOf(false));
       it.<Boolean>put(XbaseFormatterPreferenceKeys.preserveNewLines, Boolean.valueOf(true));
     };
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package foo");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("@Deprecated class bar {");
-    _builder.newLine();
-    _builder.append("}");
-    _builder.newLine();
-    StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package foo @Deprecated class bar { }");
-    _builder_1.newLine();
-    this.assertFormatted(_function, _builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1, _function);
   }
 
   @Test
   public void formatClassSingleAnnotationML1() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.newLineAfterClassAnnotations, Boolean.valueOf(false));
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.preserveNewLines, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -76,7 +80,11 @@ public class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.newLineAfterClassAnnotations, Boolean.valueOf(false));
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.preserveNewLines, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -91,29 +99,29 @@ public class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatClassSingleAnnotationML2() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo @Deprecated class bar { }");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package foo");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@Deprecated");
+    _builder_1.newLine();
+    _builder_1.append("class bar {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
     final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
       it.<Boolean>put(XbaseFormatterPreferenceKeys.newLineAfterClassAnnotations, Boolean.valueOf(true));
       it.<Boolean>put(XbaseFormatterPreferenceKeys.preserveNewLines, Boolean.valueOf(true));
     };
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package foo");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("@Deprecated");
-    _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
-    _builder.newLine();
-    StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package foo @Deprecated class bar { }");
-    _builder_1.newLine();
-    this.assertFormatted(_function, _builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1, _function);
   }
 
   @Test
@@ -126,7 +134,7 @@ public class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -143,7 +151,7 @@ public class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -158,7 +166,7 @@ public class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -243,7 +251,7 @@ public class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormattedMember(_builder.toString());
+    this.assertUnformattedEqualsFormatted(this.toMember(_builder));
   }
 
   @Test
@@ -383,6 +391,7 @@ public class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
   @Test
   public void formatMethodTwoAnnotations4() {
     final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(false));
       it.<Boolean>put(XbaseFormatterPreferenceKeys.newLineAfterMethodAnnotations, Boolean.valueOf(false));
       it.<Boolean>put(XbaseFormatterPreferenceKeys.preserveNewLines, Boolean.valueOf(false));
     };
@@ -421,6 +430,7 @@ public class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
   @Test
   public void formatMethodParameterTwoAnnotations1() {
     final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(false));
       it.<Boolean>put(XbaseFormatterPreferenceKeys.newLineAfterParameterAnnotations, Boolean.valueOf(false));
       it.<Boolean>put(XbaseFormatterPreferenceKeys.preserveNewLines, Boolean.valueOf(true));
     };
@@ -573,5 +583,35 @@ public class XtendAnnotationsFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("@  SuppressWarnings  (  (  \"all\"  +  \"more\"  )  )");
     _builder_1.newLine();
     this.assertFormattedAnnotation(_builder, _builder_1);
+  }
+
+  private void assertFormattedMember(final String expectation, final CharSequence toBeFormatted) {
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(false));
+    };
+    this.assertFormattedTo(this.toMember(toBeFormatted), this.toMember(expectation), _function);
+  }
+
+  private void assertFormattedMember(final Procedure1<? super MapBasedPreferenceValues> cfg, final String expectation, final CharSequence toBeFormatted) {
+    this.assertFormattedTo(this.toMember(toBeFormatted), this.toMember(expectation), ((Procedure1<MapBasedPreferenceValues>)cfg));
+  }
+
+  private void assertFormattedMember(final Procedure1<? super MapBasedPreferenceValues> cfg, final String expectation) {
+    this.assertUnformattedEqualsFormatted(this.toMember(expectation), ((Procedure1<MapBasedPreferenceValues>)cfg));
+  }
+
+  private CharSequence toMember(final CharSequence expression) {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class bar {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append(expression, "\t");
+    _builder.newLineIfNotEmpty();
+    _builder.append("}");
+    _builder.newLine();
+    return _builder;
   }
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendClassFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendClassFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,19 +8,24 @@
  */
 package org.eclipse.xtend.core.tests.formatting;
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.formatting2.FormatterPreferenceKeys;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(XtextRunner.class)
+@InjectWith(RuntimeInjectorProvider.class)
 @SuppressWarnings("all")
-public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
+public class XtendClassFormatterTest extends AbstractFormatterTest {
   @Test
   public void formatConstructor01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -32,14 +37,14 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatConstructor02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar");
     _builder.newLine();
@@ -56,7 +61,10 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -75,7 +83,7 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -94,7 +102,7 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -113,7 +121,7 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -150,13 +158,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatField01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -165,13 +171,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatField02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -183,13 +187,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldInit01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -198,13 +200,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldInit02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -216,13 +216,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldVal() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -231,13 +229,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldVar() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -246,13 +242,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldStatic02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -261,13 +255,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldStaticVal() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -276,13 +268,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldStaticVar() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -291,13 +281,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldExtension01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -306,13 +294,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldExtensionInit01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -321,13 +307,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldExtensionInit02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -339,13 +323,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldExtensionVal01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -354,13 +336,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldExtensionVar01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -369,13 +349,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldExtension02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class bar {");
     _builder.newLine();
@@ -387,14 +365,11 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatMethod01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -409,14 +384,14 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatMethod02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -436,7 +411,10 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -455,7 +433,7 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -474,7 +452,7 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -499,7 +477,10 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Integer>put(FormatterPreferenceKeys.maxLineWidth, Integer.valueOf(80));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -536,7 +517,7 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -549,7 +530,7 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -566,7 +547,7 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -578,13 +559,7 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.append("class bar {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def baz(");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("String x,");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("String y");
+    _builder.append("def baz(String x, String y");
     _builder.newLine();
     _builder.append("\t");
     _builder.append(") {");
@@ -601,7 +576,13 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("class bar {");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def baz(String x, String y");
+    _builder_1.append("def baz(");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("String x,");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("String y");
     _builder_1.newLine();
     _builder_1.append("\t");
     _builder_1.append(") {");
@@ -611,7 +592,7 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
@@ -630,6 +611,6 @@ public class XtendClassFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendCommentFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendCommentFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,12 +8,19 @@
  */
 package org.eclipse.xtend.core.tests.formatting;
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(XtextRunner.class)
+@InjectWith(RuntimeInjectorProvider.class)
 @SuppressWarnings("all")
-public class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
+public class XtendCommentFormatterTest extends AbstractFormatterTest {
   @Test
   public void formatMLCommentBeforePackage() {
     StringConcatenation _builder = new StringConcatenation();
@@ -23,14 +30,9 @@ public class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
     _builder.append("* copyright");
     _builder.newLine();
     _builder.append(" ");
-    _builder.append("***********/");
+    _builder.append("***********/package foo");
     _builder.newLine();
-    _builder.append("package foo");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("class zonk {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class zonk {}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("/***********");
@@ -39,11 +41,16 @@ public class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("* copyright");
     _builder_1.newLine();
     _builder_1.append(" ");
-    _builder_1.append("***********/package foo");
+    _builder_1.append("***********/");
     _builder_1.newLine();
-    _builder_1.append("class zonk {}");
+    _builder_1.append("package foo");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.newLine();
+    _builder_1.append("class zonk {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
@@ -51,26 +58,26 @@ public class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("/***********");
     _builder.newLine();
-    _builder.append(" ");
-    _builder.append("* copyright");
+    _builder.append("copyright");
     _builder.newLine();
-    _builder.append(" ");
     _builder.append("***********/");
     _builder.newLine();
-    _builder.append("class zonk {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class zonk {}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("/***********");
     _builder_1.newLine();
-    _builder_1.append("copyright");
+    _builder_1.append(" ");
+    _builder_1.append("* copyright");
     _builder_1.newLine();
+    _builder_1.append(" ");
     _builder_1.append("***********/");
     _builder_1.newLine();
-    _builder_1.append("class zonk {}");
+    _builder_1.append("class zonk {");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
@@ -78,68 +85,68 @@ public class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo // my comment");
     _builder.newLine();
-    _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class bar{}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("package foo // my comment");
     _builder_1.newLine();
-    _builder_1.append("class bar{}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("class bar {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatSLCommentBeforeStatement1() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package foo");
-    _builder.newLine();
+    _builder.append("package foo ");
     _builder.newLine();
     _builder.append("// my comment");
     _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class bar{}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package foo ");
+    _builder_1.append("package foo");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("// my comment");
     _builder_1.newLine();
-    _builder_1.append("class bar{}");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatSLCommentBeforeStatement2() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package foo");
+    _builder.append("package foo import java.util.Map ");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("import java.util.Map");
+    _builder.newLine();
     _builder.newLine();
     _builder.newLine();
     _builder.append("// my comment");
     _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class bar{}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package foo import java.util.Map ");
+    _builder_1.append("package foo");
     _builder_1.newLine();
     _builder_1.newLine();
-    _builder_1.newLine();
+    _builder_1.append("import java.util.Map");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("// my comment");
     _builder_1.newLine();
-    _builder_1.append("class bar{}");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
@@ -147,317 +154,317 @@ public class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo /* my comment */");
     _builder.newLine();
-    _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class bar{}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("package foo /* my comment */");
     _builder_1.newLine();
-    _builder_1.append("class bar{}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("class bar {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatSLCommentInStatement() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package /* my comment */ foo");
+    _builder.append("package  /* my comment */  foo");
     _builder.newLine();
-    _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class bar{}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package  /* my comment */  foo");
+    _builder_1.append("package /* my comment */ foo");
     _builder_1.newLine();
-    _builder_1.append("class bar{}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("class bar {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatMLCommentInStatement() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package");
+    _builder.append("package  /* my ");
     _builder.newLine();
-    _builder.append("/* my ");
+    _builder.append("comment */  foo");
     _builder.newLine();
-    _builder.append(" ");
-    _builder.append("comment */");
-    _builder.newLine();
-    _builder.append("foo");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class bar{}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package  /* my ");
+    _builder_1.append("package");
     _builder_1.newLine();
-    _builder_1.append("comment */  foo");
+    _builder_1.append("/* my ");
     _builder_1.newLine();
-    _builder_1.append("class bar{}");
+    _builder_1.append(" ");
+    _builder_1.append("comment */");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("foo");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("class bar {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatMLCommentBeforeStatement1() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package foo");
-    _builder.newLine();
+    _builder.append("package foo ");
     _builder.newLine();
     _builder.append("/* my comment */");
     _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class bar{}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package foo ");
+    _builder_1.append("package foo");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("/* my comment */");
     _builder_1.newLine();
-    _builder_1.append("class bar{}");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatMLCommentBeforeStatement2() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("import java.util.Map");
+    _builder.append("import java.util.Map ");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.newLine();
     _builder.newLine();
     _builder.newLine();
     _builder.append("/* my comment */");
     _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class bar{}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("import java.util.Map ");
-    _builder_1.newLine();
-    _builder_1.newLine();
-    _builder_1.newLine();
+    _builder_1.append("import java.util.Map");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("/* my comment */");
     _builder_1.newLine();
-    _builder_1.append("class bar{}");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatSLCommentAfterStatement2() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar { // my comment");
+    _builder.append("class bar{    // my comment");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{    // my comment");
+    _builder_1.append("class bar { // my comment");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatSLDocCommentInStatement21() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar {");
+    _builder.append("class bar{");
     _builder.newLine();
-    _builder.append("\t");
-    _builder.append("// my comment");
+    _builder.append(" ");
+    _builder.append("//    my comment");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
-    _builder_1.append(" ");
-    _builder_1.append("//    my comment");
+    _builder_1.append("\t");
+    _builder_1.append("// my comment");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatSLDocCommentInStatement22() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar {");
+    _builder.append("class bar{");
     _builder.newLine();
-    _builder.append("\t");
-    _builder.append("//");
+    _builder.append(" ");
+    _builder.append("//    ");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
-    _builder_1.append(" ");
-    _builder_1.append("//    ");
+    _builder_1.append("\t");
+    _builder_1.append("//");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatSLCodeCommentInStatement21() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar {");
+    _builder.append("class bar{");
     _builder.newLine();
     _builder.append("//    my comment");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
     _builder_1.append("//    my comment");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatMLCommentInBlock1() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar {");
+    _builder.append("class bar{");
     _builder.newLine();
-    _builder.append("\t");
     _builder.append("/*");
     _builder.newLine();
-    _builder.append("\t ");
-    _builder.append("* my comment");
+    _builder.append("my comment");
     _builder.newLine();
-    _builder.append("\t ");
     _builder.append("*/");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
+    _builder_1.append("\t");
     _builder_1.append("/*");
     _builder_1.newLine();
-    _builder_1.append("my comment");
+    _builder_1.append("\t ");
+    _builder_1.append("* my comment");
     _builder_1.newLine();
+    _builder_1.append("\t ");
     _builder_1.append("*/");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatMLCommentInBlock2() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar {");
+    _builder.append("class bar{");
     _builder.newLine();
-    _builder.append("\t");
+    _builder.append("\t\t");
     _builder.append("/*");
     _builder.newLine();
-    _builder.append("\t ");
-    _builder.append("* my comment");
+    _builder.append("\t\t");
+    _builder.append("my comment");
     _builder.newLine();
-    _builder.append("\t ");
+    _builder.append("\t\t");
     _builder.append("*/");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
-    _builder_1.append("\t\t");
+    _builder_1.append("\t");
     _builder_1.append("/*");
     _builder_1.newLine();
-    _builder_1.append("\t\t");
-    _builder_1.append("my comment");
+    _builder_1.append("\t ");
+    _builder_1.append("* my comment");
     _builder_1.newLine();
-    _builder_1.append("\t\t");
+    _builder_1.append("\t ");
     _builder_1.append("*/");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatMLCommentInBlock3() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar {");
+    _builder.append("class bar{");
     _builder.newLine();
-    _builder.append("\t");
+    _builder.append("\t\t");
     _builder.append("/*");
     _builder.newLine();
-    _builder.append("\t ");
-    _builder.append("* my comment");
+    _builder.append("\t\t\t\t");
+    _builder.append("*my comment");
     _builder.newLine();
-    _builder.append("\t ");
+    _builder.append("\t\t");
     _builder.append("*/");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
-    _builder_1.append("\t\t");
+    _builder_1.append("\t");
     _builder_1.append("/*");
     _builder_1.newLine();
-    _builder_1.append("\t\t\t\t");
-    _builder_1.append("*my comment");
+    _builder_1.append("\t ");
+    _builder_1.append("* my comment");
     _builder_1.newLine();
-    _builder_1.append("\t\t");
+    _builder_1.append("\t ");
     _builder_1.append("*/");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatMLCommentAfterStatement2() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar { /* my comment */");
+    _builder.append("class bar{   /* my comment */ ");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{   /* my comment */ ");
+    _builder_1.append("class bar { /* my comment */");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatMLCommentBeforeStatement21() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar {");
+    _builder.append("class bar{");
     _builder.newLine();
-    _builder.append("\t");
     _builder.append("/* my comment */");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
+    _builder_1.append("\t");
     _builder_1.append("/* my comment */");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
@@ -483,7 +490,7 @@ public class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Ignore("see https://bugs.eclipse.org/bugs/show_bug.cgi?id=415950")
@@ -509,7 +516,7 @@ public class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Ignore("see https://bugs.eclipse.org/bugs/show_bug.cgi?id=415950")
@@ -534,7 +541,7 @@ public class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Ignore("see https://github.com/eclipse/xtext-xtend/issues/77")
@@ -556,6 +563,6 @@ public class XtendCommentFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendEnumFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendEnumFormatterTest.java
@@ -8,31 +8,33 @@
  */
 package org.eclipse.xtend.core.tests.formatting;
 
-import org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys;
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(XtextRunner.class)
+@InjectWith(RuntimeInjectorProvider.class)
 @SuppressWarnings("all")
-public class XtendEnumFormatterTest extends AbstractXtendFormatterTest {
+public class XtendEnumFormatterTest extends AbstractFormatterTest {
   @Test
   public void formatPublic() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("public enum Bar {");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatLiteral01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("enum Bar {");
     _builder.newLine();
@@ -41,13 +43,11 @@ public class XtendEnumFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatLiteral02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("enum Bar {");
     _builder.newLine();
@@ -62,14 +62,11 @@ public class XtendEnumFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatLiteral03() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Integer>put(XtendFormatterPreferenceKeys.blankLinesBetweenEnumLiterals, Integer.valueOf(1));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("enum Bar {");
     _builder.newLine();
@@ -86,14 +83,11 @@ public class XtendEnumFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatBraces_01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -102,14 +96,11 @@ public class XtendEnumFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatBraces_02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -120,6 +111,9 @@ public class XtendEnumFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendFileFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendFileFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,19 +8,25 @@
  */
 package org.eclipse.xtend.core.tests.formatting;
 
+import org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys;
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.formatting2.FormatterPreferenceKeys;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(XtextRunner.class)
+@InjectWith(RuntimeInjectorProvider.class)
 @SuppressWarnings("all")
-public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
+public class XtendFileFormatterTest extends AbstractFormatterTest {
   @Test
   public void formatClass11() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -29,14 +35,14 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatClass12() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -47,14 +53,14 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatClass112() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -66,14 +72,14 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatClass122() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -87,231 +93,243 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatClass111() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package foo");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
-    _builder.newLine();
+    _builder.append("   ");
+    _builder.append("package  foo  class  bar  {  }");
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("   ");
-    _builder_1.append("package  foo  class  bar  {  }");
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("package foo");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("class bar {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatClass2() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class bar{}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{}");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatClass3() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("int member1");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("int member2");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("def meth1() {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("def meth2() {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("int member3");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("class bar{ int member1 int member2 def meth1() {} def meth2(){} int member3 }");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{ int member1 int member2 def meth1() {} def meth2(){} int member3 }");
+    _builder_1.append("class bar {");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
-  }
-
-  @Test
-  public void formatClass31() {
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("def meth1() {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("}");
-    _builder.newLine();
-    StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{");
+    _builder_1.append("\t");
+    _builder_1.append("int member1");
     _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("int member2");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def meth1() {} ");
+    _builder_1.append("def meth1() {");
     _builder_1.newLine();
-    _builder_1.newLine();
-    _builder_1.newLine();
+    _builder_1.append("\t");
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
-  }
-
-  @Test
-  public void formatClass4() {
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("int member1");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("int member2");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("def meth1() {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("def meth2() {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("int member3");
-    _builder.newLine();
-    _builder.append("}");
-    _builder.newLine();
-    StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class bar{");
     _builder_1.newLine();
     _builder_1.append("\t");
+    _builder_1.append("def meth2() {");
     _builder_1.newLine();
     _builder_1.append("\t");
+    _builder_1.append("}");
     _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.append("int member1 ");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.append("int member2 ");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.append("def meth1() {} ");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.append("def meth2(){} ");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.newLine();
-    _builder_1.append("\t");
     _builder_1.newLine();
     _builder_1.append("\t");
     _builder_1.append("int member3");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(false));
+    };
+    this.assertFormattedTo(_builder, _builder_1, _function);
+  }
+
+  @Test
+  public void formatClass31() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class bar{");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def meth1() {} ");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class bar {");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def meth1() {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(false));
+    };
+    this.assertFormattedTo(_builder, _builder_1, _function);
+  }
+
+  @Test
+  public void formatClass4() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class bar{");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("int member1 ");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("int member2 ");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def meth1() {} ");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def meth2(){} ");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("int member3");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class bar {");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("int member1");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("int member2");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def meth1() {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def meth2() {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("int member3");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(false));
+    };
+    this.assertFormattedTo(_builder, _builder_1, _function);
   }
 
   @Test
   public void formatClasses1() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package foo");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("class baz {");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("package foo class bar{} class baz{}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package foo class bar{} class baz{}");
+    _builder_1.append("package foo");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.newLine();
+    _builder_1.append("class bar {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("class baz {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatClasses2() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package foo");
+    _builder.append("package foo ");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("class bar {");
-    _builder.newLine();
-    _builder.append("}");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("class baz {");
+    _builder.append("class bar{} ");
     _builder.newLine();
-    _builder.append("}");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class baz{}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package foo ");
+    _builder_1.append("package foo");
     _builder_1.newLine();
     _builder_1.newLine();
+    _builder_1.append("class bar {");
+    _builder_1.newLine();
+    _builder_1.append("}");
     _builder_1.newLine();
     _builder_1.newLine();
-    _builder_1.append("class bar{} ");
+    _builder_1.append("class baz {");
     _builder_1.newLine();
+    _builder_1.append("}");
     _builder_1.newLine();
-    _builder_1.newLine();
-    _builder_1.newLine();
-    _builder_1.append("class baz{}");
-    _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
@@ -335,7 +353,7 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -347,7 +365,10 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.append("import java.util.Map");
     _builder.newLine();
     _builder.newLine();
+    _builder.newLine();
     _builder.append("import java.util.Set");
+    _builder.newLine();
+    _builder.newLine();
     _builder.newLine();
     _builder.newLine();
     _builder.append("class bar {");
@@ -361,17 +382,14 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("import java.util.Map");
     _builder_1.newLine();
     _builder_1.newLine();
-    _builder_1.newLine();
     _builder_1.append("import java.util.Set");
-    _builder_1.newLine();
-    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("class bar {");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
@@ -423,7 +441,10 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Integer>put(FormatterPreferenceKeys.maxLineWidth, Integer.valueOf(80));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -475,7 +496,10 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Integer>put(FormatterPreferenceKeys.maxLineWidth, Integer.valueOf(80));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -498,7 +522,7 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -521,7 +545,7 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -592,6 +616,6 @@ public class XtendFileFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,6 +8,7 @@
  */
 package org.eclipse.xtend.core.tests.formatting;
 
+import org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.formatting2.FormatterPreferenceKeys;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
@@ -44,7 +45,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -104,7 +105,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
       _builder.newLine();
       it.setToBeFormatted(_builder);
     };
-    this.tester.assertFormatted(_function);
+    this.formatterTestHelper.assertFormatted(_function);
   }
 
   @Test
@@ -143,7 +144,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -156,23 +157,26 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("@Deprecated");
+    _builder.append("@Deprecated ");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("extension IntegerExtensions y");
+    _builder.append("extension ");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("@Deprecated extension IntegerExtensions x");
+    _builder.append("IntegerExtensions y");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@Deprecated   extension    IntegerExtensions x");
     _builder.newLine();
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def all(@Deprecated extension IntegerExtensions x) {");
+    _builder.append("def all(@Deprecated   extension    IntegerExtensions x) {");
     _builder.newLine();
     _builder.append("\t\t");
-    _builder.append("val extension IntegerExtensions foo = null");
+    _builder.append("val extension    IntegerExtensions foo = null");
     _builder.newLine();
     _builder.append("\t\t");
-    _builder.append("val c = [ extension IntegerExtensions p |");
+    _builder.append("val c = [ extension    IntegerExtensions p |");
     _builder.newLine();
     _builder.append("\t\t\t");
     _builder.append("123.bitwiseAnd(1)");
@@ -183,12 +187,11 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.append("\t");
     _builder.append("}");
     _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def all2(   extension  @Deprecated  IntegerExtensions x) {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def all2(extension @Deprecated IntegerExtensions x) {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
+    _builder.append("}\t");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
@@ -200,26 +203,23 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("@Deprecated ");
+    _builder_1.append("@Deprecated");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("extension ");
+    _builder_1.append("extension IntegerExtensions y");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("IntegerExtensions y");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.append("@Deprecated   extension    IntegerExtensions x");
+    _builder_1.append("@Deprecated extension IntegerExtensions x");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def all(@Deprecated   extension    IntegerExtensions x) {");
+    _builder_1.append("def all(@Deprecated extension IntegerExtensions x) {");
     _builder_1.newLine();
     _builder_1.append("\t\t");
-    _builder_1.append("val extension    IntegerExtensions foo = null");
+    _builder_1.append("val extension IntegerExtensions foo = null");
     _builder_1.newLine();
     _builder_1.append("\t\t");
-    _builder_1.append("val c = [ extension    IntegerExtensions p |");
+    _builder_1.append("val c = [ extension IntegerExtensions p |");
     _builder_1.newLine();
     _builder_1.append("\t\t\t");
     _builder_1.append("123.bitwiseAnd(1)");
@@ -230,22 +230,22 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder_1.append("\t");
     _builder_1.append("}");
     _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.append("def all2(   extension  @Deprecated  IntegerExtensions x) {");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("}\t");
+    _builder_1.append("def all2(extension @Deprecated IntegerExtensions x) {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void testBug398718() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
-    _builder.newLine();
     _builder.newLine();
     _builder.append("class bar {");
     _builder.newLine();
@@ -255,41 +255,39 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.append("\t\t");
     _builder.append("```");
     _builder.newLine();
-    _builder.append("\t\t\t");
+    _builder.append("\t\t");
     _builder.append("package foo;");
     _builder.newLine();
-    _builder.append("\t\t\t");
     _builder.newLine();
-    _builder.append("\t\t\t");
+    _builder.append("\t\t");
     _builder.append("import java.util.Arrays;");
     _builder.newLine();
-    _builder.append("\t\t\t");
     _builder.newLine();
-    _builder.append("\t\t\t");
+    _builder.append("\t\t");
     _builder.append("@SuppressWarnings(\"all\")");
     _builder.newLine();
-    _builder.append("\t\t\t");
+    _builder.append("\t\t");
     _builder.append("public class NoSuchElementException {");
     _builder.newLine();
-    _builder.append("\t\t\t");
     _builder.newLine();
-    _builder.append("\t\t\t  ");
+    _builder.append("\t\t  ");
     _builder.append("}");
     _builder.newLine();
-    _builder.append("\t\t\t");
+    _builder.append("\t\t");
     _builder.append("}");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("```");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("\t");
+    _builder.append("\t\t");
     _builder.append("}");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("package foo");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("class bar {");
     _builder_1.newLine();
@@ -299,37 +297,40 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder_1.append("\t\t");
     _builder_1.append("```");
     _builder_1.newLine();
-    _builder_1.append("\t\t");
+    _builder_1.append("\t\t\t");
     _builder_1.append("package foo;");
     _builder_1.newLine();
+    _builder_1.append("\t\t\t");
     _builder_1.newLine();
-    _builder_1.append("\t\t");
+    _builder_1.append("\t\t\t");
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("\t\t\t");
     _builder_1.newLine();
-    _builder_1.append("\t\t");
+    _builder_1.append("\t\t\t");
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
-    _builder_1.append("\t\t");
+    _builder_1.append("\t\t\t");
     _builder_1.append("public class NoSuchElementException {");
     _builder_1.newLine();
+    _builder_1.append("\t\t\t");
     _builder_1.newLine();
-    _builder_1.append("\t\t  ");
+    _builder_1.append("\t\t\t  ");
     _builder_1.append("}");
     _builder_1.newLine();
-    _builder_1.append("\t\t");
+    _builder_1.append("\t\t\t");
     _builder_1.append("}");
     _builder_1.newLine();
     _builder_1.append("\t\t");
     _builder_1.append("```");
     _builder_1.newLine();
     _builder_1.newLine();
-    _builder_1.append("\t\t");
+    _builder_1.append("\t");
     _builder_1.append("}");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(this.decode(_builder), this.decode(_builder_1));
+    this.assertFormattedTo(this.decode(_builder), this.decode(_builder_1));
   }
 
   @Test
@@ -348,7 +349,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -374,7 +375,10 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Integer>put(FormatterPreferenceKeys.maxLineWidth, Integer.valueOf(80));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -400,7 +404,10 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Integer>put(FormatterPreferenceKeys.maxLineWidth, Integer.valueOf(80));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -452,7 +459,10 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Integer>put(FormatterPreferenceKeys.maxLineWidth, Integer.valueOf(80));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -469,7 +479,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -524,7 +534,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Ignore("Conflict")
@@ -572,7 +582,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -604,7 +614,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -629,26 +639,32 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Integer>put(FormatterPreferenceKeys.maxLineWidth, Integer.valueOf(80));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void testBug455582() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("abstract package class XtendTest {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("static final def void foo() {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.append("}");
+    _builder.append("abstract  package  class  XtendTest  {  static  final  def  void  foo  (  )  {  }  }");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("  ");
-    _builder_1.append("abstract  package  class  XtendTest  {  static  final  def  void  foo  (  )  {  }  }");
-    this.assertFormatted(_builder, _builder_1);
+    _builder_1.append("abstract package class XtendTest {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("static final def void foo() {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(false));
+    };
+    this.assertFormattedTo(_builder, _builder_1, _function);
   }
 
   @Test
@@ -677,7 +693,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
       _builder.newLine();
       it.setToBeFormatted(_builder);
     };
-    this.tester.assertFormatted(_function);
+    this.formatterTestHelper.assertFormatted(_function);
   }
 
   @Test
@@ -722,7 +738,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
       _builder.newLine();
       it.setToBeFormatted(_builder);
     };
-    this.tester.assertFormatted(_function);
+    this.formatterTestHelper.assertFormatted(_function);
   }
 
   @Test
@@ -760,7 +776,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
       _builder.newLine();
       it.setToBeFormatted(_builder);
     };
-    this.tester.assertFormatted(_function);
+    this.formatterTestHelper.assertFormatted(_function);
   }
 
   @Test
@@ -807,7 +823,7 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
       _builder.newLine();
       it.setToBeFormatted(_builder);
     };
-    this.tester.assertFormatted(_function);
+    this.formatterTestHelper.assertFormatted(_function);
   }
 
   @Test
@@ -848,6 +864,6 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
       _builder.newLine();
       it.setToBeFormatted(_builder);
     };
-    this.tester.assertFormatted(_function);
+    this.formatterTestHelper.assertFormatted(_function);
   }
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendInterfaceFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendInterfaceFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,18 +8,24 @@
  */
 package org.eclipse.xtend.core.tests.formatting;
 
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.formatting2.FormatterPreferenceKeys;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.eclipse.xtext.xbase.formatting2.XbaseFormatterPreferenceKeys;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(XtextRunner.class)
+@InjectWith(RuntimeInjectorProvider.class)
 @SuppressWarnings("all")
-public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
+public class XtendInterfaceFormatterTest extends AbstractFormatterTest {
   @Test
   public void formatField01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -28,13 +34,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatField02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -46,13 +50,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldInit01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -61,13 +63,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldInit02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -79,13 +79,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldVal() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -94,13 +92,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldFinal() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -109,13 +105,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldPublicFinal() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -124,13 +118,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldStatic02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -139,13 +131,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldStatic03() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -154,13 +144,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldStaticVal() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -169,13 +157,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldStaticFinal() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -184,13 +170,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatFieldPublicStaticFinal() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface bar {");
     _builder.newLine();
@@ -199,14 +183,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatMethod01() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(false));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -218,14 +199,11 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatMethod02() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -239,14 +217,14 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatMethod03() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -260,14 +238,14 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatMethod04() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");
     _builder.newLine();
@@ -281,7 +259,10 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XbaseFormatterPreferenceKeys.bracesInNewLine, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -297,7 +278,7 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -313,7 +294,7 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -335,7 +316,10 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Integer>put(FormatterPreferenceKeys.maxLineWidth, Integer.valueOf(80));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -352,7 +336,7 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
@@ -364,13 +348,7 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.append("interface bar {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def baz(");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("String x,");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("String y");
+    _builder.append("def baz(String x, String y");
     _builder.newLine();
     _builder.append("\t");
     _builder.append(")");
@@ -384,14 +362,20 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("interface bar {");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def baz(String x, String y");
+    _builder_1.append("def baz(");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("String x,");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("String y");
     _builder_1.newLine();
     _builder_1.append("\t");
     _builder_1.append(")");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
@@ -407,6 +391,6 @@ public class XtendInterfaceFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendOnelinersFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendOnelinersFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,14 +9,21 @@
 package org.eclipse.xtend.core.tests.formatting;
 
 import org.eclipse.xtend.core.formatting2.XtendFormatterPreferenceKeys;
+import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(XtextRunner.class)
+@InjectWith(RuntimeInjectorProvider.class)
 @SuppressWarnings("all")
-public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
+public class XtendOnelinersFormatterTest extends AbstractFormatterTest {
   @Test
   public void formatEmptyMethod1() {
     StringConcatenation _builder = new StringConcatenation();
@@ -30,14 +37,11 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatEmptyMethod2() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class C {");
     _builder.newLine();
@@ -49,38 +53,14 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
   public void formatEmptyMethod3() {
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class C {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("def m() {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.append("}");
-    _builder.newLine();
-    StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class C {");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.append("def m() {}");
-    _builder_1.newLine();
-    _builder_1.append("}");
-    _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
-  }
-
-  @Test
-  public void formatEmptyMethod4() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class C {");
     _builder.newLine();
@@ -93,11 +73,41 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("class C {");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def m() {          }");
+    _builder_1.append("def m() {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_function, _builder, _builder_1);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(false));
+    };
+    this.assertFormattedTo(_builder, _builder_1, _function);
+  }
+
+  @Test
+  public void formatEmptyMethod4() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class C {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def m() {          }");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class C {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def m() {}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
+    };
+    this.assertFormattedTo(_builder, _builder_1, _function);
   }
 
   @Test
@@ -116,14 +126,11 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatMethodWithJustAComment2() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class C {");
     _builder.newLine();
@@ -138,42 +145,15 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Ignore("Another manifestation of Bug 415950")
   @Test
   public void formatMethodWithJustAComment3() {
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("class C {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("def m() {");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("/*foo*/");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.append("}");
-    _builder.newLine();
-    StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class C {");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.append("def m() { /*foo*/ }");
-    _builder_1.newLine();
-    _builder_1.append("}");
-    _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
-  }
-
-  @Test
-  public void formatMethodWithJustAComment4() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class C {");
     _builder.newLine();
@@ -186,11 +166,41 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("class C {");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def m() {     /*foo*/          }");
+    _builder_1.append("def m() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("/*foo*/");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_function, _builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
+  }
+
+  @Test
+  public void formatMethodWithJustAComment4() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class C {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def m() {     /*foo*/          }");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class C {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def m() { /*foo*/ }");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
+    };
+    this.assertFormattedTo(_builder, _builder_1, _function);
   }
 
   @Test
@@ -209,14 +219,11 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatMethodWithOneExpression2() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class C {");
     _builder.newLine();
@@ -231,7 +238,10 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -240,13 +250,7 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder.append("class C {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def m() {");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("\"Foo\"");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
+    _builder.append("def m() {\"Foo\"}");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
@@ -254,23 +258,29 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("class C {");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def m() {\"Foo\"}");
+    _builder_1.append("def m() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("\"Foo\"");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(false));
+    };
+    this.assertFormattedTo(_builder, _builder_1, _function);
   }
 
   @Test
   public void formatMethodWithOneExpression4() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class C {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def m() { \"Foo\" }");
+    _builder.append("def m() {       \"Foo\"     }");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
@@ -278,41 +288,23 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("class C {");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def m() {       \"Foo\"     }");
+    _builder_1.append("def m() { \"Foo\" }");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_function, _builder, _builder_1);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
+    };
+    this.assertFormattedTo(_builder, _builder_1, _function);
   }
 
   @Test
   public void formatMethodWithTryCatchExpression() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class C {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def m() {");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("try {");
-    _builder.newLine();
-    _builder.append("\t\t\t");
-    _builder.append("\"Foo\"");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("} catch (Exception e) {");
-    _builder.newLine();
-    _builder.append("\t\t\t");
-    _builder.append("\"Bar\"");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
+    _builder.append("def m() {try{\"Foo\"} catch (Exception e) {\"Bar\"} }");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
@@ -320,11 +312,32 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("class C {");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def m() {try{\"Foo\"} catch (Exception e) {\"Bar\"} }");
+    _builder_1.append("def m() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("try {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("\"Foo\"");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("} catch (Exception e) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("\"Bar\"");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_function, _builder, _builder_1);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
+    };
+    this.assertFormattedTo(_builder, _builder_1, _function);
   }
 
   @Test
@@ -346,14 +359,11 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_builder);
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   @Test
   public void formatMethodWithTwoExpressions2() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class C {");
     _builder.newLine();
@@ -371,7 +381,10 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormatted(_function, _builder);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
+    };
+    this.assertUnformattedEqualsFormatted(_builder, _function);
   }
 
   @Test
@@ -380,16 +393,7 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder.append("class C {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def m() {");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("println(this)");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("\"Foo\"");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
+    _builder.append("def m() {println(this) \"Foo\"}");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
@@ -397,32 +401,29 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("class C {");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def m() {println(this) \"Foo\"}");
+    _builder_1.append("def m() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("println(this)");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("\"Foo\"");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_builder, _builder_1);
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   @Test
   public void formatMethodWithTwoExpressions4() {
-    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
-      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
-    };
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class C {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def m() {");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("println(this)");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("\"Foo\"");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
+    _builder.append("def m() {     println(this)      \"Foo\"     }");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
@@ -430,10 +431,22 @@ public class XtendOnelinersFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("class C {");
     _builder_1.newLine();
     _builder_1.append("\t");
-    _builder_1.append("def m() {     println(this)      \"Foo\"     }");
+    _builder_1.append("def m() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("println(this)");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("\"Foo\"");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(_function, _builder, _builder_1);
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<Boolean>put(XtendFormatterPreferenceKeys.keepOneLineMethods, Boolean.valueOf(true));
+    };
+    this.assertFormattedTo(_builder, _builder_1, _function);
   }
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendRichStringFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendRichStringFormatterTest.java
@@ -498,8 +498,8 @@ public class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
     this.assertFormattedRichStringExpression(_builder);
   }
 
-  @Test
   @Ignore("indentation increases every time the formatter runs")
+  @Test
   public void prefixedForLoop() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("val x = ```");
@@ -602,7 +602,7 @@ public class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.assertFormattedRichString(_builder);
+    this.assertUnformattedEqualsFormatted(this.decode(_builder));
   }
 
   @Test
@@ -619,7 +619,7 @@ public class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
     _builder.append("\t\t\t");
     _builder.append("<<IF true>>");
     _builder.newLine();
-    _builder.append("\t\t\t\t");
+    _builder.append("\t\t\t");
     _builder.newLine();
     _builder.append("\t\t\t");
     _builder.append("<<ENDIF>>");
@@ -644,7 +644,7 @@ public class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("\t\t\t");
     _builder_1.append("<<IF true>>");
     _builder_1.newLine();
-    _builder_1.append("\t\t\t");
+    _builder_1.append("\t\t\t\t");
     _builder_1.newLine();
     _builder_1.append("\t\t\t");
     _builder_1.append("<<ENDIF>>");
@@ -657,7 +657,7 @@ public class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(this.decode(_builder), this.decode(_builder_1));
+    this.assertFormattedTo(this.decode(_builder), this.decode(_builder_1));
   }
 
   @Test
@@ -674,7 +674,6 @@ public class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
     _builder.append("\t\t\t");
     _builder.append("<<IF true>>");
     _builder.newLine();
-    _builder.append("\t\t\t");
     _builder.newLine();
     _builder.append("\t\t\t");
     _builder.append("<<ENDIF>>");
@@ -699,6 +698,7 @@ public class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.append("\t\t\t");
     _builder_1.append("<<IF true>>");
     _builder_1.newLine();
+    _builder_1.append("\t\t\t");
     _builder_1.newLine();
     _builder_1.append("\t\t\t");
     _builder_1.append("<<ENDIF>>");
@@ -711,6 +711,6 @@ public class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.assertFormatted(this.decode(_builder), this.decode(_builder_1));
+    this.assertFormattedTo(this.decode(_builder), this.decode(_builder_1));
   }
 }

--- a/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/formatter/AbstractFormatterTest.java
+++ b/org.eclipse.xtext.testing/src/org/eclipse/xtext/testing/formatter/AbstractFormatterTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2024 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.testing.formatter;
+
+import java.util.function.Consumer;
+
+import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
+import org.eclipse.xtext.xbase.lib.Extension;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+
+/**
+ * @author miklossy - Initial contribution and API
+ * @since 2.35
+ */
+@Beta
+public abstract class AbstractFormatterTest {
+
+	@Inject @Extension
+	protected FormatterTestHelper formatterTestHelper;
+
+	/**
+	 * Verifies whether the formatted document equals the unformatted document.
+	 * 
+	 * @param formatterInput
+	 *				The document content before and after formatting.
+	 */
+	protected void assertUnformattedEqualsFormatted(CharSequence formatterInput) {
+		assertFormattedTo(formatterInput, null);
+	}
+
+	/**
+	 * Verifies whether the formatted document equals the unformatted document.
+	 * 
+	 * @param formatterInput
+	 *				The document content before and after formatting.
+	 * @param preferences
+	 *				The preferences to configure the formatter.
+	 */
+	protected void assertUnformattedEqualsFormatted(CharSequence formatterInput, Consumer<MapBasedPreferenceValues> preferences) {
+		assertFormattedTo(formatterInput, formatterInput, preferences);
+	}
+
+	/**
+	 * Verifies whether formatting the <i>formatterInput</i> results in the <i>formatterExpectation</i>.
+	 *
+	 * @param formatterInput
+	 *				The document content before formatting.
+	 * @param formatterExpectation
+	 *				The document content after formatting.
+	 */
+	protected void assertFormattedTo(CharSequence formatterInput, CharSequence formatterExpectation) {
+		assertFormattedTo(formatterInput, formatterExpectation, null);
+	}
+
+	/**
+	 * Verifies whether formatting the <i>formatterInput</i> results in the <i>formatterExpectation</i>.
+	 *
+	 * @param formatterInput
+	 *				The document content before formatting.
+	 * @param formatterExpectation
+	 *				The document content after formatting.
+	 * @param preferences
+	 *				The preferences to configure the formatter.
+	 */
+	protected void assertFormattedTo(CharSequence formatterInput, CharSequence formatterExpectation, Consumer<MapBasedPreferenceValues> preferences) {
+		formatterTestHelper.assertFormatted(request -> {
+			request.setToBeFormatted(formatterInput);
+			request.setExpectation(formatterExpectation);
+			if (preferences != null) {
+				preferences.accept(request.getOrCreateMapBasedPreferences());
+			}
+		});
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/FormatterTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/FormatterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,41 +8,36 @@
  *******************************************************************************/
 package org.eclipse.xtext.example.domainmodel.tests
 
-import com.google.inject.Inject
 import org.eclipse.xtext.formatting2.FormatterPreferenceKeys
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
-import org.eclipse.xtext.testing.formatter.FormatterTestHelper
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(XtextRunner)
 @InjectWith(DomainmodelInjectorProvider)
-class FormatterTest {
-
-	@Inject extension FormatterTestHelper
+class FormatterTest extends AbstractFormatterTest {
 
 	/**
 	 * This example tests if the formatted document equals the unformatted document.
 	 * This is the most convenient way to test a formatter.
 	 */
 	@Test def void example1() {
-		assertFormatted[
-			toBeFormatted = '''
-				entity Foo {
-					propertyName:String
-				
-					op name() {
-						val x = 1 + 2 + 4
-						val foo = {
-							println()
-							println()
-							null
-						}
+		'''
+			entity Foo {
+				propertyName:String
+			
+				op name() {
+					val x = 1 + 2 + 4
+					val foo = {
+						println()
+						println()
+						null
 					}
 				}
-			'''
-		]
+			}
+		'''.assertUnformattedEqualsFormatted
 	}
 
 	/**
@@ -52,42 +47,33 @@ class FormatterTest {
 	* Here, it depends on the formatters input document whether there will be one or two newLines on the output.
 	*/
 	@Test def void example2() {
-		assertFormatted[
-			expectation = '''
-				entity Foo {
-					op foo():String {
-						"xx"
-					}
+		'''
+			entity Foo {  op  foo  (  )  :  String  {  "xx"  }  }
+		'''.assertFormattedTo('''
+			entity Foo {
+				op foo():String {
+					"xx"
 				}
-			'''
-			toBeFormatted = '''
-				entity Foo {  op  foo  (  )  :  String  {  "xx"  }  }
-			'''
-		]
+			}
+		''')
 	}
 
 	/**
 	* This example shows how to test property-dependent formatting behavior.
 	*/
 	@Test def void example3() {
-		assertFormatted[
-			preferences[
-				put(FormatterPreferenceKeys.indentation, " ")
-			]
-			expectation = '''
-				entity Foo {
-				 op foo():String {
-				  "xx"
-				 }
+		'''
+			entity Foo {
+				op foo():String {
+					"xx"
 				}
-			'''
-			toBeFormatted = '''
-				entity Foo {
-					op foo():String {
-						"xx"
-					}
-				}
-			'''
-		]
+			}
+		'''.assertFormattedTo('''
+			entity Foo {
+			 op foo():String {
+			  "xx"
+			 }
+			}
+		''',[put(FormatterPreferenceKeys.indentation, " ")])
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/FormatterTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/FormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,15 +8,12 @@
  */
 package org.eclipse.xtext.example.domainmodel.tests;
 
-import com.google.inject.Inject;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.formatting2.FormatterPreferenceKeys;
 import org.eclipse.xtext.preferences.MapBasedPreferenceValues;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
-import org.eclipse.xtext.testing.formatter.FormatterTestHelper;
-import org.eclipse.xtext.testing.formatter.FormatterTestRequest;
-import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.testing.formatter.AbstractFormatterTest;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,54 +21,47 @@ import org.junit.runner.RunWith;
 @RunWith(XtextRunner.class)
 @InjectWith(DomainmodelInjectorProvider.class)
 @SuppressWarnings("all")
-public class FormatterTest {
-  @Inject
-  @Extension
-  private FormatterTestHelper _formatterTestHelper;
-
+public class FormatterTest extends AbstractFormatterTest {
   /**
    * This example tests if the formatted document equals the unformatted document.
    * This is the most convenient way to test a formatter.
    */
   @Test
   public void example1() {
-    final Procedure1<FormatterTestRequest> _function = (FormatterTestRequest it) -> {
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("entity Foo {");
-      _builder.newLine();
-      _builder.append("\t");
-      _builder.append("propertyName:String");
-      _builder.newLine();
-      _builder.newLine();
-      _builder.append("\t");
-      _builder.append("op name() {");
-      _builder.newLine();
-      _builder.append("\t\t");
-      _builder.append("val x = 1 + 2 + 4");
-      _builder.newLine();
-      _builder.append("\t\t");
-      _builder.append("val foo = {");
-      _builder.newLine();
-      _builder.append("\t\t\t");
-      _builder.append("println()");
-      _builder.newLine();
-      _builder.append("\t\t\t");
-      _builder.append("println()");
-      _builder.newLine();
-      _builder.append("\t\t\t");
-      _builder.append("null");
-      _builder.newLine();
-      _builder.append("\t\t");
-      _builder.append("}");
-      _builder.newLine();
-      _builder.append("\t");
-      _builder.append("}");
-      _builder.newLine();
-      _builder.append("}");
-      _builder.newLine();
-      it.setToBeFormatted(_builder);
-    };
-    this._formatterTestHelper.assertFormatted(_function);
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("propertyName:String");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op name() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("val x = 1 + 2 + 4");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("val foo = {");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("println()");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("println()");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("null");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.assertUnformattedEqualsFormatted(_builder);
   }
 
   /**
@@ -82,28 +72,24 @@ public class FormatterTest {
    */
   @Test
   public void example2() {
-    final Procedure1<FormatterTestRequest> _function = (FormatterTestRequest it) -> {
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("entity Foo {");
-      _builder.newLine();
-      _builder.append("\t");
-      _builder.append("op foo():String {");
-      _builder.newLine();
-      _builder.append("\t\t");
-      _builder.append("\"xx\"");
-      _builder.newLine();
-      _builder.append("\t");
-      _builder.append("}");
-      _builder.newLine();
-      _builder.append("}");
-      _builder.newLine();
-      it.setExpectation(_builder);
-      StringConcatenation _builder_1 = new StringConcatenation();
-      _builder_1.append("entity Foo {  op  foo  (  )  :  String  {  \"xx\"  }  }");
-      _builder_1.newLine();
-      it.setToBeFormatted(_builder_1);
-    };
-    this._formatterTestHelper.assertFormatted(_function);
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Foo {  op  foo  (  )  :  String  {  \"xx\"  }  }");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("entity Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("op foo():String {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("\"xx\"");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormattedTo(_builder, _builder_1);
   }
 
   /**
@@ -111,42 +97,37 @@ public class FormatterTest {
    */
   @Test
   public void example3() {
-    final Procedure1<FormatterTestRequest> _function = (FormatterTestRequest it) -> {
-      final Procedure1<MapBasedPreferenceValues> _function_1 = (MapBasedPreferenceValues it_1) -> {
-        it_1.<String>put(FormatterPreferenceKeys.indentation, " ");
-      };
-      it.preferences(_function_1);
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("entity Foo {");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("op foo():String {");
-      _builder.newLine();
-      _builder.append("  ");
-      _builder.append("\"xx\"");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("}");
-      _builder.newLine();
-      _builder.append("}");
-      _builder.newLine();
-      it.setExpectation(_builder);
-      StringConcatenation _builder_1 = new StringConcatenation();
-      _builder_1.append("entity Foo {");
-      _builder_1.newLine();
-      _builder_1.append("\t");
-      _builder_1.append("op foo():String {");
-      _builder_1.newLine();
-      _builder_1.append("\t\t");
-      _builder_1.append("\"xx\"");
-      _builder_1.newLine();
-      _builder_1.append("\t");
-      _builder_1.append("}");
-      _builder_1.newLine();
-      _builder_1.append("}");
-      _builder_1.newLine();
-      it.setToBeFormatted(_builder_1);
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op foo():String {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("\"xx\"");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("entity Foo {");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("op foo():String {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("\"xx\"");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    final Procedure1<MapBasedPreferenceValues> _function = (MapBasedPreferenceValues it) -> {
+      it.<String>put(FormatterPreferenceKeys.indentation, " ");
     };
-    this._formatterTestHelper.assertFormatted(_function);
+    this.assertFormattedTo(_builder, _builder_1, _function);
   }
 }


### PR DESCRIPTION
- Add the org.eclipse.xtext.testing.AbstractFormatterTest class.
- Modify the FormatterTest class of the Domainmodel example to demonstrate the usage of the AbstractFormatterTest class.
- Modify the AbstractXtendFormatterTest base class to inherit from the newly created AbstractFormatterTest class and adapt the Xtend formatter test cases to use the inherited members/methods.

Closes #2965 