### PR TITLE
Replace usage of Maps.newHashMapWithExpectedSize() with standard Java

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/clustering/CopiedResourceDescription.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/clustering/CopiedResourceDescription.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.builder.clustering;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -26,7 +27,6 @@ import org.eclipse.xtext.resource.impl.AbstractResourceDescription;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 
 /**
  * Makes an eager copy of the exported objects of another resource description.
@@ -56,7 +56,7 @@ public class CopiedResourceDescription extends AbstractResourceDescription {
                         Map<String, String> userData = null;
                         for (final String key : from.getUserDataKeys()) {
                             if (userData == null) {
-                                userData = Maps.newHashMapWithExpectedSize(2);
+                                userData = new HashMap<>(3);
                             }
                             userData.put(key, from.getUserData(key));
                         }

--- a/org.eclipse.xtext.ecore/src/org/eclipse/xtext/ecore/EcoreResourceDescriptionStrategy.java
+++ b/org.eclipse.xtext.ecore/src/org/eclipse/xtext/ecore/EcoreResourceDescriptionStrategy.java
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.ecore;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
@@ -19,7 +20,6 @@ import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.impl.DefaultResourceDescriptionStrategy;
 import org.eclipse.xtext.util.IAcceptor;
 
-import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -48,8 +48,7 @@ public class EcoreResourceDescriptionStrategy extends DefaultResourceDescription
 		try {
 			QualifiedName qualifiedName = qualifiedNameProvider.getFullyQualifiedName(eObject);
 			if (qualifiedName != null) {
-				Map<String, String> userData = Maps.newHashMapWithExpectedSize(1);
-				userData.put(NS_URI_INDEX_ENTRY, Boolean.toString(isNsURI));
+				Map<String, String> userData = Collections.singletonMap(NS_URI_INDEX_ENTRY, Boolean.toString(isNsURI));
 				IEObjectDescription description = EObjectDescription.create(qualifiedName, eObject, userData);
 				acceptor.accept(description);
 				return true;

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/EObjectDescriptionProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/EObjectDescriptionProvider.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.ide.serializer.impl;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -31,7 +32,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
 
@@ -59,7 +59,7 @@ public class EObjectDescriptionProvider implements IEObjectDescriptionProvider {
 			Map<String, String> userData = null;
 			for (final String key : source.getUserDataKeys()) {
 				if (userData == null) {
-					userData = Maps.newHashMapWithExpectedSize(2);
+					userData = new HashMap<>(3);
 				}
 				userData.put(key, source.getUserData(key));
 			}

--- a/org.eclipse.xtext.testlanguages/src/org/eclipse/xtext/testlanguages/ecore/EcoreResourceDescriptionStrategy.java
+++ b/org.eclipse.xtext.testlanguages/src/org/eclipse/xtext/testlanguages/ecore/EcoreResourceDescriptionStrategy.java
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.testlanguages.ecore;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
@@ -19,7 +20,6 @@ import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.impl.DefaultResourceDescriptionStrategy;
 import org.eclipse.xtext.util.IAcceptor;
 
-import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -48,8 +48,7 @@ public class EcoreResourceDescriptionStrategy extends DefaultResourceDescription
 		try {
 			QualifiedName qualifiedName = qualifiedNameProvider.getFullyQualifiedName(eObject);
 			if (qualifiedName != null) {
-				Map<String, String> userData = Maps.newHashMapWithExpectedSize(1);
-				userData.put(NS_URI_INDEX_ENTRY, Boolean.toString(isNsURI));
+				Map<String, String> userData = Collections.singletonMap(NS_URI_INDEX_ENTRY, Boolean.toString(isNsURI));
 				IEObjectDescription description = EObjectDescription.create(qualifiedName, eObject, userData);
 				acceptor.accept(description);
 				return true;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/StatefulResourceDescription.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/StatefulResourceDescription.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.ui.editor;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -27,7 +28,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.inject.Provider;
 
 /**
@@ -61,7 +61,7 @@ public class StatefulResourceDescription extends AbstractResourceDescription {
 				Map<String, String> userData = null;
 				for(String key: from.getUserDataKeys()) {
 					if (userData == null) {
-						userData = Maps.newHashMapWithExpectedSize(2);
+						userData = new HashMap<>(3);
 					}
 					userData.put(key, from.getUserData(key));
 				}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.xtend
@@ -8,7 +8,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.generator
 
-import com.google.common.collect.Maps
 import com.google.inject.Binder
 import com.google.inject.Guice
 import com.google.inject.Inject
@@ -18,6 +17,7 @@ import com.google.inject.Provider
 import com.google.inject.Singleton
 import com.google.inject.name.Names
 import java.util.Collections
+import java.util.HashMap
 import java.util.List
 import java.util.Map
 import java.util.Properties
@@ -36,12 +36,12 @@ import org.eclipse.xtext.xtext.generator.model.FileAccessFactory
 import org.eclipse.xtext.xtext.generator.model.GeneratedJavaFileAccess
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
 import org.eclipse.xtext.xtext.generator.model.JavaFileAccess
+import org.eclipse.xtext.xtext.generator.model.TextFileAccess
 import org.eclipse.xtext.xtext.generator.model.TypeReference
 import org.eclipse.xtext.xtext.generator.model.annotations.SuppressWarningsAnnotation
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig
 
 import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
-import org.eclipse.xtext.xtext.generator.model.TextFileAccess
 
 /**
  * Templates for generating the common language infrastructure.
@@ -505,7 +505,7 @@ class XtextGeneratorTemplates {
 				
 				private static «activator.simpleName» INSTANCE;
 				
-				private «Map»<String, «Injector»> injectors = «Collections».synchronizedMap(«Maps».<String, «Injector»> newHashMapWithExpectedSize(1));
+				private «Map»<String, «Injector»> injectors = «Collections».synchronizedMap(new «HashMap»<>(2));
 				
 				@Override
 				public void start(«'org.osgi.framework.BundleContext'.typeRef» context) throws Exception {

--- a/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
+++ b/org.eclipse.xtext.xtext.generator/xtend-gen/org/eclipse/xtext/xtext/generator/XtextGeneratorTemplates.java
@@ -8,7 +8,6 @@
  */
 package org.eclipse.xtext.xtext.generator;
 
-import com.google.common.collect.Maps;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -17,6 +16,7 @@ import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -1526,11 +1526,9 @@ public class XtextGeneratorTemplates {
         _builder.append(Injector.class, "\t");
         _builder.append("> injectors = ");
         _builder.append(Collections.class, "\t");
-        _builder.append(".synchronizedMap(");
-        _builder.append(Maps.class, "\t");
-        _builder.append(".<String, ");
-        _builder.append(Injector.class, "\t");
-        _builder.append("> newHashMapWithExpectedSize(1));");
+        _builder.append(".synchronizedMap(new ");
+        _builder.append(HashMap.class, "\t");
+        _builder.append("<>(2));");
         _builder.newLineIfNotEmpty();
         _builder.append("\t");
         _builder.newLine();

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/AbstractTraceRegion.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/AbstractTraceRegion.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.generator.trace;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -132,8 +133,7 @@ public abstract class AbstractTraceRegion {
 
 	protected Map<SourceRelativeURI, List<Pair<ILocationData, AbstractTraceRegion>>> collectMatchingLocations(
 			SourceRelativeURI expectedAssociatedPath) {
-		Map<SourceRelativeURI, List<Pair<ILocationData, AbstractTraceRegion>>> result = Maps
-				.newHashMapWithExpectedSize(2);
+		Map<SourceRelativeURI, List<Pair<ILocationData, AbstractTraceRegion>>> result = new HashMap<>(3);
 		Iterator<AbstractTraceRegion> treeIterator = treeIterator();
 		while (treeIterator.hasNext()) {
 			AbstractTraceRegion next = treeIterator.next();

--- a/org.eclipse.xtext/src/org/eclipse/xtext/resource/SaveOptions.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/resource/SaveOptions.java
@@ -8,9 +8,8 @@
  *******************************************************************************/
 package org.eclipse.xtext.resource;
 
+import java.util.HashMap;
 import java.util.Map;
-
-import com.google.common.collect.Maps;
 
 /**
  * Immutable SaveOptions can be used to read and write options into the
@@ -70,7 +69,7 @@ public class SaveOptions {
 	}
 	
 	public Map<Object, Object> toOptionsMap() {
-		Map<Object, Object> result = Maps.newHashMapWithExpectedSize(2);
+		Map<Object, Object> result = new HashMap<>(3);
 		addTo(result);
 		return result;
 	}


### PR DESCRIPTION
In Java-19 there is even static factory method `HashMap.newHashMap(int)` that can be used as a drop-in replacement once Java-19 or later is required.
For now I calculate the necessary capacity explicitly using the formula: `expected-size *4/3+1`.

The change in XtextGeneratorTemplates also removes the usage of `Maps.newHashMapWithExpectedSize()` of many generated Activators, but I haven't changed them manually. I assume they should be regenerated, shouldn't they?

Part of https://github.com/eclipse/xtext/issues/2975