### PR TITLE
Added IterableExtensions.lastOrNull and deprecated last

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
@@ -4847,7 +4847,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 		'''
 		val file = file(input.toString(), true)
 		val barType = file.eResource.contents.filter(typeof(JvmDeclaredType)).head
-		val bazType = file.eResource.contents.filter(typeof(JvmDeclaredType)).last
+		val bazType = file.eResource.contents.filter(typeof(JvmDeclaredType)).lastOrNull
 		val generatorConfig =  generatorConfigProvider.get(barType)
 		var barJavaCode = generator.generateType(barType, generatorConfig);
 		barJavaCode = postProcessor.postProcess(null, barJavaCode);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/java8/Java8TypeProviderTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/java8/Java8TypeProviderTest.xtend
@@ -44,7 +44,7 @@ class Java8TypeProviderTest {
 				static def void staticMethod() {}
 			}
 		''')
-		val intf = file.eResource.contents.last as JvmGenericType
+		val intf = file.eResource.contents.lastOrNull as JvmGenericType
 		doTestMethods(intf)
 	}
 

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/jvmmodel/JvmModelTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/jvmmodel/JvmModelTests.xtend
@@ -222,9 +222,9 @@ class JvmModelTests extends AbstractXtendTestCase {
 		assertTrue(anonymous.anonymous)
 		assertEquals(JvmVisibility.DEFAULT, anonymous.visibility)
 		assertEquals(2, anonymous.superTypes.size)
-		assertEquals('java.lang.Runnable', anonymous.superTypes.last.qualifiedName)
+		assertEquals('java.lang.Runnable', anonymous.superTypes.lastOrNull.qualifiedName)
 		assertEquals(3, anonymous.members.size)
-		val constructor = anonymous.members.last
+		val constructor = anonymous.members.lastOrNull
 		assertTrue(constructor instanceof JvmConstructor)
 		assertEquals(0, (constructor as JvmConstructor).parameters.size)
 		assertTrue(anonymous.members.head instanceof JvmField)
@@ -250,9 +250,9 @@ class JvmModelTests extends AbstractXtendTestCase {
 		assertTrue(anonymous.anonymous)
 		assertEquals(JvmVisibility.DEFAULT, anonymous.visibility)
 		assertEquals(2, anonymous.superTypes.size)
-		assertEquals('java.lang.Runnable', anonymous.superTypes.last.qualifiedName)
+		assertEquals('java.lang.Runnable', anonymous.superTypes.lastOrNull.qualifiedName)
 		assertEquals(2, anonymous.members.size)
-		val constructor = anonymous.members.last
+		val constructor = anonymous.members.lastOrNull
 		assertTrue(constructor instanceof JvmConstructor)
 		assertEquals(0, (constructor as JvmConstructor).parameters.size)
 		val overriding = anonymous.members.head
@@ -278,9 +278,9 @@ class JvmModelTests extends AbstractXtendTestCase {
 		assertEquals(0, anonymous.typeParameters.size)
 		assertEquals(JvmVisibility.DEFAULT, anonymous.visibility)
 		assertEquals(2, anonymous.superTypes.size)
-		assertEquals('java.lang.Iterable<T>', anonymous.superTypes.last.qualifiedName)
+		assertEquals('java.lang.Iterable<T>', anonymous.superTypes.lastOrNull.qualifiedName)
 		assertEquals(2, anonymous.members.size)
-		val constructor = anonymous.members.last
+		val constructor = anonymous.members.lastOrNull
 		assertTrue(constructor instanceof JvmConstructor)
 		assertEquals(0, (constructor as JvmConstructor).typeParameters.size)
 		val overriding = anonymous.members.head
@@ -322,8 +322,8 @@ class JvmModelTests extends AbstractXtendTestCase {
 		assertTrue(nested2.static)
 
 		assertEquals(2, nested1.members.size)
-		assertTrue(nested1.members.last instanceof JvmEnumerationType)
-		val nested3 = nested1.members.last as JvmEnumerationType
+		assertTrue(nested1.members.lastOrNull instanceof JvmEnumerationType)
+		val nested3 = nested1.members.lastOrNull as JvmEnumerationType
 		assertEquals('Nested3', nested3.simpleName)
 		assertTrue(nested3.static)
 	}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/linking/OverloadedInstanceMethodsTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/linking/OverloadedInstanceMethodsTests.xtend
@@ -36,7 +36,7 @@ abstract class AbstractOverloadedInstanceMethodTest extends AbstractXtendTestCas
 		val c = file.xtendTypes.head as XtendClass
 		val m = c.members.head as XtendFunction
 		val body = m.expression as XBlockExpression
-		val featureCall = body.expressions.last as XAbstractFeatureCall
+		val featureCall = body.expressions.lastOrNull as XAbstractFeatureCall
 		val operation = featureCall.feature as JvmOperation
 		val owner = new StandardTypeReferenceOwner(services, file)
 		val declaration = owner.newParameterizedTypeReference(operation.declaringType)

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/linking/OverloadedStaticMethodTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/linking/OverloadedStaticMethodTests.xtend
@@ -36,7 +36,7 @@ abstract class AbstractOverloadedStaticMethodTest extends AbstractXtendTestCase 
 		val c = file.xtendTypes.head as XtendClass
 		val m = c.members.head as XtendFunction
 		val body = m.expression as XBlockExpression
-		val featureCall = body.expressions.last as XAbstractFeatureCall
+		val featureCall = body.expressions.lastOrNull as XAbstractFeatureCall
 		val operation = featureCall.feature as JvmOperation
 		val owner = new StandardTypeReferenceOwner(services, file)
 		val declaration = owner.newParameterizedTypeReference(operation.declaringType)

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.xtend
@@ -1344,7 +1344,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				assertEquals(1, value.annotations.size)
 				assertNotNull(value.findAnnotation(deprecatedAnnotationType))
 			}
-			assertEquals("D", enumerationType.declaredValues.last.simpleName)
+			assertEquals("D", enumerationType.declaredValues.lastOrNull.simpleName)
 			assertNotNull(enumerationType.findDeclaredValue("D"))
 		]
 	}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/TypeReferenceAssignabilityTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/TypeReferenceAssignabilityTest.xtend
@@ -35,7 +35,7 @@ class TypeReferenceAssignabilityTest extends AssignabilityTest {
 				else
 					toTypeReference(owner.newAnyTypeReference)
 			val rhsType = if (rhs !== null)
-					toTypeReference(operation.parameters.last.parameterType)
+					toTypeReference(operation.parameters.lastOrNull.parameterType)
 				else
 					toTypeReference(owner.newAnyTypeReference)
 			assertEquals(lhsType.simpleName + " := " + rhsType.simpleName, expectation,

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.xtend
@@ -261,7 +261,7 @@ class DeclarationsTest extends AbstractXtendTestCase {
 			assertEquals("add", listAdd.simpleName)
 			assertEquals("E", listAdd.parameters.head.type.simpleName)
 			
-			val intfAdd = allOverridden.last
+			val intfAdd = allOverridden.lastOrNull
 			assertEquals("add", intfAdd.simpleName)
 			assertEquals("String", intfAdd.parameters.head.type.simpleName)
 		]

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/resource/ResourceStorageTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/resource/ResourceStorageTest.xtend
@@ -154,7 +154,7 @@ class ResourceStorageTest extends AbstractXtendTestCase {
 		
 		// check constant value was written
 		val jvmClass = resource.contents.get(1) as JvmGenericType
-		val field = jvmClass.members.last as JvmField
+		val field = jvmClass.members.lastOrNull as JvmField
 		assertTrue(field.constant)
 		assertTrue(field.isSetConstant)
 		assertEquals('ab0', field.constantValue)
@@ -185,7 +185,7 @@ class ResourceStorageTest extends AbstractXtendTestCase {
 		
 		// check constant value was written
 		val jvmClass = resource.contents.get(1) as JvmGenericType
-		val field = jvmClass.members.last as JvmField
+		val field = jvmClass.members.lastOrNull as JvmField
 		assertFalse(field.constant)
 		assertTrue(field.isSetConstant)
 		assertNull(field.constantValue)

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/AssignabilityTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/AssignabilityTests.xtend
@@ -74,7 +74,7 @@ abstract class AbstractAssignabilityTest extends AbstractTestingTypeReferenceOwn
 		val function = function(signature.toString)
 		val operation = function.directlyInferredOperation
 		val lhsType = if (lhsAndParams.key !== null) operation.parameters.head.parameterType.toLightweightTypeReference else owner.newAnyTypeReference
-		val rhsType = if (rhs !== null) operation.parameters.last.parameterType.toLightweightTypeReference else owner.newAnyTypeReference
+		val rhsType = if (rhs !== null) operation.parameters.lastOrNull.parameterType.toLightweightTypeReference else owner.newAnyTypeReference
 		assertEquals(lhsType.simpleName + " := " + rhsType.simpleName, expectation, lhsType.testIsAssignable(rhsType))
 		if (expectation) {
 			for(superType: lhsType.allSuperTypes) {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/DeferredTypeParameterHintCollectorTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/DeferredTypeParameterHintCollectorTest.xtend
@@ -64,7 +64,7 @@ class DeferredTypeParameterHintCollectorTest extends AbstractTestingTypeReferenc
 		resolver.initializeFrom(EcoreUtil.getRootContainer(operation))
 		val substitutor = new MockTypeParameterSubstitutor(owner, new PublicResolvedTypes(resolver))
 		val hasUnbounds = substitutor.substitute(operation.parameters.head.parameterType.toLightweightTypeReference)
-		val isActual = operation.parameters.last.parameterType.toLightweightTypeReference
+		val isActual = operation.parameters.lastOrNull.parameterType.toLightweightTypeReference
 		collector.processPairedReferences(hasUnbounds, isActual)
 		return substitutor.typeParameterMapping
 	}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ErrorTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ErrorTest.xtend
@@ -1225,7 +1225,7 @@ class ErrorTest extends AbstractXtendTestCase {
 			}
 		'''.processWithoutException
 		val resolvedTypes = typeResolver.resolveTypes(file)
-		val casted = file.eAllContents.filter(XCastedExpression).last
+		val casted = file.eAllContents.filter(XCastedExpression).lastOrNull
 		assertNull(casted.type)
 		assertNotNull(resolvedTypes.getActualType(casted))
 	}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ErrorTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ErrorTest.xtend
@@ -75,7 +75,7 @@ class ErrorTest extends AbstractXtendTestCase {
 				@
 		'''.processWithoutException
 		val clazz = file.xtendTypes.head as XtendClass
-		val lastMember = clazz.members.last
+		val lastMember = clazz.members.lastOrNull
 		val annotations = lastMember.annotations
 		val resolvedTypes = typeResolver.resolveTypes(annotations.head)
 		assertNotNull(resolvedTypes.getActualType(annotations.head))
@@ -91,7 +91,7 @@ class ErrorTest extends AbstractXtendTestCase {
 				d
 		'''.processWithoutException
 		val clazz = file.xtendTypes.head as XtendClass
-		val lastMember = clazz.members.last
+		val lastMember = clazz.members.lastOrNull
 		val annotations = lastMember.annotations
 		val resolvedTypes = typeResolver.resolveTypes(annotations.head)
 		assertNotNull(resolvedTypes.getActualType(annotations.head))
@@ -107,7 +107,7 @@ class ErrorTest extends AbstractXtendTestCase {
 				def m
 		'''.processWithoutException
 		val clazz = file.xtendTypes.head as XtendClass
-		val lastMember = clazz.members.last
+		val lastMember = clazz.members.lastOrNull
 		val annotations = lastMember.annotations
 		val resolvedTypes = typeResolver.resolveTypes(annotations.head)
 		assertNotNull(resolvedTypes.getActualType(annotations.head))
@@ -130,7 +130,7 @@ class ErrorTest extends AbstractXtendTestCase {
 			@Data class A {}
 			@
 		'''.processWithoutException
-		val typeDeclaration = file.xtendTypes.last
+		val typeDeclaration = file.xtendTypes.lastOrNull
 		val annotations = typeDeclaration.annotations
 		val resolvedTypes = typeResolver.resolveTypes(annotations.head)
 		assertNotNull(resolvedTypes.getActualType(annotations.head))
@@ -142,7 +142,7 @@ class ErrorTest extends AbstractXtendTestCase {
 			@Data class A {}
 			@Data class
 		'''.processWithoutException
-		val typeDeclaration = file.xtendTypes.last
+		val typeDeclaration = file.xtendTypes.lastOrNull
 		val annotations = typeDeclaration.annotations
 		val resolvedTypes = typeResolver.resolveTypes(annotations.head)
 		assertNotNull(resolvedTypes.getActualType(annotations.head))
@@ -153,8 +153,8 @@ class ErrorTest extends AbstractXtendTestCase {
 		val file = '''
 			annotation Bar { @
 		'''.processWithoutException
-		val typeDeclaration = file.xtendTypes.last
-		val annotations = typeDeclaration.members.last.annotations
+		val typeDeclaration = file.xtendTypes.lastOrNull
+		val annotations = typeDeclaration.members.lastOrNull.annotations
 		val resolvedTypes = typeResolver.resolveTypes(annotations.head)
 		assertNotNull(resolvedTypes.getActualType(annotations.head))
 	}
@@ -165,8 +165,8 @@ class ErrorTest extends AbstractXtendTestCase {
 			class X {
 				@Property val S
 		'''.processWithoutException
-		val typeDeclaration = file.xtendTypes.last
-		val annotations = typeDeclaration.members.last.annotations
+		val typeDeclaration = file.xtendTypes.lastOrNull
+		val annotations = typeDeclaration.members.lastOrNull.annotations
 		val resolvedTypes = typeResolver.resolveTypes(annotations.head)
 		assertNotNull(resolvedTypes.getActualType(annotations.head))
 	}
@@ -176,7 +176,7 @@ class ErrorTest extends AbstractXtendTestCase {
 		val file = '''
 			@SuppressWarnings("unused"
 		'''.processWithoutException
-		val typeDeclaration = file.xtendTypes.last
+		val typeDeclaration = file.xtendTypes.lastOrNull
 		val annotations = typeDeclaration.annotations
 		val resolvedTypes = typeResolver.resolveTypes(annotations.head)
 		assertNotNull(resolvedTypes.getActualType(annotations.head))
@@ -189,7 +189,7 @@ class ErrorTest extends AbstractXtendTestCase {
 				val inferred = 'bar'
 			}
 		'''.processWithoutException
-		val annotation = file.xtendTypes.last
+		val annotation = file.xtendTypes.lastOrNull
 		val field = annotation.members.head as XtendField
 		val initializer = field.initialValue
 		val resolvedTypes = typeResolver.resolveTypes(initializer)
@@ -239,7 +239,7 @@ class ErrorTest extends AbstractXtendTestCase {
 			   def  getHeader();
 			}
 		'''.processWithoutException
-		val headerAccess = file.xtendTypes.last
+		val headerAccess = file.xtendTypes.lastOrNull
 		val function = headerAccess.members.head as XtendFunction // error recovery parses two fields after the function #test
 		val operation = associations.getJvmElements(function).head as JvmOperation
 		val resolvedTypes = typeResolver.resolveTypes(operation)
@@ -258,7 +258,7 @@ class ErrorTest extends AbstractXtendTestCase {
 				def String foo(String x, String...args)
 			}
 		'''.processWithoutException
-		val headerAccess = file.xtendTypes.last
+		val headerAccess = file.xtendTypes.lastOrNull
 		val function = headerAccess.members.head as XtendFunction // error recovery parses two fields after the function #test
 		val operation = associations.getJvmElements(function).head as JvmOperation
 		val resolvedTypes = typeResolver.resolveTypes(operation)
@@ -288,7 +288,7 @@ class ErrorTest extends AbstractXtendTestCase {
 			}
 		'''.processWithoutException
 		val unnamed = file.xtendTypes.head
-		val constructor = unnamed.members.last as XtendConstructor
+		val constructor = unnamed.members.lastOrNull as XtendConstructor
 		val body = constructor.expression as XBlockExpression
 		val assignment = body.expressions.head as XAssignment
 		val resolvedTypes = typeResolver.resolveTypes(assignment)
@@ -314,7 +314,7 @@ class ErrorTest extends AbstractXtendTestCase {
 				valuri = [| new URI('')].propagate [ new IllegalArgumentException(it) ]
 			}
 		'''.processWithoutException
-		val client = file.xtendTypes.last
+		val client = file.xtendTypes.lastOrNull
 		val field = client.members.head as XtendField
 		val initializer = field.initialValue as XMemberFeatureCall
 		val closure = initializer.memberCallArguments.head as XClosure
@@ -369,7 +369,7 @@ class ErrorTest extends AbstractXtendTestCase {
 			}
 		'''.processWithoutException
 		val y = file.xtendTypes.head
-		val function = y.members.last as XtendFunction
+		val function = y.members.lastOrNull as XtendFunction
 		val body = function.expression as XBlockExpression
 		val featureCall = body.expressions.head as XMemberFeatureCall
 		val implicitReceiver = featureCall.implicitReceiver as XMemberFeatureCall

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/VarArgFeatureCallArgumentsTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/VarArgFeatureCallArgumentsTest.xtend
@@ -130,7 +130,7 @@ class VarArgFeatureCallArgumentsTest extends AbstractTestingTypeReferenceOwner {
 		val expressions = valid.argumentExpressions
 		assertEquals(2, expressions.size)
 		assertTrue(expressions.head instanceof XStringLiteral)
-		assertTrue(expressions.last instanceof XNumberLiteral)
+		assertTrue(expressions.lastOrNull instanceof XNumberLiteral)
 		
 		valid.markProcessed
 		
@@ -152,7 +152,7 @@ class VarArgFeatureCallArgumentsTest extends AbstractTestingTypeReferenceOwner {
 		val expressions = valid.argumentExpressions
 		assertEquals(2, expressions.size)
 		assertTrue(expressions.head instanceof XStringLiteral)
-		assertTrue(expressions.last instanceof XNumberLiteral)		
+		assertTrue(expressions.lastOrNull instanceof XNumberLiteral)		
 
 		assertTrue(arguments.isProcessed(0))
 		assertFalse(arguments.isProcessed(1))

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typing/AnonymousClassTypeTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typing/AnonymousClassTypeTest.xtend
@@ -53,7 +53,7 @@ class AnonymousClassTypeTest extends AbstractXtendTestCase {
 		val operation = function.directlyInferredOperation
 		val resolvedTypes = operation.eResource.resolveTypes
 		assertEquals('Runnable', resolvedTypes.getActualType(operation).toString)	
-		val variable = (function.expression as XBlockExpression).expressions.last
+		val variable = (function.expression as XBlockExpression).expressions.lastOrNull
 		val variableType = resolvedTypes.getActualType(variable)
 		assertEquals('__Foo_1', variableType.toString)
 		assertTrue(variableType.isSubtypeOf(Runnable))
@@ -72,7 +72,7 @@ class AnonymousClassTypeTest extends AbstractXtendTestCase {
 		val resolvedTypes = operation.eResource.resolveTypes
 		assertEquals('Iterable<String>', resolvedTypes.getActualType(operation).toString)
 		val anonymousClass = (function.expression as XBlockExpression).expressions.head as AnonymousClass
-		val overriding = (anonymousClass.members.last as XtendFunction).directlyInferredOperation
+		val overriding = (anonymousClass.members.lastOrNull as XtendFunction).directlyInferredOperation
 		assertEquals('Iterator<String>', resolvedTypes.getActualType(overriding).toString)
 	}
 	
@@ -89,7 +89,7 @@ class AnonymousClassTypeTest extends AbstractXtendTestCase {
 		val resolvedTypes = operation.eResource.resolveTypes
 		assertEquals('Iterable<T>', resolvedTypes.getActualType(operation).toString)
 		val anonymousClass = (function.expression as XBlockExpression).expressions.head as AnonymousClass
-		val overriding = (anonymousClass.members.last as XtendFunction).directlyInferredOperation
+		val overriding = (anonymousClass.members.lastOrNull as XtendFunction).directlyInferredOperation
 		assertEquals('Iterator<T>', resolvedTypes.getActualType(overriding).toString)
 	}
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/AmbiguityValidationTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/AmbiguityValidationTests.xtend
@@ -50,7 +50,7 @@ abstract class AmbiguityValidationTest extends AbstractXtendTestCase {
 		val firstMember = firstType.members.head as XtendFunction
 		val block = firstMember.expression as XBlockExpression
 		val resolvedTypes = file.resolveTypes
-		val linkingCandidate = switch featureOrConstructorCall : block.expressions.last {
+		val linkingCandidate = switch featureOrConstructorCall : block.expressions.lastOrNull {
 			XAbstractFeatureCall: resolvedTypes.getLinkingCandidate(featureOrConstructorCall)
 			XConstructorCall: resolvedTypes.getLinkingCandidate(featureOrConstructorCall)
 			default: throw new IllegalArgumentException(String.valueOf(featureOrConstructorCall.eClass.name))

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
@@ -10697,7 +10697,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
       final String expectedBazClass = _builder_2.toString();
       final XtendFile file = this.file(input.toString(), true);
       final JvmDeclaredType barType = IterableExtensions.<JvmDeclaredType>head(Iterables.<JvmDeclaredType>filter(file.eResource().getContents(), JvmDeclaredType.class));
-      final JvmDeclaredType bazType = IterableExtensions.<JvmDeclaredType>last(Iterables.<JvmDeclaredType>filter(file.eResource().getContents(), JvmDeclaredType.class));
+      final JvmDeclaredType bazType = IterableExtensions.<JvmDeclaredType>lastOrNull(Iterables.<JvmDeclaredType>filter(file.eResource().getContents(), JvmDeclaredType.class));
       final GeneratorConfig generatorConfig = this.generatorConfigProvider.get(barType);
       CharSequence barJavaCode = this.generator.generateType(barType, generatorConfig);
       barJavaCode = this.postProcessor.postProcess(null, barJavaCode);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/java8/Java8TypeProviderTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/java8/Java8TypeProviderTest.java
@@ -64,8 +64,8 @@ public class Java8TypeProviderTest {
       _builder.append("}");
       _builder.newLine();
       final XtendFile file = this.parseHelper.parse(_builder);
-      EObject _last = IterableExtensions.<EObject>last(file.eResource().getContents());
-      final JvmGenericType intf = ((JvmGenericType) _last);
+      EObject _lastOrNull = IterableExtensions.<EObject>lastOrNull(file.eResource().getContents());
+      final JvmGenericType intf = ((JvmGenericType) _lastOrNull);
       this.doTestMethods(intf);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/jvmmodel/JvmModelTests.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/jvmmodel/JvmModelTests.java
@@ -374,9 +374,9 @@ public class JvmModelTests extends AbstractXtendTestCase {
       Assert.assertTrue(anonymous.isAnonymous());
       Assert.assertEquals(JvmVisibility.DEFAULT, anonymous.getVisibility());
       Assert.assertEquals(2, anonymous.getSuperTypes().size());
-      Assert.assertEquals("java.lang.Runnable", IterableExtensions.<JvmTypeReference>last(anonymous.getSuperTypes()).getQualifiedName());
+      Assert.assertEquals("java.lang.Runnable", IterableExtensions.<JvmTypeReference>lastOrNull(anonymous.getSuperTypes()).getQualifiedName());
       Assert.assertEquals(3, anonymous.getMembers().size());
-      final JvmMember constructor = IterableExtensions.<JvmMember>last(anonymous.getMembers());
+      final JvmMember constructor = IterableExtensions.<JvmMember>lastOrNull(anonymous.getMembers());
       Assert.assertTrue((constructor instanceof JvmConstructor));
       Assert.assertEquals(0, ((JvmConstructor) constructor).getParameters().size());
       JvmMember _head = IterableExtensions.<JvmMember>head(anonymous.getMembers());
@@ -415,9 +415,9 @@ public class JvmModelTests extends AbstractXtendTestCase {
       Assert.assertTrue(anonymous.isAnonymous());
       Assert.assertEquals(JvmVisibility.DEFAULT, anonymous.getVisibility());
       Assert.assertEquals(2, anonymous.getSuperTypes().size());
-      Assert.assertEquals("java.lang.Runnable", IterableExtensions.<JvmTypeReference>last(anonymous.getSuperTypes()).getQualifiedName());
+      Assert.assertEquals("java.lang.Runnable", IterableExtensions.<JvmTypeReference>lastOrNull(anonymous.getSuperTypes()).getQualifiedName());
       Assert.assertEquals(2, anonymous.getMembers().size());
-      final JvmMember constructor = IterableExtensions.<JvmMember>last(anonymous.getMembers());
+      final JvmMember constructor = IterableExtensions.<JvmMember>lastOrNull(anonymous.getMembers());
       Assert.assertTrue((constructor instanceof JvmConstructor));
       Assert.assertEquals(0, ((JvmConstructor) constructor).getParameters().size());
       final JvmMember overriding = IterableExtensions.<JvmMember>head(anonymous.getMembers());
@@ -455,9 +455,9 @@ public class JvmModelTests extends AbstractXtendTestCase {
       Assert.assertEquals(0, anonymous.getTypeParameters().size());
       Assert.assertEquals(JvmVisibility.DEFAULT, anonymous.getVisibility());
       Assert.assertEquals(2, anonymous.getSuperTypes().size());
-      Assert.assertEquals("java.lang.Iterable<T>", IterableExtensions.<JvmTypeReference>last(anonymous.getSuperTypes()).getQualifiedName());
+      Assert.assertEquals("java.lang.Iterable<T>", IterableExtensions.<JvmTypeReference>lastOrNull(anonymous.getSuperTypes()).getQualifiedName());
       Assert.assertEquals(2, anonymous.getMembers().size());
-      final JvmMember constructor = IterableExtensions.<JvmMember>last(anonymous.getMembers());
+      final JvmMember constructor = IterableExtensions.<JvmMember>lastOrNull(anonymous.getMembers());
       Assert.assertTrue((constructor instanceof JvmConstructor));
       Assert.assertEquals(0, ((JvmConstructor) constructor).getTypeParameters().size());
       final JvmMember overriding = IterableExtensions.<JvmMember>head(anonymous.getMembers());
@@ -525,10 +525,10 @@ public class JvmModelTests extends AbstractXtendTestCase {
       Assert.assertEquals("Nested2", nested2.getSimpleName());
       Assert.assertTrue(nested2.isStatic());
       Assert.assertEquals(2, nested1.getMembers().size());
-      JvmMember _last = IterableExtensions.<JvmMember>last(nested1.getMembers());
-      Assert.assertTrue((_last instanceof JvmEnumerationType));
-      JvmMember _last_1 = IterableExtensions.<JvmMember>last(nested1.getMembers());
-      final JvmEnumerationType nested3 = ((JvmEnumerationType) _last_1);
+      JvmMember _lastOrNull = IterableExtensions.<JvmMember>lastOrNull(nested1.getMembers());
+      Assert.assertTrue((_lastOrNull instanceof JvmEnumerationType));
+      JvmMember _lastOrNull_1 = IterableExtensions.<JvmMember>lastOrNull(nested1.getMembers());
+      final JvmEnumerationType nested3 = ((JvmEnumerationType) _lastOrNull_1);
       Assert.assertEquals("Nested3", nested3.getSimpleName());
       Assert.assertTrue(nested3.isStatic());
     } catch (Throwable _e) {

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/linking/AbstractOverloadedInstanceMethodTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/linking/AbstractOverloadedInstanceMethodTest.java
@@ -52,8 +52,8 @@ public abstract class AbstractOverloadedInstanceMethodTest extends AbstractXtend
       final XtendFunction m = ((XtendFunction) _head_1);
       XExpression _expression = m.getExpression();
       final XBlockExpression body = ((XBlockExpression) _expression);
-      XExpression _last = IterableExtensions.<XExpression>last(body.getExpressions());
-      final XAbstractFeatureCall featureCall = ((XAbstractFeatureCall) _last);
+      XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(body.getExpressions());
+      final XAbstractFeatureCall featureCall = ((XAbstractFeatureCall) _lastOrNull);
       JvmIdentifiableElement _feature = featureCall.getFeature();
       final JvmOperation operation = ((JvmOperation) _feature);
       final StandardTypeReferenceOwner owner = new StandardTypeReferenceOwner(this.services, file);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/linking/AbstractOverloadedStaticMethodTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/linking/AbstractOverloadedStaticMethodTest.java
@@ -52,8 +52,8 @@ public abstract class AbstractOverloadedStaticMethodTest extends AbstractXtendTe
       final XtendFunction m = ((XtendFunction) _head_1);
       XExpression _expression = m.getExpression();
       final XBlockExpression body = ((XBlockExpression) _expression);
-      XExpression _last = IterableExtensions.<XExpression>last(body.getExpressions());
-      final XAbstractFeatureCall featureCall = ((XAbstractFeatureCall) _last);
+      XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(body.getExpressions());
+      final XAbstractFeatureCall featureCall = ((XAbstractFeatureCall) _lastOrNull);
       JvmIdentifiableElement _feature = featureCall.getFeature();
       final JvmOperation operation = ((JvmOperation) _feature);
       final StandardTypeReferenceOwner owner = new StandardTypeReferenceOwner(this.services, file);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.java
@@ -2623,7 +2623,7 @@ public abstract class AbstractReusableActiveAnnotationTests {
           Assert.assertNotNull(value.findAnnotation(deprecatedAnnotationType));
         }
       }
-      Assert.assertEquals("D", IterableExtensions.last(enumerationType.getDeclaredValues()).getSimpleName());
+      Assert.assertEquals("D", IterableExtensions.lastOrNull(enumerationType.getDeclaredValues()).getSimpleName());
       Assert.assertNotNull(enumerationType.findDeclaredValue("D"));
     };
     this.assertProcessing(_mappedTo, _mappedTo_1, _function);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/TypeReferenceAssignabilityTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/TypeReferenceAssignabilityTest.java
@@ -74,7 +74,7 @@ public class TypeReferenceAssignabilityTest extends AssignabilityTest {
         final TypeReference lhsType = _xifexpression;
         TypeReference _xifexpression_1 = null;
         if ((rhs != null)) {
-          _xifexpression_1 = it.toTypeReference(IterableExtensions.<JvmFormalParameter>last(operation.getParameters()).getParameterType());
+          _xifexpression_1 = it.toTypeReference(IterableExtensions.<JvmFormalParameter>lastOrNull(operation.getParameters()).getParameterType());
         } else {
           _xifexpression_1 = it.toTypeReference(this.getOwner().newAnyTypeReference());
         }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.java
@@ -366,7 +366,7 @@ public class DeclarationsTest extends AbstractXtendTestCase {
       final MethodDeclaration listAdd = IterableExtensions.head(allOverridden);
       Assert.assertEquals("add", listAdd.getSimpleName());
       Assert.assertEquals("E", IterableExtensions.head(listAdd.getParameters()).getType().getSimpleName());
-      final MethodDeclaration intfAdd = IterableExtensions.last(allOverridden);
+      final MethodDeclaration intfAdd = IterableExtensions.lastOrNull(allOverridden);
       Assert.assertEquals("add", intfAdd.getSimpleName());
       Assert.assertEquals("String", IterableExtensions.head(intfAdd.getParameters()).getType().getSimpleName());
     };

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/resource/ResourceStorageTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/resource/ResourceStorageTest.java
@@ -212,8 +212,8 @@ public class ResourceStorageTest extends AbstractXtendTestCase {
       resource.loadFromStorage(in);
       EObject _get = resource.getContents().get(1);
       final JvmGenericType jvmClass = ((JvmGenericType) _get);
-      JvmMember _last = IterableExtensions.<JvmMember>last(jvmClass.getMembers());
-      final JvmField field = ((JvmField) _last);
+      JvmMember _lastOrNull = IterableExtensions.<JvmMember>lastOrNull(jvmClass.getMembers());
+      final JvmField field = ((JvmField) _lastOrNull);
       Assert.assertTrue(field.isConstant());
       Assert.assertTrue(field.isSetConstant());
       Assert.assertEquals("ab0", field.getConstantValue());
@@ -253,8 +253,8 @@ public class ResourceStorageTest extends AbstractXtendTestCase {
       resource.loadFromStorage(in);
       EObject _get = resource.getContents().get(1);
       final JvmGenericType jvmClass = ((JvmGenericType) _get);
-      JvmMember _last = IterableExtensions.<JvmMember>last(jvmClass.getMembers());
-      final JvmField field = ((JvmField) _last);
+      JvmMember _lastOrNull = IterableExtensions.<JvmMember>lastOrNull(jvmClass.getMembers());
+      final JvmField field = ((JvmField) _lastOrNull);
       Assert.assertFalse(field.isConstant());
       Assert.assertTrue(field.isSetConstant());
       Assert.assertNull(field.getConstantValue());

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/AbstractAssignabilityTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/AbstractAssignabilityTest.java
@@ -113,7 +113,7 @@ public abstract class AbstractAssignabilityTest extends AbstractTestingTypeRefer
       final LightweightTypeReference lhsType = _xifexpression;
       LightweightTypeReference _xifexpression_1 = null;
       if ((rhs != null)) {
-        _xifexpression_1 = this.toLightweightTypeReference(IterableExtensions.<JvmFormalParameter>last(operation.getParameters()).getParameterType());
+        _xifexpression_1 = this.toLightweightTypeReference(IterableExtensions.<JvmFormalParameter>lastOrNull(operation.getParameters()).getParameterType());
       } else {
         _xifexpression_1 = this.getOwner().newAnyTypeReference();
       }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/DeferredTypeParameterHintCollectorTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/DeferredTypeParameterHintCollectorTest.java
@@ -91,7 +91,7 @@ public class DeferredTypeParameterHintCollectorTest extends AbstractTestingTypeR
     PublicResolvedTypes _publicResolvedTypes = new PublicResolvedTypes(resolver);
     final MockTypeParameterSubstitutor substitutor = new MockTypeParameterSubstitutor(_owner_1, _publicResolvedTypes);
     final LightweightTypeReference hasUnbounds = substitutor.substitute(this.toLightweightTypeReference(IterableExtensions.<JvmFormalParameter>head(operation.getParameters()).getParameterType()));
-    final LightweightTypeReference isActual = this.toLightweightTypeReference(IterableExtensions.<JvmFormalParameter>last(operation.getParameters()).getParameterType());
+    final LightweightTypeReference isActual = this.toLightweightTypeReference(IterableExtensions.<JvmFormalParameter>lastOrNull(operation.getParameters()).getParameterType());
     collector.processPairedReferences(hasUnbounds, isActual);
     return substitutor.getTypeParameterMapping();
   }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ErrorTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ErrorTest.java
@@ -123,7 +123,7 @@ public class ErrorTest extends AbstractXtendTestCase {
     final XtendFile file = this.processWithoutException(_builder);
     XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(file.getXtendTypes());
     final XtendClass clazz = ((XtendClass) _head);
-    final XtendMember lastMember = IterableExtensions.<XtendMember>last(clazz.getMembers());
+    final XtendMember lastMember = IterableExtensions.<XtendMember>lastOrNull(clazz.getMembers());
     final EList<XAnnotation> annotations = lastMember.getAnnotations();
     final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(IterableExtensions.<XAnnotation>head(annotations));
     Assert.assertNotNull(resolvedTypes.getActualType(IterableExtensions.<XAnnotation>head(annotations)));
@@ -148,7 +148,7 @@ public class ErrorTest extends AbstractXtendTestCase {
     final XtendFile file = this.processWithoutException(_builder);
     XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(file.getXtendTypes());
     final XtendClass clazz = ((XtendClass) _head);
-    final XtendMember lastMember = IterableExtensions.<XtendMember>last(clazz.getMembers());
+    final XtendMember lastMember = IterableExtensions.<XtendMember>lastOrNull(clazz.getMembers());
     final EList<XAnnotation> annotations = lastMember.getAnnotations();
     final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(IterableExtensions.<XAnnotation>head(annotations));
     Assert.assertNotNull(resolvedTypes.getActualType(IterableExtensions.<XAnnotation>head(annotations)));
@@ -173,7 +173,7 @@ public class ErrorTest extends AbstractXtendTestCase {
     final XtendFile file = this.processWithoutException(_builder);
     XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(file.getXtendTypes());
     final XtendClass clazz = ((XtendClass) _head);
-    final XtendMember lastMember = IterableExtensions.<XtendMember>last(clazz.getMembers());
+    final XtendMember lastMember = IterableExtensions.<XtendMember>lastOrNull(clazz.getMembers());
     final EList<XAnnotation> annotations = lastMember.getAnnotations();
     final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(IterableExtensions.<XAnnotation>head(annotations));
     Assert.assertNotNull(resolvedTypes.getActualType(IterableExtensions.<XAnnotation>head(annotations)));
@@ -199,7 +199,7 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.append("@");
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
-    final XtendTypeDeclaration typeDeclaration = IterableExtensions.<XtendTypeDeclaration>last(file.getXtendTypes());
+    final XtendTypeDeclaration typeDeclaration = IterableExtensions.<XtendTypeDeclaration>lastOrNull(file.getXtendTypes());
     final EList<XAnnotation> annotations = typeDeclaration.getAnnotations();
     final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(IterableExtensions.<XAnnotation>head(annotations));
     Assert.assertNotNull(resolvedTypes.getActualType(IterableExtensions.<XAnnotation>head(annotations)));
@@ -213,7 +213,7 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.append("@Data class");
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
-    final XtendTypeDeclaration typeDeclaration = IterableExtensions.<XtendTypeDeclaration>last(file.getXtendTypes());
+    final XtendTypeDeclaration typeDeclaration = IterableExtensions.<XtendTypeDeclaration>lastOrNull(file.getXtendTypes());
     final EList<XAnnotation> annotations = typeDeclaration.getAnnotations();
     final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(IterableExtensions.<XAnnotation>head(annotations));
     Assert.assertNotNull(resolvedTypes.getActualType(IterableExtensions.<XAnnotation>head(annotations)));
@@ -225,8 +225,8 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.append("annotation Bar { @");
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
-    final XtendTypeDeclaration typeDeclaration = IterableExtensions.<XtendTypeDeclaration>last(file.getXtendTypes());
-    final EList<XAnnotation> annotations = IterableExtensions.<XtendMember>last(typeDeclaration.getMembers()).getAnnotations();
+    final XtendTypeDeclaration typeDeclaration = IterableExtensions.<XtendTypeDeclaration>lastOrNull(file.getXtendTypes());
+    final EList<XAnnotation> annotations = IterableExtensions.<XtendMember>lastOrNull(typeDeclaration.getMembers()).getAnnotations();
     final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(IterableExtensions.<XAnnotation>head(annotations));
     Assert.assertNotNull(resolvedTypes.getActualType(IterableExtensions.<XAnnotation>head(annotations)));
   }
@@ -240,8 +240,8 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.append("@Property val S");
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
-    final XtendTypeDeclaration typeDeclaration = IterableExtensions.<XtendTypeDeclaration>last(file.getXtendTypes());
-    final EList<XAnnotation> annotations = IterableExtensions.<XtendMember>last(typeDeclaration.getMembers()).getAnnotations();
+    final XtendTypeDeclaration typeDeclaration = IterableExtensions.<XtendTypeDeclaration>lastOrNull(file.getXtendTypes());
+    final EList<XAnnotation> annotations = IterableExtensions.<XtendMember>lastOrNull(typeDeclaration.getMembers()).getAnnotations();
     final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(IterableExtensions.<XAnnotation>head(annotations));
     Assert.assertNotNull(resolvedTypes.getActualType(IterableExtensions.<XAnnotation>head(annotations)));
   }
@@ -252,7 +252,7 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.append("@SuppressWarnings(\"unused\"");
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
-    final XtendTypeDeclaration typeDeclaration = IterableExtensions.<XtendTypeDeclaration>last(file.getXtendTypes());
+    final XtendTypeDeclaration typeDeclaration = IterableExtensions.<XtendTypeDeclaration>lastOrNull(file.getXtendTypes());
     final EList<XAnnotation> annotations = typeDeclaration.getAnnotations();
     final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(IterableExtensions.<XAnnotation>head(annotations));
     Assert.assertNotNull(resolvedTypes.getActualType(IterableExtensions.<XAnnotation>head(annotations)));
@@ -269,7 +269,7 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.append("}");
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
-    final XtendTypeDeclaration annotation = IterableExtensions.<XtendTypeDeclaration>last(file.getXtendTypes());
+    final XtendTypeDeclaration annotation = IterableExtensions.<XtendTypeDeclaration>lastOrNull(file.getXtendTypes());
     XtendMember _head = IterableExtensions.<XtendMember>head(annotation.getMembers());
     final XtendField field = ((XtendField) _head);
     final XExpression initializer = field.getInitialValue();
@@ -367,7 +367,7 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.append("}");
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
-    final XtendTypeDeclaration headerAccess = IterableExtensions.<XtendTypeDeclaration>last(file.getXtendTypes());
+    final XtendTypeDeclaration headerAccess = IterableExtensions.<XtendTypeDeclaration>lastOrNull(file.getXtendTypes());
     XtendMember _head = IterableExtensions.<XtendMember>head(headerAccess.getMembers());
     final XtendFunction function = ((XtendFunction) _head);
     EObject _head_1 = IterableExtensions.<EObject>head(this.associations.getJvmElements(function));
@@ -400,7 +400,7 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.append("}");
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
-    final XtendTypeDeclaration headerAccess = IterableExtensions.<XtendTypeDeclaration>last(file.getXtendTypes());
+    final XtendTypeDeclaration headerAccess = IterableExtensions.<XtendTypeDeclaration>lastOrNull(file.getXtendTypes());
     XtendMember _head = IterableExtensions.<XtendMember>head(headerAccess.getMembers());
     final XtendFunction function = ((XtendFunction) _head);
     EObject _head_1 = IterableExtensions.<EObject>head(this.associations.getJvmElements(function));
@@ -444,8 +444,8 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
     final XtendTypeDeclaration unnamed = IterableExtensions.<XtendTypeDeclaration>head(file.getXtendTypes());
-    XtendMember _last = IterableExtensions.<XtendMember>last(unnamed.getMembers());
-    final XtendConstructor constructor = ((XtendConstructor) _last);
+    XtendMember _lastOrNull = IterableExtensions.<XtendMember>lastOrNull(unnamed.getMembers());
+    final XtendConstructor constructor = ((XtendConstructor) _lastOrNull);
     XExpression _expression = constructor.getExpression();
     final XBlockExpression body = ((XBlockExpression) _expression);
     XExpression _head = IterableExtensions.<XExpression>head(body.getExpressions());
@@ -495,7 +495,7 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.append("}");
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
-    final XtendTypeDeclaration client = IterableExtensions.<XtendTypeDeclaration>last(file.getXtendTypes());
+    final XtendTypeDeclaration client = IterableExtensions.<XtendTypeDeclaration>lastOrNull(file.getXtendTypes());
     XtendMember _head = IterableExtensions.<XtendMember>head(client.getMembers());
     final XtendField field = ((XtendField) _head);
     XExpression _initialValue = field.getInitialValue();
@@ -580,8 +580,8 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
     final XtendTypeDeclaration y = IterableExtensions.<XtendTypeDeclaration>head(file.getXtendTypes());
-    XtendMember _last = IterableExtensions.<XtendMember>last(y.getMembers());
-    final XtendFunction function = ((XtendFunction) _last);
+    XtendMember _lastOrNull = IterableExtensions.<XtendMember>lastOrNull(y.getMembers());
+    final XtendFunction function = ((XtendFunction) _lastOrNull);
     XExpression _expression = function.getExpression();
     final XBlockExpression body = ((XBlockExpression) _expression);
     XExpression _head = IterableExtensions.<XExpression>head(body.getExpressions());

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ErrorTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ErrorTest.java
@@ -2238,7 +2238,7 @@ public class ErrorTest extends AbstractXtendTestCase {
     _builder.newLine();
     final XtendFile file = this.processWithoutException(_builder);
     final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(file);
-    final XCastedExpression casted = IteratorExtensions.<XCastedExpression>last(Iterators.<XCastedExpression>filter(file.eAllContents(), XCastedExpression.class));
+    final XCastedExpression casted = IteratorExtensions.<XCastedExpression>lastOrNull(Iterators.<XCastedExpression>filter(file.eAllContents(), XCastedExpression.class));
     Assert.assertNull(casted.getType());
     Assert.assertNotNull(resolvedTypes.getActualType(casted));
   }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/VarArgFeatureCallArgumentsTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/VarArgFeatureCallArgumentsTest.java
@@ -153,8 +153,8 @@ public class VarArgFeatureCallArgumentsTest extends AbstractTestingTypeReference
     Assert.assertEquals(2, expressions.size());
     XExpression _head = IterableExtensions.<XExpression>head(expressions);
     Assert.assertTrue((_head instanceof XStringLiteral));
-    XExpression _last = IterableExtensions.<XExpression>last(expressions);
-    Assert.assertTrue((_last instanceof XNumberLiteral));
+    XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(expressions);
+    Assert.assertTrue((_lastOrNull instanceof XNumberLiteral));
     valid.markProcessed();
     Assert.assertTrue(arguments.isProcessed(0));
     Assert.assertTrue(arguments.isProcessed(1));
@@ -173,8 +173,8 @@ public class VarArgFeatureCallArgumentsTest extends AbstractTestingTypeReference
     Assert.assertEquals(2, expressions.size());
     XExpression _head = IterableExtensions.<XExpression>head(expressions);
     Assert.assertTrue((_head instanceof XStringLiteral));
-    XExpression _last = IterableExtensions.<XExpression>last(expressions);
-    Assert.assertTrue((_last instanceof XNumberLiteral));
+    XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(expressions);
+    Assert.assertTrue((_lastOrNull instanceof XNumberLiteral));
     Assert.assertTrue(arguments.isProcessed(0));
     Assert.assertFalse(arguments.isProcessed(1));
     Assert.assertFalse(arguments.isProcessed(2));

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typing/AnonymousClassTypeTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typing/AnonymousClassTypeTest.java
@@ -93,7 +93,7 @@ public class AnonymousClassTypeTest extends AbstractXtendTestCase {
       final IResolvedTypes resolvedTypes = this._iBatchTypeResolver.resolveTypes(operation.eResource());
       Assert.assertEquals("Runnable", resolvedTypes.getActualType(operation).toString());
       XExpression _expression = function.getExpression();
-      final XExpression variable = IterableExtensions.<XExpression>last(((XBlockExpression) _expression).getExpressions());
+      final XExpression variable = IterableExtensions.<XExpression>lastOrNull(((XBlockExpression) _expression).getExpressions());
       final LightweightTypeReference variableType = resolvedTypes.getActualType(variable);
       Assert.assertEquals("__Foo_1", variableType.toString());
       Assert.assertTrue(variableType.isSubtypeOf(Runnable.class));
@@ -126,8 +126,8 @@ public class AnonymousClassTypeTest extends AbstractXtendTestCase {
       XExpression _expression = function.getExpression();
       XExpression _head = IterableExtensions.<XExpression>head(((XBlockExpression) _expression).getExpressions());
       final AnonymousClass anonymousClass = ((AnonymousClass) _head);
-      XtendMember _last = IterableExtensions.<XtendMember>last(anonymousClass.getMembers());
-      final JvmOperation overriding = this._iXtendJvmAssociations.getDirectlyInferredOperation(((XtendFunction) _last));
+      XtendMember _lastOrNull = IterableExtensions.<XtendMember>lastOrNull(anonymousClass.getMembers());
+      final JvmOperation overriding = this._iXtendJvmAssociations.getDirectlyInferredOperation(((XtendFunction) _lastOrNull));
       Assert.assertEquals("Iterator<String>", resolvedTypes.getActualType(overriding).toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
@@ -158,8 +158,8 @@ public class AnonymousClassTypeTest extends AbstractXtendTestCase {
       XExpression _expression = function.getExpression();
       XExpression _head = IterableExtensions.<XExpression>head(((XBlockExpression) _expression).getExpressions());
       final AnonymousClass anonymousClass = ((AnonymousClass) _head);
-      XtendMember _last = IterableExtensions.<XtendMember>last(anonymousClass.getMembers());
-      final JvmOperation overriding = this._iXtendJvmAssociations.getDirectlyInferredOperation(((XtendFunction) _last));
+      XtendMember _lastOrNull = IterableExtensions.<XtendMember>lastOrNull(anonymousClass.getMembers());
+      final JvmOperation overriding = this._iXtendJvmAssociations.getDirectlyInferredOperation(((XtendFunction) _lastOrNull));
       Assert.assertEquals("Iterator<T>", resolvedTypes.getActualType(overriding).toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/AmbiguityValidationTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/AmbiguityValidationTest.java
@@ -83,8 +83,8 @@ public abstract class AmbiguityValidationTest extends AbstractXtendTestCase {
     final XBlockExpression block = ((XBlockExpression) _expression);
     final IResolvedTypes resolvedTypes = this._iBatchTypeResolver.resolveTypes(file);
     ILinkingCandidate _switchResult = null;
-    XExpression _last = IterableExtensions.<XExpression>last(block.getExpressions());
-    final XExpression featureOrConstructorCall = _last;
+    XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(block.getExpressions());
+    final XExpression featureOrConstructorCall = _lastOrNull;
     boolean _matched = false;
     if (featureOrConstructorCall instanceof XAbstractFeatureCall) {
       _matched=true;

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/RichStringFormatter.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/RichStringFormatter.xtend
@@ -82,11 +82,11 @@ import org.eclipse.emf.ecore.plugin.EcorePlugin
 		for (e : richString.expressions)
 			format(e, doc)
 		val lines = impl.model.lines
-		val canIndent = !lines.empty && lines.last.content.nullOrEmpty
+		val canIndent = !lines.empty && lines.lastOrNull.content.nullOrEmpty
 		for (line : lines) {
 			if (impl.model.rootIndentLenght > 0) {
 				val increaseIndentationChange = if(canIndent && line == lines.head) 1 else 0
-				val decraseIndentationChange = if(canIndent && line == lines.last) 1 else 0
+				val decraseIndentationChange = if(canIndent && line == lines.lastOrNull) 1 else 0
 				val nloffset = if(line.leadingSemanticNewLine) line.offset + line.newLineCharCount else line.offset
 				val i = Math.min(line.indentLength, impl.model.rootIndentLenght)
 				val nllength = if(line.leadingSemanticNewLine) i else line.newLineCharCount + i
@@ -187,7 +187,7 @@ import org.eclipse.emf.ecore.plugin.EcorePlugin
 
 	def dispatch void format(RichStringIf expr, extension IFormattableDocument doc) {
 		expr.regionFor.keyword("IF").prepend[noSpace].append[oneSpace]
-		expr.elseIfs.last.append[noSpace]
+		expr.elseIfs.lastOrNull.append[noSpace]
 		formatIntoSingleLine(doc, expr.^if)
 		format(expr.then, doc)
 		for (elseif : expr.elseIfs)
@@ -308,7 +308,7 @@ class RichStringToLineModel extends AbstractRichStringPartAcceptor.ForLoopOnce {
 				model.leadingText = lastLinesContent
 				contentStartColumn = 0
 			} else {
-				val lastLine = model.lines.last
+				val lastLine = model.lines.lastOrNull
 				lastLine.content = lastLinesContent
 				val newContentStartColumn = contentStartOffset - (lastLine.offset + lastLine.newLineCharCount)
 				if (lastLine.leadingSemanticNewLine) {
@@ -323,7 +323,7 @@ class RichStringToLineModel extends AbstractRichStringPartAcceptor.ForLoopOnce {
 						if (ws.column > newContentStartColumn)
 							indentationStack.remove(ws)
 					}
-					val lastWs = indentationStack.last
+					val lastWs = indentationStack.lastOrNull
 					val length = if (lastWs === null)
 							newContentStartColumn - model.rootIndentLenght
 						else if (lastWs instanceof SemanticWhitespace)
@@ -348,7 +348,7 @@ class RichStringToLineModel extends AbstractRichStringPartAcceptor.ForLoopOnce {
 				// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=398718
 				if (newContentStartColumn != 0)
 					contentStartColumn = newContentStartColumn
-				model.lines.last.chunks += indentationStack
+				model.lines.lastOrNull.chunks += indentationStack
 			}
 		}
 		if (indentNextLine) {

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/XtendFormatter.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/XtendFormatter.xtend
@@ -64,7 +64,7 @@ class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		xtendFile.importSection?.format
 		for (clazz : xtendFile.xtendTypes) {
 			clazz.format
-			if (clazz != xtendFile.xtendTypes.last)
+			if (clazz != xtendFile.xtendTypes.lastOrNull)
 				clazz.append(blankLinesBetweenClasses)
 		}
 		xtendFile.append[newLine]
@@ -335,12 +335,12 @@ class XtendFormatter extends XbaseWithAnnotationsFormatter {
 	}
 
 	override protected builder(List<XExpression> params) {
-		if (params.last !== null) {
-			val grammarElement = params.last.grammarElement
+		if (params.lastOrNull !== null) {
+			val grammarElement = params.lastOrNull.grammarElement
 			if (grammarElement == XMemberFeatureCallAccess.memberCallArgumentsXClosureParserRuleCall_1_1_4_0 ||
 				grammarElement == XFeatureCallAccess.featureCallArgumentsXClosureParserRuleCall_4_0 ||
 				grammarElement == xbaseConstructorCallAccess.argumentsXClosureParserRuleCall_5_0)
-				params.last as XClosure
+				params.lastOrNull as XClosure
 		}
 	}
 

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringFormatter.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringFormatter.java
@@ -97,7 +97,7 @@ public class RichStringFormatter {
       this.format(e, doc);
     }
     final List<Line> lines = impl.getModel().getLines();
-    final boolean canIndent = ((!lines.isEmpty()) && StringExtensions.isNullOrEmpty(IterableExtensions.<Line>last(lines).getContent()));
+    final boolean canIndent = ((!lines.isEmpty()) && StringExtensions.isNullOrEmpty(IterableExtensions.<Line>lastOrNull(lines).getContent()));
     for (final Line line : lines) {
       int _rootIndentLenght = impl.getModel().getRootIndentLenght();
       boolean _greaterThan = (_rootIndentLenght > 0);
@@ -110,7 +110,7 @@ public class RichStringFormatter {
         }
         final int increaseIndentationChange = _xifexpression;
         int _xifexpression_1 = (int) 0;
-        if ((canIndent && Objects.equal(line, IterableExtensions.<Line>last(lines)))) {
+        if ((canIndent && Objects.equal(line, IterableExtensions.<Line>lastOrNull(lines)))) {
           _xifexpression_1 = 1;
         } else {
           _xifexpression_1 = 0;
@@ -278,7 +278,7 @@ public class RichStringFormatter {
     final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it) -> {
       it.noSpace();
     };
-    doc.<RichStringElseIf>append(IterableExtensions.<RichStringElseIf>last(expr.getElseIfs()), _function_2);
+    doc.<RichStringElseIf>append(IterableExtensions.<RichStringElseIf>lastOrNull(expr.getElseIfs()), _function_2);
     this.formatIntoSingleLine(doc, expr.getIf());
     this.format(expr.getThen(), doc);
     EList<RichStringElseIf> _elseIfs = expr.getElseIfs();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringToLineModel.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringToLineModel.java
@@ -186,7 +186,7 @@ public class RichStringToLineModel extends AbstractRichStringPartAcceptor.ForLoo
         this.model.setLeadingText(lastLinesContent);
         this.contentStartColumn = 0;
       } else {
-        final Line lastLine = IterableExtensions.<Line>last(this.model.getLines());
+        final Line lastLine = IterableExtensions.<Line>lastOrNull(this.model.getLines());
         lastLine.setContent(lastLinesContent);
         int _offset = lastLine.getOffset();
         int _newLineCharCount = lastLine.getNewLineCharCount();
@@ -210,7 +210,7 @@ public class RichStringToLineModel extends AbstractRichStringPartAcceptor.ForLoo
               this.indentationStack.remove(ws);
             }
           }
-          final Chunk lastWs = IterableExtensions.<Chunk>last(this.indentationStack);
+          final Chunk lastWs = IterableExtensions.<Chunk>lastOrNull(this.indentationStack);
           int _xifexpression = (int) 0;
           if ((lastWs == null)) {
             int _rootIndentLenght = this.model.getRootIndentLenght();
@@ -244,7 +244,7 @@ public class RichStringToLineModel extends AbstractRichStringPartAcceptor.ForLoo
         if ((newContentStartColumn != 0)) {
           this.contentStartColumn = newContentStartColumn;
         }
-        List<Chunk> _chunks = IterableExtensions.<Line>last(this.model.getLines()).getChunks();
+        List<Chunk> _chunks = IterableExtensions.<Line>lastOrNull(this.model.getLines()).getChunks();
         Iterables.<Chunk>addAll(_chunks, this.indentationStack);
       }
     }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
@@ -120,8 +120,8 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     for (final XtendTypeDeclaration clazz : _xtendTypes) {
       {
         format.<XtendTypeDeclaration>format(clazz);
-        XtendTypeDeclaration _last = IterableExtensions.<XtendTypeDeclaration>last(xtendFile.getXtendTypes());
-        boolean _notEquals = (!Objects.equal(clazz, _last));
+        XtendTypeDeclaration _lastOrNull = IterableExtensions.<XtendTypeDeclaration>lastOrNull(xtendFile.getXtendTypes());
+        boolean _notEquals = (!Objects.equal(clazz, _lastOrNull));
         if (_notEquals) {
           format.<XtendTypeDeclaration>append(clazz, XtendFormatterPreferenceKeys.blankLinesBetweenClasses);
         }
@@ -663,18 +663,18 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
   @Override
   protected XClosure builder(final List<XExpression> params) {
     XClosure _xifexpression = null;
-    XExpression _last = IterableExtensions.<XExpression>last(params);
-    boolean _tripleNotEquals = (_last != null);
+    XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(params);
+    boolean _tripleNotEquals = (_lastOrNull != null);
     if (_tripleNotEquals) {
       XClosure _xblockexpression = null;
       {
-        final EObject grammarElement = this.grammarElement(IterableExtensions.<XExpression>last(params));
+        final EObject grammarElement = this.grammarElement(IterableExtensions.<XExpression>lastOrNull(params));
         XClosure _xifexpression_1 = null;
         if (((Objects.equal(grammarElement, this._xtendGrammarAccess.getXMemberFeatureCallAccess().getMemberCallArgumentsXClosureParserRuleCall_1_1_4_0()) || 
           Objects.equal(grammarElement, this._xtendGrammarAccess.getXFeatureCallAccess().getFeatureCallArgumentsXClosureParserRuleCall_4_0())) || 
           Objects.equal(grammarElement, this._xtendGrammarAccess.getXbaseConstructorCallAccess().getArgumentsXClosureParserRuleCall_5_0()))) {
-          XExpression _last_1 = IterableExtensions.<XExpression>last(params);
-          _xifexpression_1 = ((XClosure) _last_1);
+          XExpression _lastOrNull_1 = IterableExtensions.<XExpression>lastOrNull(params);
+          _xifexpression_1 = ((XClosure) _lastOrNull_1);
         }
         _xblockexpression = _xifexpression_1;
       }

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/highlighting/HighlightingReconcilerTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/highlighting/HighlightingReconcilerTest.xtend
@@ -69,7 +69,7 @@ class HighlightingReconcilerTest extends AbstractXtendUITestCase {
 		assertEquals('Highlighting regions broken', 3, semanticSnippets.size)
 		assertEquals('Foo', semanticSnippets.head)
 		assertEquals('foo', semanticSnippets.tail.head)
-		assertEquals('3', semanticSnippets.last)
+		assertEquals('3', semanticSnippets.lastOrNull)
 	}
 	
 	@Test def void testOpenedEditorHasSemanticHighlighting() {
@@ -93,6 +93,6 @@ class HighlightingReconcilerTest extends AbstractXtendUITestCase {
 		// this fails if the first highlighting job didn't color the document
 		assertEquals('Highlighting regions broken ' + semanticSnippets.join(','), 2, semanticSnippets.size)
 		assertEquals('Foo', semanticSnippets.head)
-		assertEquals('foo', semanticSnippets.last)
+		assertEquals('foo', semanticSnippets.lastOrNull)
 	}
 }

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.xtend
@@ -60,7 +60,7 @@ class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase {
         }
         ''',resourceSet)
         val clazz = xtendFile.getXtendTypes.filter(typeof(XtendClass)).head
-        val function = clazz.members.last as XtendFunction
+        val function = clazz.members.lastOrNull as XtendFunction
         val docu = documentationProvider.getDocumentation(function)
         assertEquals('''<code><a href="eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.1">#foo</a></code><dl><dt>Parameters:</dt><dd><b>a</b> </dd><dd><b>b</b> </dd></dl>'''.toString, docu)
     }
@@ -92,7 +92,7 @@ class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase {
         }
         ''',resourceSet)
         val clazz = xtendFile.getXtendTypes.filter(typeof(XtendClass)).head
-        val function = clazz.members.last as XtendFunction
+        val function = clazz.members.lastOrNull as XtendFunction
         val docu = documentationProvider.getDocumentation(function)
         assertEquals('''<code><a href="eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.2">#foo(Object)</a></code><dl><dt>Parameters:</dt><dd><b>a</b> </dd><dd><b>b</b> </dd></dl>'''.toString, docu)
     }
@@ -124,7 +124,7 @@ class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase {
         }
         ''',resourceSet)
         val clazz = xtendFile.getXtendTypes.filter(typeof(XtendClass)).head
-        val function = clazz.members.last as XtendFunction
+        val function = clazz.members.lastOrNull as XtendFunction
         val docu = documentationProvider.getDocumentation(function)
         assertEquals('''<code><a href="eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.1">#foo</a></code><dl><dt>Parameters:</dt><dd><b>a</b> </dd><dd><b>b</b> </dd></dl>'''.toString, docu)
     }
@@ -156,7 +156,7 @@ class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase {
         }
         ''',resourceSet)
         val clazz = xtendFile.getXtendTypes.filter(typeof(XtendClass)).head
-        val function = clazz.members.last as XtendFunction
+        val function = clazz.members.lastOrNull as XtendFunction
         val docu = documentationProvider.getDocumentation(function)
         // Due to a bug in JDT (3.5) the org.eclipse.jdt.core.dom.ASTParser would introduce a } after foo( 
         // So we can only check that the documentation gets computed and starts with foo(

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/macros/AbstractReusableActiveAnnotationTests.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/macros/AbstractReusableActiveAnnotationTests.xtend
@@ -1344,7 +1344,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				assertEquals(1, value.annotations.size)
 				assertNotNull(value.findAnnotation(deprecatedAnnotationType))
 			}
-			assertEquals("D", enumerationType.declaredValues.last.simpleName)
+			assertEquals("D", enumerationType.declaredValues.lastOrNull.simpleName)
 			assertNotNull(enumerationType.findDeclaredValue("D"))
 		]
 	}

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/highlighting/HighlightingReconcilerTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/highlighting/HighlightingReconcilerTest.java
@@ -109,7 +109,7 @@ public class HighlightingReconcilerTest extends AbstractXtendUITestCase {
       Assert.assertEquals("Highlighting regions broken", 3, semanticSnippets.size());
       Assert.assertEquals("Foo", IterableExtensions.<String>head(semanticSnippets));
       Assert.assertEquals("foo", IterableExtensions.<String>head(IterableExtensions.<String>tail(semanticSnippets)));
-      Assert.assertEquals("3", IterableExtensions.<String>last(semanticSnippets));
+      Assert.assertEquals("3", IterableExtensions.<String>lastOrNull(semanticSnippets));
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -170,7 +170,7 @@ public class HighlightingReconcilerTest extends AbstractXtendUITestCase {
       String _plus = ("Highlighting regions broken " + _join);
       Assert.assertEquals(_plus, 2, semanticSnippets.size());
       Assert.assertEquals("Foo", IterableExtensions.<String>head(semanticSnippets));
-      Assert.assertEquals("foo", IterableExtensions.<String>last(semanticSnippets));
+      Assert.assertEquals("foo", IterableExtensions.<String>lastOrNull(semanticSnippets));
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.java
@@ -89,8 +89,8 @@ public class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase
       _builder.newLine();
       final XtendFile xtendFile = this.parseHelper.parse(_builder, this.getResourceSet());
       final XtendClass clazz = IterableExtensions.<XtendClass>head(Iterables.<XtendClass>filter(xtendFile.getXtendTypes(), XtendClass.class));
-      XtendMember _last = IterableExtensions.<XtendMember>last(clazz.getMembers());
-      final XtendFunction function = ((XtendFunction) _last);
+      XtendMember _lastOrNull = IterableExtensions.<XtendMember>lastOrNull(clazz.getMembers());
+      final XtendFunction function = ((XtendFunction) _lastOrNull);
       final String docu = this.documentationProvider.getDocumentation(function);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("<code><a href=\"eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.1\">#foo</a></code><dl><dt>Parameters:</dt><dd><b>a</b> </dd><dd><b>b</b> </dd></dl>");
@@ -153,8 +153,8 @@ public class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase
       _builder.newLine();
       final XtendFile xtendFile = this.parseHelper.parse(_builder, this.getResourceSet());
       final XtendClass clazz = IterableExtensions.<XtendClass>head(Iterables.<XtendClass>filter(xtendFile.getXtendTypes(), XtendClass.class));
-      XtendMember _last = IterableExtensions.<XtendMember>last(clazz.getMembers());
-      final XtendFunction function = ((XtendFunction) _last);
+      XtendMember _lastOrNull = IterableExtensions.<XtendMember>lastOrNull(clazz.getMembers());
+      final XtendFunction function = ((XtendFunction) _lastOrNull);
       final String docu = this.documentationProvider.getDocumentation(function);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("<code><a href=\"eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.2\">#foo(Object)</a></code><dl><dt>Parameters:</dt><dd><b>a</b> </dd><dd><b>b</b> </dd></dl>");
@@ -217,8 +217,8 @@ public class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase
       _builder.newLine();
       final XtendFile xtendFile = this.parseHelper.parse(_builder, this.getResourceSet());
       final XtendClass clazz = IterableExtensions.<XtendClass>head(Iterables.<XtendClass>filter(xtendFile.getXtendTypes(), XtendClass.class));
-      XtendMember _last = IterableExtensions.<XtendMember>last(clazz.getMembers());
-      final XtendFunction function = ((XtendFunction) _last);
+      XtendMember _lastOrNull = IterableExtensions.<XtendMember>lastOrNull(clazz.getMembers());
+      final XtendFunction function = ((XtendFunction) _lastOrNull);
       final String docu = this.documentationProvider.getDocumentation(function);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("<code><a href=\"eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.1\">#foo</a></code><dl><dt>Parameters:</dt><dd><b>a</b> </dd><dd><b>b</b> </dd></dl>");
@@ -281,8 +281,8 @@ public class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase
       _builder.newLine();
       final XtendFile xtendFile = this.parseHelper.parse(_builder, this.getResourceSet());
       final XtendClass clazz = IterableExtensions.<XtendClass>head(Iterables.<XtendClass>filter(xtendFile.getXtendTypes(), XtendClass.class));
-      XtendMember _last = IterableExtensions.<XtendMember>last(clazz.getMembers());
-      final XtendFunction function = ((XtendFunction) _last);
+      XtendMember _lastOrNull = IterableExtensions.<XtendMember>lastOrNull(clazz.getMembers());
+      final XtendFunction function = ((XtendFunction) _lastOrNull);
       final String docu = this.documentationProvider.getDocumentation(function);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("<code><a href=\"eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.1\"> #foo(");

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/macros/AbstractReusableActiveAnnotationTests.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/macros/AbstractReusableActiveAnnotationTests.java
@@ -2623,7 +2623,7 @@ public abstract class AbstractReusableActiveAnnotationTests {
           Assert.assertNotNull(value.findAnnotation(deprecatedAnnotationType));
         }
       }
-      Assert.assertEquals("D", IterableExtensions.last(enumerationType.getDeclaredValues()).getSimpleName());
+      Assert.assertEquals("D", IterableExtensions.lastOrNull(enumerationType.getDeclaredValues()).getSimpleName());
       Assert.assertNotNull(enumerationType.findDeclaredValue("D"));
     };
     this.assertProcessing(_mappedTo, _mappedTo_1, _function);

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.xtend
@@ -69,7 +69,7 @@ abstract class AbstractExecutableBuilder extends AbstractCodeBuilder {
 		appendable.append("(")
 		val notAllowed = newHashSet
 		if(!parameterBuilders.isEmpty)
-			parameterBuilders.last.varArgsFlag = varArgsFlag
+			parameterBuilders.lastOrNull.varArgsFlag = varArgsFlag
 		for (i : 0 ..< parameterBuilders.size) {
 			val parameterBuilder = parameterBuilders.get(i)
 			val acceptor = new VariableNameAcceptor(notAllowed)

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/InsertionOffsets.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/InsertionOffsets.xtend
@@ -33,7 +33,7 @@ class InsertionOffsets {
 		val callingMember = EcoreUtil2.getContainerOfType(call, XtendField)
 		if (callingMember !== null && ownerType.members.contains(callingMember))
 			return before(callingMember)
-		val lastDefinedField = ownerType.members.filter(XtendField).last
+		val lastDefinedField = ownerType.members.filter(XtendField).lastOrNull
 		if (lastDefinedField === null)
 			return before(ownerType.members.head)
 		else
@@ -47,11 +47,11 @@ class InsertionOffsets {
 		else if (ownerType.members.empty)
 			return inEmpty(ownerType)
 		else
-			return after(ownerType.members.last)
+			return after(ownerType.members.lastOrNull)
 	}
 
 	def getNewConstructorInsertOffset(/* @Nullable */ EObject call, XtendTypeDeclaration ownerType) {
-		val lastDefinedConstructor = ownerType.members.filter(XtendConstructor).last
+		val lastDefinedConstructor = ownerType.members.filter(XtendConstructor).lastOrNull
 		if(lastDefinedConstructor === null)
 			return getNewFieldInsertOffset(call, ownerType)		
 		else	

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/labeling/XtendJvmLabelProvider.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/labeling/XtendJvmLabelProvider.xtend
@@ -34,7 +34,7 @@ class XtendJvmLabelProvider extends XbaseLabelProvider {
 	protected override text(JvmGenericType element) {
 		val local = element.isLocal()
 		if (local) {
-			val supertype = element.superTypes.last
+			val supertype = element.superTypes.lastOrNull
 			return '''new «supertype.simpleName»() {...}'''
 		}
 		element.simpleName + if (element.typeParameters.empty)

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.java
@@ -108,8 +108,8 @@ public abstract class AbstractExecutableBuilder extends AbstractCodeBuilder {
       boolean _isEmpty = this.parameterBuilders.isEmpty();
       boolean _not = (!_isEmpty);
       if (_not) {
-        AbstractParameterBuilder _last = IterableExtensions.<AbstractParameterBuilder>last(this.parameterBuilders);
-        _last.setVarArgsFlag(this.varArgsFlag);
+        AbstractParameterBuilder _lastOrNull = IterableExtensions.<AbstractParameterBuilder>lastOrNull(this.parameterBuilders);
+        _lastOrNull.setVarArgsFlag(this.varArgsFlag);
       }
       int _size = this.parameterBuilders.size();
       ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, _size, true);

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/InsertionOffsets.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/InsertionOffsets.java
@@ -42,7 +42,7 @@ public class InsertionOffsets {
     if (((callingMember != null) && ownerType.getMembers().contains(callingMember))) {
       return this.before(callingMember);
     }
-    final XtendField lastDefinedField = IterableExtensions.<XtendField>last(Iterables.<XtendField>filter(ownerType.getMembers(), XtendField.class));
+    final XtendField lastDefinedField = IterableExtensions.<XtendField>lastOrNull(Iterables.<XtendField>filter(ownerType.getMembers(), XtendField.class));
     if ((lastDefinedField == null)) {
       return this.before(IterableExtensions.<XtendMember>head(ownerType.getMembers()));
     } else {
@@ -59,13 +59,13 @@ public class InsertionOffsets {
       if (_isEmpty) {
         return this.inEmpty(ownerType);
       } else {
-        return this.after(IterableExtensions.<XtendMember>last(ownerType.getMembers()));
+        return this.after(IterableExtensions.<XtendMember>lastOrNull(ownerType.getMembers()));
       }
     }
   }
 
   public int getNewConstructorInsertOffset(final EObject call, final XtendTypeDeclaration ownerType) {
-    final XtendConstructor lastDefinedConstructor = IterableExtensions.<XtendConstructor>last(Iterables.<XtendConstructor>filter(ownerType.getMembers(), XtendConstructor.class));
+    final XtendConstructor lastDefinedConstructor = IterableExtensions.<XtendConstructor>lastOrNull(Iterables.<XtendConstructor>filter(ownerType.getMembers(), XtendConstructor.class));
     if ((lastDefinedConstructor == null)) {
       return this.getNewFieldInsertOffset(call, ownerType);
     } else {

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/labeling/XtendJvmLabelProvider.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/labeling/XtendJvmLabelProvider.java
@@ -41,7 +41,7 @@ public class XtendJvmLabelProvider extends XbaseLabelProvider {
     {
       final boolean local = element.isLocal();
       if (local) {
-        final JvmTypeReference supertype = IterableExtensions.<JvmTypeReference>last(element.getSuperTypes());
+        final JvmTypeReference supertype = IterableExtensions.<JvmTypeReference>lastOrNull(element.getSuperTypes());
         StringConcatenation _builder = new StringConcatenation();
         _builder.append("new ");
         String _simpleName = supertype.getSimpleName();

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/util/DocumentHighlightComparatorTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/util/DocumentHighlightComparatorTest.java
@@ -103,7 +103,7 @@ public class DocumentHighlightComparatorTest extends Assert {
 		assertEquals(1, input.get(2).getRange().getEnd().getLine());
 		assertEquals(1, input.get(2).getRange().getEnd().getCharacter());
 		assertEquals(DocumentHighlightKind.Write, input.get(2).getKind());
-		assertNull(IterableExtensions.last(input));
+		assertNull(IterableExtensions.lastOrNull(input));
 	}
 
 	private DocumentHighlight newHighlight(DocumentHighlightKind kind, Range range) {

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/util/PositionComparatorTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/util/PositionComparatorTest.java
@@ -61,7 +61,7 @@ public class PositionComparatorTest extends Assert {
 		assertEquals(2, input.get(1).getLine());
 		assertEquals(2, input.get(1).getCharacter());
 
-		assertNull(IterableExtensions.last(input));
+		assertNull(IterableExtensions.lastOrNull(input));
 	}
 
 	private List<? extends Position> sort(List<? extends Position> toSort) {

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/util/RangeComparatorTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/util/RangeComparatorTest.java
@@ -70,7 +70,7 @@ public class RangeComparatorTest extends Assert {
 		assertEquals(2, input.get(1).getStart().getCharacter());
 		assertEquals(2, input.get(1).getEnd().getLine());
 		assertEquals(3, input.get(1).getEnd().getCharacter());
-		assertNull(IterableExtensions.last(input));
+		assertNull(IterableExtensions.lastOrNull(input));
 	}
 
 	private Range newRange(int startLine, int startChar, int endLine, int endChar) {

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/indentation/IndentationAwareLanguageTest.xtend
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/indentation/IndentationAwareLanguageTest.xtend
@@ -69,7 +69,7 @@ class IndentationAwareLanguageTest {
 		assertNotNull(tree)
 		assertEquals(2, tree.nodes.size)
 		assertEquals('first', tree.nodes.head.name)
-		assertEquals('second', tree.nodes.last.name)
+		assertEquals('second', tree.nodes.lastOrNull.name)
 	}
 	
 	@Test
@@ -83,7 +83,7 @@ class IndentationAwareLanguageTest {
 		assertEquals(2, tree.nodes.size)
 		assertEquals('first', tree.nodes.head.name)
 		assertEquals(0, tree.nodes.head.children.size)
-		assertEquals('second', tree.nodes.last.name)
+		assertEquals('second', tree.nodes.lastOrNull.name)
 	}
 	
 	@Test
@@ -97,7 +97,7 @@ class IndentationAwareLanguageTest {
 		assertEquals(2, tree.moreNodes.size)
 		assertEquals('first', tree.moreNodes.head.name)
 		assertNull(tree.moreNodes.head.childList)
-		assertEquals('second', tree.moreNodes.last.name)
+		assertEquals('second', tree.moreNodes.lastOrNull.name)
 	}
 	
 	@Test

--- a/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/parser/indentation/IndentationAwareLanguageTest.java
+++ b/org.eclipse.xtext.tests/xtend-gen/org/eclipse/xtext/parser/indentation/IndentationAwareLanguageTest.java
@@ -83,7 +83,7 @@ public class IndentationAwareLanguageTest {
     Assert.assertNotNull(tree);
     Assert.assertEquals(2, tree.getNodes().size());
     Assert.assertEquals("first", IterableExtensions.<TreeNode>head(tree.getNodes()).getName());
-    Assert.assertEquals("second", IterableExtensions.<TreeNode>last(tree.getNodes()).getName());
+    Assert.assertEquals("second", IterableExtensions.<TreeNode>lastOrNull(tree.getNodes()).getName());
   }
 
   @Test
@@ -100,7 +100,7 @@ public class IndentationAwareLanguageTest {
     Assert.assertEquals(2, tree.getNodes().size());
     Assert.assertEquals("first", IterableExtensions.<TreeNode>head(tree.getNodes()).getName());
     Assert.assertEquals(0, IterableExtensions.<TreeNode>head(tree.getNodes()).getChildren().size());
-    Assert.assertEquals("second", IterableExtensions.<TreeNode>last(tree.getNodes()).getName());
+    Assert.assertEquals("second", IterableExtensions.<TreeNode>lastOrNull(tree.getNodes()).getName());
   }
 
   @Test
@@ -117,7 +117,7 @@ public class IndentationAwareLanguageTest {
     Assert.assertEquals(2, tree.getMoreNodes().size());
     Assert.assertEquals("first", IterableExtensions.<OtherTreeNode>head(tree.getMoreNodes()).getName());
     Assert.assertNull(IterableExtensions.<OtherTreeNode>head(tree.getMoreNodes()).getChildList());
-    Assert.assertEquals("second", IterableExtensions.<OtherTreeNode>last(tree.getMoreNodes()).getName());
+    Assert.assertEquals("second", IterableExtensions.<OtherTreeNode>lastOrNull(tree.getMoreNodes()).getName());
   }
 
   @Test

--- a/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/contentassist/XbaseIdeCrossrefProposalProvider.java
+++ b/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/contentassist/XbaseIdeCrossrefProposalProvider.java
@@ -126,7 +126,7 @@ public class XbaseIdeCrossrefProposalProvider extends IdeCrossrefProposalProvide
 						info.selectionLength = "value".length();
 						return info;
 					}
-					JvmTypeReference parameterType = IterableExtensions.<JvmFormalParameter>last(parameters)
+					JvmTypeReference parameterType = IterableExtensions.<JvmFormalParameter>lastOrNull(parameters)
 							.getParameterType();
 					LightweightTypeReference light = getTypeConverter(contentAssistContext.getResource())
 							.toLightweightReference(parameterType);

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/BaseIterablesIteratorsTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/BaseIterablesIteratorsTest.java
@@ -297,39 +297,39 @@ public abstract class BaseIterablesIteratorsTest<IterableOrIterator> extends Ass
 		}
 	}
 	
-	protected abstract Integer last(IterableOrIterator input);
+	protected abstract Integer lastOrNull(IterableOrIterator input);
 	
-	@Test public void testLast_empty() {
+	@Test public void testLastOrNull_empty() {
 		for(IterableOrIterator testMe: testData()) {
-			Integer last = last(testMe);
+			Integer last = lastOrNull(testMe);
 			assertNull("empty input yields null", last);
 		}
 	}
 	
-	@Test public void testLast_oneEntry() {
+	@Test public void testLastOrNull_oneEntry() {
 		for(IterableOrIterator testMe: testData(first)) {
-			Integer last = last(testMe);
+			Integer last = lastOrNull(testMe);
 			assertEquals(first, last);
 		}
 	}
 	
-	@Test public void testLast_entryIsNull() {
+	@Test public void testLastOrNull_entryIsNull() {
 		for(IterableOrIterator testMe: nullableTestData((Integer)null)) {
-			Integer last = last(testMe);
+			Integer last = lastOrNull(testMe);
 			assertEquals(null, last);
 		}
 	}
 	
-	@Test public void testLast_moreEntries() {
+	@Test public void testLastOrNull_moreEntries() {
 		for(IterableOrIterator testMe: testData(first, second, third)) {
-			Integer last = last(testMe);
+			Integer last = lastOrNull(testMe);
 			assertEquals(third, last);
 		}
 	}
 	
-	@Test public void testLast_NPE() {
+	@Test public void testLastOrNull_NPE() {
 		try {
-			last(null);
+			lastOrNull(null);
 			fail("expeced NPE");
 		} catch(NullPointerException npe) {
 			// expected

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IterableExtensionsTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IterableExtensionsTest.java
@@ -86,7 +86,7 @@ public class IterableExtensionsTest extends BaseIterablesIteratorsTest<Iterable<
 	}
 
 	@Override
-	protected Integer last(Iterable<Integer> input) {
+	protected Integer lastOrNull(Iterable<Integer> input) {
 		return IterableExtensions.lastOrNull(input);
 	}
 

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IterableExtensionsTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IterableExtensionsTest.java
@@ -87,7 +87,7 @@ public class IterableExtensionsTest extends BaseIterablesIteratorsTest<Iterable<
 
 	@Override
 	protected Integer last(Iterable<Integer> input) {
-		return IterableExtensions.last(input);
+		return IterableExtensions.lastOrNull(input);
 	}
 
 	@Override

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IteratorExtensionsTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IteratorExtensionsTest.java
@@ -83,7 +83,7 @@ public class IteratorExtensionsTest extends BaseIterablesIteratorsTest<Iterator<
 	}
 
 	@Override
-	protected Integer last(Iterator<Integer> input) {
+	protected Integer lastOrNull(Iterator<Integer> input) {
 		return IteratorExtensions.lastOrNull(input);
 	}
 

--- a/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IteratorExtensionsTest.java
+++ b/org.eclipse.xtext.xbase.lib.tests/src/org/eclipse/xtext/xbase/tests/lib/IteratorExtensionsTest.java
@@ -84,7 +84,7 @@ public class IteratorExtensionsTest extends BaseIterablesIteratorsTest<Iterator<
 
 	@Override
 	protected Integer last(Iterator<Integer> input) {
-		return IteratorExtensions.last(input);
+		return IteratorExtensions.lastOrNull(input);
 	}
 
 	@Override

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
@@ -146,7 +146,7 @@ public class IterableExtensions {
 	 * collection is empty, instead of returning null.
 	 * @see https://github.com/eclipse/xtext/issues/2981
 	 */
-	@Deprecated(since = "2.35.0")
+	@Deprecated
 	public static <T> T last(Iterable<T> iterable) {
 		return lastOrNull(iterable);
 	}

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
@@ -171,7 +171,7 @@ public class IterableExtensions {
 				return null;
 			return sortedSet.last();
 		} else {
-			return IteratorExtensions.last(iterable.iterator());
+			return IteratorExtensions.lastOrNull(iterable.iterator());
 		}
 	}
 

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IterableExtensions.java
@@ -138,8 +138,28 @@ public class IterableExtensions {
 	 * @param iterable
 	 *            the iterable. May not be <code>null</code>.
 	 * @return the last element in the iterable or <code>null</code>.
+	 * @deprecated Use {@link #lastOrNull(Iterable<T>)} instead: in Java 21, the
+	 * method getLast has been introduced to some collection classes and would
+	 * be preferred to this one by the Xbase/Xtend compiler, breaking the
+	 * semantics of the original code:
+	 * The Java 21 getLast method throws a {@link NoSuchElementException} when the
+	 * collection is empty, instead of returning null.
+	 * @see https://github.com/eclipse/xtext/issues/2981
 	 */
+	@Deprecated(since = "2.35.0")
 	public static <T> T last(Iterable<T> iterable) {
+		return lastOrNull(iterable);
+	}
+
+	/**
+	 * Returns the last element in the given iterable or <code>null</code> if empty.
+	 * 
+	 * @param iterable
+	 *            the iterable. May not be <code>null</code>.
+	 * @return the last element in the iterable or <code>null</code>.
+	 * @since 2.35
+	 */
+	public static <T> T lastOrNull(Iterable<T> iterable) {
 		if (iterable instanceof List<?>) {
 			List<T> list = (List<T>) iterable;
 			if (list.isEmpty())

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IteratorExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/IteratorExtensions.java
@@ -167,8 +167,24 @@ import com.google.common.collect.Sets;
 	 * @param iterator
 	 *            the iterator. May not be <code>null</code>.
 	 * @return the last element in the iterator or <code>null</code>.
+	 * @deprecated Use {@link #lastOrNull(Iterator<T>)} instead. To be aligned with
+	 * {@link IterableExtensions#lastOrNull(Iterable)} (see the deprecation reason of
+	 * {@link IterableExtensions#last(Iterable)}).
 	 */
+	@Deprecated
 	public static <T> T last(Iterator<T> iterator) {
+		return lastOrNull(iterator);
+	}
+
+	/**
+	 * Returns the last element in the given iterator or <code>null</code> if empty.
+	 * 
+	 * @param iterator
+	 *            the iterator. May not be <code>null</code>.
+	 * @return the last element in the iterator or <code>null</code>.
+	 * @since 2.35
+	 */
+	public static <T> T lastOrNull(Iterator<T> iterator) {
 		T result = null;
 		while(iterator.hasNext()) {
 			result = iterator.next();

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/ExpressionScopeTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/ExpressionScopeTest.java
@@ -157,7 +157,7 @@ public class ExpressionScopeTest extends AbstractXbaseTestCase {
 	@Test
 	public void testReassignedType_01() throws Exception {
 		XIfExpression ifExpr = (XIfExpression) IterableExtensions
-				.last(((XBlockExpression) expression("{ var it = new Object() if (it instanceof String) {} }", false)).getExpressions());
+				.lastOrNull(((XBlockExpression) expression("{ var it = new Object() if (it instanceof String) {} }", false)).getExpressions());
 		XBlockExpression block = (XBlockExpression) ifExpr.getThen();
 		IExpressionScope expressionScope = batchTypeResolver.resolveTypes(block).getExpressionScope(block, IExpressionScope.Anchor.BEFORE);
 		contains(expressionScope, "charAt");
@@ -168,7 +168,7 @@ public class ExpressionScopeTest extends AbstractXbaseTestCase {
 	@Test
 	public void testReassignedType_02() throws Exception {
 		XIfExpression ifExpr = (XIfExpression) IterableExtensions
-				.last(((XBlockExpression) expression("{ var it = new Object() if (it instanceof String) { it = new Object() } }", false))
+				.lastOrNull(((XBlockExpression) expression("{ var it = new Object() if (it instanceof String) { it = new Object() } }", false))
 						.getExpressions());
 		XBlockExpression block = (XBlockExpression) ifExpr.getThen();
 		IExpressionScope expressionScope = batchTypeResolver.resolveTypes(block).getExpressionScope(block, IExpressionScope.Anchor.BEFORE);
@@ -180,7 +180,7 @@ public class ExpressionScopeTest extends AbstractXbaseTestCase {
 	@Test
 	public void testReassignedType_03() throws Exception {
 		XIfExpression ifExpr = (XIfExpression) IterableExtensions
-				.last(((XBlockExpression) expression("{ var it = new Object() if (it instanceof String) { it = new Object() } }", false))
+				.lastOrNull(((XBlockExpression) expression("{ var it = new Object() if (it instanceof String) { it = new Object() } }", false))
 						.getExpressions());
 		XBlockExpression block = (XBlockExpression) ifExpr.getThen();
 		XExpression assignment = Iterables.getFirst(block.getExpressions(), null);

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/document/DocumentSourceAppender.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/document/DocumentSourceAppender.java
@@ -220,7 +220,7 @@ public class DocumentSourceAppender implements ISourceAppender {
 				return importedType;
 			}
 		}
-		return IterableExtensions.last(importedTypes);
+		return IterableExtensions.lastOrNull(importedTypes);
 	}
 	
 	protected char getInnerTypeSeparator() {

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/quickfix/XbaseQuickfixProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/quickfix/XbaseQuickfixProvider.java
@@ -269,7 +269,7 @@ public class XbaseQuickfixProvider extends DefaultQuickfixProvider {
 		if (nodes.isEmpty())
 			return;
 		INode firstNode = IterableExtensions.head(nodes);
-		INode lastNode = IterableExtensions.last(nodes);
+		INode lastNode = IterableExtensions.lastOrNull(nodes);
 		int offset = firstNode.getOffset();
 		int length = lastNode.getEndOffset() - offset;
 		ReplacingAppendable appendable = appendableFactory.create(context.getXtextDocument(),
@@ -327,7 +327,7 @@ public class XbaseQuickfixProvider extends DefaultQuickfixProvider {
 						if (switchExpression == null) {
 							return;
 						}
-						XCasePart casePart = IterableExtensions.last(switchExpression.getCases());
+						XCasePart casePart = IterableExtensions.lastOrNull(switchExpression.getCases());
 						if (casePart == null || !(casePart.isFallThrough() && casePart.getThen() == null)) {
 							return;
 						}
@@ -337,7 +337,7 @@ public class XbaseQuickfixProvider extends DefaultQuickfixProvider {
 							return;
 						}
 						INode firstNode = IterableExtensions.head(nodes);
-						INode lastNode = IterableExtensions.last(nodes);
+						INode lastNode = IterableExtensions.lastOrNull(nodes);
 						int offset = firstNode.getOffset();
 						int length = lastNode.getEndOffset() - offset;
 						ReplacingAppendable appendable = appendableFactory.create(context.getXtextDocument(),
@@ -404,7 +404,7 @@ public class XbaseQuickfixProvider extends DefaultQuickfixProvider {
 		if (cases.isEmpty()) {
 			return insertionOffsets.inEmpty(switchExpression);
 		}
-		XCasePart casePart = IterableExtensions.last(cases);
+		XCasePart casePart = IterableExtensions.lastOrNull(cases);
 		return insertionOffsets.after(casePart);
 	}
 

--- a/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/FormattingDataFactory.xtend
+++ b/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/FormattingDataFactory.xtend
@@ -147,7 +147,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 							result += new WhitespaceData(leaf.offset, leaf.length, increaseIndentationChange, decreaseIndentationChange,
 								if (trace) new RuntimeException(), if (leaf.offset == 0) "" else if(leafs.containsComment) null else " ")
 						else
-							if(equalIndentationChange && leafs.leafs.last != leaf)
+							if(equalIndentationChange && leafs.leafs.lastOrNull != leaf)
 								result += new NewLineData(leaf.offset, leaf.length, increaseIndentationChange, decreaseIndentationChange, if (trace) new RuntimeException(), newLines)
 							else
 								result += new NewLineData(leaf.offset, leaf.length, if(equalIndentationChange) 0  else increaseIndentationChange, if(equalIndentationChange) 0 else decreaseIndentationChange, if (trace) new RuntimeException(), newLines)
@@ -156,7 +156,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 						var newLines = 1
 						if (leaf.leadingComment?.endsWithNewLine)
 							newLines = newLines - 1
-						if(equalIndentationChange && leafs.leafs.last != leaf)
+						if(equalIndentationChange && leafs.leafs.lastOrNull != leaf)
 							result += new NewLineData(leaf.offset, leaf.length, increaseIndentationChange, decreaseIndentationChange, if (trace) new RuntimeException(), newLines)
 						else
 							result += new NewLineData(leaf.offset, leaf.length, 0, 0, if (trace) new RuntimeException(), newLines)

--- a/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/HiddenLeafAccess.java
+++ b/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/HiddenLeafAccess.java
@@ -68,7 +68,7 @@ public class HiddenLeafAccess {
 				}
 			}
 			if (comment) {
-				if (!(IterableExtensions.last(result.getLeafs()) instanceof WhitespaceInfo)) {
+				if (!(IterableExtensions.lastOrNull(result.getLeafs()) instanceof WhitespaceInfo)) {
 					result.getLeafs().add(new WhitespaceInfo(result, null, 0, node.getOffset()));
 				}
 				result.getLeafs().add(new CommentInfo(result, node, newLines, trailing));
@@ -79,12 +79,12 @@ public class HiddenLeafAccess {
 				trailing = false;
 			}
 		}
-		if (!(IterableExtensions.last(result.getLeafs()) instanceof WhitespaceInfo)) {
+		if (!(IterableExtensions.lastOrNull(result.getLeafs()) instanceof WhitespaceInfo)) {
 			int whitespaceOffset = 0;
 			if (result.getLeafs().isEmpty()) {
 				whitespaceOffset = offset;
 			} else {
-				whitespaceOffset = IterableExtensions.last(result.getLeafs()).getNode().getEndOffset();
+				whitespaceOffset = IterableExtensions.lastOrNull(result.getLeafs()).getNode().getEndOffset();
 			}
 			result.getLeafs().add(new WhitespaceInfo(result, null, 0, whitespaceOffset));
 		}

--- a/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/XbaseFormatter2.xtend
+++ b/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/XbaseFormatter2.xtend
@@ -84,7 +84,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 						format += open.append[newLine; increaseIndentation]
 					else if (comma !== null)
 						format += comma.append[newLine]
-					if (elem == elements.last)
+					if (elem == elements.lastOrNull)
 						format += elem.nodeForEObject.append[newLine; decreaseIndentation]
 					elem.format(format)
 					comma = elem.nodeForEObject.immediatelyFollowingKeyword(",")
@@ -111,7 +111,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 				format += comma.prepend[noSpace]
 			}
 			if (elements.size > 0) {
-				val last = elements.last.nodeForEObject
+				val last = elements.lastOrNull.nodeForEObject
 				format += last.append[noSpace]
 				if (indented)
 					format += last.append[decreaseIndentation]
@@ -207,7 +207,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			for (n : leafs)
 				if (n.grammarElement instanceof Keyword && n.text == "::") {
 					document += n.prepend[noSpace]
-					if (n != leafs.last)
+					if (n != leafs.lastOrNull)
 						document += n.append[noSpace]
 				}
 		}
@@ -267,7 +267,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 						indented = true
 					}
 				}
-				if (arg == explicitParams.last) {
+				if (arg == explicitParams.lastOrNull) {
 					format += arg.nodeForEObject.append[noSpace]
 				}
 				arg.format(format)
@@ -275,7 +275,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 				format += node.prepend[noSpace]
 			}
 		if (indented)
-			format += explicitParams.last.nodeForEObject.append[decreaseIndentation]
+			format += explicitParams.lastOrNull.nodeForEObject.append[decreaseIndentation]
 		if (builder !== null) {
 			format += builder.nodeForEObject.prepend [
 				if (builder.isMultilineLambda)
@@ -288,13 +288,13 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 	}
 
 	def protected XClosure builder(List<XExpression> params) {
-		if (params.last !== null){
-			val grammarElement = (params.last.nodeForEObject as ICompositeNode).firstChild.grammarElement
+		if (params.lastOrNull !== null){
+			val grammarElement = (params.lastOrNull.nodeForEObject as ICompositeNode).firstChild.grammarElement
 			if(grammarElement == XMemberFeatureCallAccess.memberCallArgumentsXClosureParserRuleCall_1_1_4_0 || 
 				grammarElement == XFeatureCallAccess.featureCallArgumentsXClosureParserRuleCall_4_0 ||
 				grammarElement == XConstructorCallAccess.argumentsXClosureParserRuleCall_5_0
 			)
-				params.last as XClosure
+				params.lastOrNull as XClosure
 		}
 	}
 
@@ -317,7 +317,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 					format += head.prepend[newLine; increaseIndentation]
 				} else if (node !== null)
 					format += node.append[newLine]
-				if (arg == explicitParams.last)
+				if (arg == explicitParams.lastOrNull)
 					format += arg.nodeForEObject.append[newLine; decreaseIndentation]
 				arg.format(format)
 				node = arg.nodeForEObject.immediatelyFollowingKeyword(",")
@@ -509,7 +509,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			}
 		}
 		if (indented)
-			format += calls.last.nodeForEObject.append[decreaseIndentation]
+			format += calls.lastOrNull.nodeForEObject.append[decreaseIndentation]
 	}
 
 	def protected AbstractRule binaryOperationPrecedence(EObject op) {
@@ -556,7 +556,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			format(call.rightOperand, format)
 		}
 		if (indented)
-			format += calls.last.nodeForEObject.append[decreaseIndentation]
+			format += calls.lastOrNull.nodeForEObject.append[decreaseIndentation]
 	}
 	
 	def protected dispatch void format(XSynchronizedExpression expr, FormattableDocument format) {
@@ -740,7 +740,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 				}
 				for (child : expr.expressions) {
 					child.format(format)
-					if (child != expr.expressions.last || close !== null) {
+					if (child != expr.expressions.lastOrNull || close !== null) {
 						val childNode = child.nodeForEObject
 						val sem = childNode.immediatelyFollowingKeyword(";")
 						if (sem !== null) {
@@ -802,7 +802,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 		expr.expression.format(format)
 		for (cc : expr.catchClauses) {
 			cc.format(format)
-			if (cc != expr.catchClauses.last || expr.finallyExpression !== null) {
+			if (cc != expr.catchClauses.lastOrNull || expr.finallyExpression !== null) {
 				if (cc.expression instanceof XBlockExpression)
 					format += cc.nodeForEObject.append[cfg(bracesInNewLine)]
 				else
@@ -879,7 +879,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			format += open.append[increaseIndentation]
 			for (c : expr.cases) {
 				format += c.then.nodeForEObject.prepend[oneSpace]
-				if (c != expr.cases.last)
+				if (c != expr.cases.lastOrNull)
 					format += c.nodeForEObject.append[newLine]
 			}
 			if(expr.^default !== null) {
@@ -897,7 +897,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 				val cnode = c.then.nodeForEObject?:c.nodeForFeature(XCASE_PART__FALL_THROUGH)
 				if (c.then instanceof XBlockExpression) {
 					format += cnode.prepend[cfg(bracesInNewLine)]
-					if (expr.^default !== null || c != expr.cases.last)
+					if (expr.^default !== null || c != expr.cases.lastOrNull)
 						format += cnode.append[newLine]
 					else
 						format += cnode.append[newLine; decreaseIndentation]
@@ -907,7 +907,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 					} else {
 						format += cnode.prepend[newLine; increaseIndentation]
 					}
-					if (expr.^default !== null || c != expr.cases.last)
+					if (expr.^default !== null || c != expr.cases.lastOrNull)
 						format += cnode.append[newLine; decreaseIndentation]
 					else
 						format += cnode.append[newLine; decreaseIndentationChange = -2]
@@ -983,7 +983,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			val node = c.nodeForEObject
 			val semicolon = node.immediatelyFollowingKeyword(";")
 			format += semicolon.prepend[noSpace]
-			if (c != children.last)
+			if (c != children.lastOrNull)
 				format += (semicolon ?: node).append[newLine]
 		}
 		format += close.prepend[newLine; decreaseIndentation]
@@ -1028,7 +1028,7 @@ import static org.eclipse.xtext.xbase.formatting.XbaseFormatterPreferenceKeys.*
 			}
 		}
 		if (indented)
-			format += children.last.nodeForEObject.append[decreaseIndentation]
+			format += children.lastOrNull.nodeForEObject.append[decreaseIndentation]
 		format += close.prepend[noSpace]
 	}
 

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/output/ImportingStringConcatenation.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/output/ImportingStringConcatenation.java
@@ -73,7 +73,7 @@ public class ImportingStringConcatenation extends StringConcatenation {
 	@Override
 	protected List<String> getSignificantContent() {
 		List<String> result = super.getSignificantContent();
-		if (result.size() >= 1 && Objects.equal(getLineDelimiter(), IterableExtensions.last(result))) {
+		if (result.size() >= 1 && Objects.equal(getLineDelimiter(), IterableExtensions.lastOrNull(result))) {
 			return result.subList(0, result.size() - 1);
 		}
 		return result;

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/SeparatorRegions.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/SeparatorRegions.java
@@ -66,7 +66,7 @@ public class SeparatorRegions<T extends Object, R extends ITextSegment> implemen
 		if (first == null) {
 			first = newObject;
 		} else {
-			SeparatorEntry<T, R> last = IterableExtensions.last(separators());
+			SeparatorEntry<T, R> last = IterableExtensions.lastOrNull(separators());
 			newObject.previous = last;
 			last.next = newObject;
 		}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.xtend
@@ -83,7 +83,7 @@ class XbaseFormatter extends XtypeFormatter {
 				elem.format
 				elem.immediatelyFollowing.keyword(",").prepend[noSpace].append[newLine]
 			}
-			elements.last.append[newLine]
+			elements.lastOrNull.append[newLine]
 			interior(open, close)[indent]
 		} else {
 			val indent = new IndentOnceAutowrapFormatter(close.previousHiddenRegion)
@@ -170,12 +170,12 @@ class XbaseFormatter extends XtypeFormatter {
 	}
 
 	def protected XClosure builder(List<XExpression> params) {
-		if (params.last !== null) {
-			val grammarElement = params.last.grammarElement
+		if (params.lastOrNull !== null) {
+			val grammarElement = params.lastOrNull.grammarElement
 			if (grammarElement == XMemberFeatureCallAccess.memberCallArgumentsXClosureParserRuleCall_1_1_4_0 ||
 				grammarElement == XFeatureCallAccess.featureCallArgumentsXClosureParserRuleCall_4_0 ||
 				grammarElement == XConstructorCallAccess.argumentsXClosureParserRuleCall_5_0)
-				params.last as XClosure
+				params.lastOrNull as XClosure
 		}
 	}
 
@@ -412,7 +412,7 @@ class XbaseFormatter extends XtypeFormatter {
 		for (cc : expr.catchClauses) {
 			cc.regionFor.keyword("catch").append(whitespaceBetweenKeywordAndParenthesisML)
 			cc.declaredParam.prepend[noSpace].append[noSpace].format
-			if (cc != expr.catchClauses.last || expr.finallyExpression !== null)
+			if (cc != expr.catchClauses.lastOrNull || expr.finallyExpression !== null)
 				cc.expression.formatBodyInline(true, format)
 			else
 				cc.expression.formatBody(true, format)
@@ -466,7 +466,7 @@ class XbaseFormatter extends XtypeFormatter {
 				c.^case.format
 				c.then.format
 				c.then.prepend[oneSpace]
-				if (c != expr.cases.last)
+				if (c != expr.cases.lastOrNull)
 					c.append[newLine]
 			}
 			if (expr.^default !== null) {
@@ -549,9 +549,9 @@ class XbaseFormatter extends XtypeFormatter {
 					c.format
 					val semicolon = c.immediatelyFollowing.keyword(";")
 					if (semicolon !== null)
-						semicolon.prepend[noSpace].append[if(c == children.last) noSpace else oneSpace]
+						semicolon.prepend[noSpace].append[if(c == children.lastOrNull) noSpace else oneSpace]
 					else
-						c.append[if(c == children.last) noSpace else oneSpace]
+						c.append[if(c == children.lastOrNull) noSpace else oneSpace]
 				}
 			], [ doc |
 				val last = expr.formatClosureParams(open, doc)[oneSpace]

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XtypeFormatter.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/formatting2/XtypeFormatter.xtend
@@ -63,7 +63,7 @@ class XtypeFormatter extends AbstractJavaFormatter {
 	def dispatch format(XImportSection section, extension IFormattableDocument format) {
 		for (imp : section.importDeclarations) {
 			imp.format
-			if (imp != section.importDeclarations.last)
+			if (imp != section.importDeclarations.lastOrNull)
 				imp.append(blankLinesBetweenImports)
 			else
 				imp.append(blankLinesAfterImports)

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/ImportsCollector.xtend
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/ImportsCollector.xtend
@@ -114,7 +114,7 @@ class ImportsCollector {
 
 	dispatch def void visit(JvmGenericType jvmType, INode originNode, ImportsAcceptor acceptor) {
 		if (jvmType.anonymous) {
-			visit(jvmType.superTypes.last.type, originNode, acceptor)
+			visit(jvmType.superTypes.lastOrNull.type, originNode, acceptor)
 		} else {
 			_visit(jvmType as JvmDeclaredType, originNode, acceptor)
 		}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/XbaseValidator.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/XbaseValidator.java
@@ -1495,7 +1495,7 @@ public class XbaseValidator extends AbstractXbaseValidator {
 	
 	@Check
 	public void checkRedundantCase(XSwitchExpression switchExpression) {
-		XCasePart casePart = IterableExtensions.last(switchExpression.getCases());
+		XCasePart casePart = IterableExtensions.lastOrNull(switchExpression.getCases());
 		if (casePart == null || !(casePart.isFallThrough() && casePart.getThen() == null)) {
 			return;
 		}

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/FormattingDataFactory.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/FormattingDataFactory.java
@@ -313,7 +313,7 @@ public class FormattingDataFactory {
                 WhitespaceData _whitespaceData_1 = new WhitespaceData(_offset_2, _length_1, increaseIndentationChange, decreaseIndentationChange, _xifexpression_3, _xifexpression_4);
                 result.add(_whitespaceData_1);
               } else {
-                if ((equalIndentationChange && (!Objects.equal(IterableExtensions.<LeafInfo>last(leafs.getLeafs()), leaf)))) {
+                if ((equalIndentationChange && (!Objects.equal(IterableExtensions.<LeafInfo>lastOrNull(leafs.getLeafs()), leaf)))) {
                   int _offset_4 = ((WhitespaceInfo)leaf).getOffset();
                   int _length_2 = ((WhitespaceInfo)leaf).getLength();
                   RuntimeException _xifexpression_6 = null;
@@ -356,7 +356,7 @@ public class FormattingDataFactory {
               if (_endsWithNewLine_2) {
                 newLines_1 = (newLines_1 - 1);
               }
-              if ((equalIndentationChange && (!Objects.equal(IterableExtensions.<LeafInfo>last(leafs.getLeafs()), leaf)))) {
+              if ((equalIndentationChange && (!Objects.equal(IterableExtensions.<LeafInfo>lastOrNull(leafs.getLeafs()), leaf)))) {
                 int _offset_6 = ((WhitespaceInfo)leaf).getOffset();
                 int _length_4 = ((WhitespaceInfo)leaf).getLength();
                 RuntimeException _xifexpression_10 = null;

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/XbaseFormatter2.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting/XbaseFormatter2.java
@@ -161,8 +161,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
                 format.operator_add(_append_2);
               }
             }
-            EObject _last = IterableExtensions.last(elements);
-            boolean _equals_1 = Objects.equal(elem, _last);
+            EObject _lastOrNull = IterableExtensions.lastOrNull(elements);
+            boolean _equals_1 = Objects.equal(elem, _lastOrNull);
             if (_equals_1) {
               final Procedure1<FormattingDataInit> _function_3 = (FormattingDataInit it) -> {
                 it.newLine();
@@ -235,7 +235,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
       int _size = elements.size();
       boolean _greaterThan_1 = (_size > 0);
       if (_greaterThan_1) {
-        final INode last = this._nodeModelAccess.nodeForEObject(IterableExtensions.last(elements));
+        final INode last = this._nodeModelAccess.nodeForEObject(IterableExtensions.lastOrNull(elements));
         final Procedure1<FormattingDataInit> _function_1 = (FormattingDataInit it) -> {
           it.noSpace();
         };
@@ -524,8 +524,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
           };
           Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend = this._formattingDataFactory.prepend(n, _function);
           document.operator_add(_prepend);
-          ILeafNode _last = IterableExtensions.<ILeafNode>last(leafs);
-          boolean _notEquals = (!Objects.equal(n, _last));
+          ILeafNode _lastOrNull = IterableExtensions.<ILeafNode>lastOrNull(leafs);
+          boolean _notEquals = (!Objects.equal(n, _lastOrNull));
           if (_notEquals) {
             final Procedure1<FormattingDataInit> _function_1 = (FormattingDataInit it) -> {
               it.noSpace();
@@ -641,8 +641,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
               }
             }
           }
-          XExpression _last = IterableExtensions.<XExpression>last(explicitParams);
-          boolean _equals_1 = Objects.equal(arg, _last);
+          XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(explicitParams);
+          boolean _equals_1 = Objects.equal(arg, _lastOrNull);
           if (_equals_1) {
             final Procedure1<FormattingDataInit> _function_7 = (FormattingDataInit it) -> {
               it.noSpace();
@@ -664,7 +664,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
       final Procedure1<FormattingDataInit> _function_1 = (FormattingDataInit it) -> {
         it.decreaseIndentation();
       };
-      Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append_1 = this._formattingDataFactory.append(this._nodeModelAccess.nodeForEObject(IterableExtensions.<XExpression>last(explicitParams)), _function_1);
+      Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append_1 = this._formattingDataFactory.append(this._nodeModelAccess.nodeForEObject(IterableExtensions.<XExpression>lastOrNull(explicitParams)), _function_1);
       format.operator_add(_append_1);
     }
     if ((builder != null)) {
@@ -684,19 +684,19 @@ public class XbaseFormatter2 extends AbstractFormatter {
 
   protected XClosure builder(final List<XExpression> params) {
     XClosure _xifexpression = null;
-    XExpression _last = IterableExtensions.<XExpression>last(params);
-    boolean _tripleNotEquals = (_last != null);
+    XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(params);
+    boolean _tripleNotEquals = (_lastOrNull != null);
     if (_tripleNotEquals) {
       XClosure _xblockexpression = null;
       {
-        INode _nodeForEObject = this._nodeModelAccess.nodeForEObject(IterableExtensions.<XExpression>last(params));
+        INode _nodeForEObject = this._nodeModelAccess.nodeForEObject(IterableExtensions.<XExpression>lastOrNull(params));
         final EObject grammarElement = ((ICompositeNode) _nodeForEObject).getFirstChild().getGrammarElement();
         XClosure _xifexpression_1 = null;
         if (((Objects.equal(grammarElement, this._xbaseGrammarAccess.getXMemberFeatureCallAccess().getMemberCallArgumentsXClosureParserRuleCall_1_1_4_0()) || 
           Objects.equal(grammarElement, this._xbaseGrammarAccess.getXFeatureCallAccess().getFeatureCallArgumentsXClosureParserRuleCall_4_0())) || 
           Objects.equal(grammarElement, this._xbaseGrammarAccess.getXConstructorCallAccess().getArgumentsXClosureParserRuleCall_5_0()))) {
-          XExpression _last_1 = IterableExtensions.<XExpression>last(params);
-          _xifexpression_1 = ((XClosure) _last_1);
+          XExpression _lastOrNull_1 = IterableExtensions.<XExpression>lastOrNull(params);
+          _xifexpression_1 = ((XClosure) _lastOrNull_1);
         }
         _xblockexpression = _xifexpression_1;
       }
@@ -755,8 +755,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
               format.operator_add(_append_1);
             }
           }
-          XExpression _last = IterableExtensions.<XExpression>last(explicitParams);
-          boolean _equals_1 = Objects.equal(arg, _last);
+          XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(explicitParams);
+          boolean _equals_1 = Objects.equal(arg, _lastOrNull);
           if (_equals_1) {
             final Procedure1<FormattingDataInit> _function_3 = (FormattingDataInit it) -> {
               it.newLine();
@@ -1141,7 +1141,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
       final Procedure1<FormattingDataInit> _function = (FormattingDataInit it) -> {
         it.decreaseIndentation();
       };
-      Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append = this._formattingDataFactory.append(this._nodeModelAccess.nodeForEObject(IterableExtensions.<XMemberFeatureCall>last(calls)), _function);
+      Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append = this._formattingDataFactory.append(this._nodeModelAccess.nodeForEObject(IterableExtensions.<XMemberFeatureCall>lastOrNull(calls)), _function);
       format.operator_add(_append);
     }
   }
@@ -1225,7 +1225,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
       final Procedure1<FormattingDataInit> _function = (FormattingDataInit it) -> {
         it.decreaseIndentation();
       };
-      Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append = this._formattingDataFactory.append(this._nodeModelAccess.nodeForEObject(IterableExtensions.<XBinaryOperation>last(calls)), _function);
+      Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append = this._formattingDataFactory.append(this._nodeModelAccess.nodeForEObject(IterableExtensions.<XBinaryOperation>lastOrNull(calls)), _function);
       format.operator_add(_append);
     }
   }
@@ -1869,7 +1869,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
         for (final XExpression child : _expressions) {
           {
             this.format(child, format);
-            if (((!Objects.equal(child, IterableExtensions.<XExpression>last(expr.getExpressions()))) || (close != null))) {
+            if (((!Objects.equal(child, IterableExtensions.<XExpression>lastOrNull(expr.getExpressions()))) || (close != null))) {
               final INode childNode = this._nodeModelAccess.nodeForEObject(child);
               final ILeafNode sem = this._nodeModelAccess.immediatelyFollowingKeyword(childNode, ";");
               if ((sem != null)) {
@@ -2007,7 +2007,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
     for (final XCatchClause cc : _catchClauses) {
       {
         this.format(cc, format);
-        if (((!Objects.equal(cc, IterableExtensions.<XCatchClause>last(expr.getCatchClauses()))) || (expr.getFinallyExpression() != null))) {
+        if (((!Objects.equal(cc, IterableExtensions.<XCatchClause>lastOrNull(expr.getCatchClauses()))) || (expr.getFinallyExpression() != null))) {
           XExpression _expression_1 = cc.getExpression();
           if ((_expression_1 instanceof XBlockExpression)) {
             final Procedure1<FormattingDataInit> _function_4 = (FormattingDataInit it) -> {
@@ -2237,8 +2237,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
             };
             Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend_3 = this._formattingDataFactory.prepend(this._nodeModelAccess.nodeForEObject(c_1.getThen()), _function_12);
             format.operator_add(_prepend_3);
-            XCasePart _last = IterableExtensions.<XCasePart>last(expr.getCases());
-            boolean _notEquals = (!Objects.equal(c_1, _last));
+            XCasePart _lastOrNull = IterableExtensions.<XCasePart>lastOrNull(expr.getCases());
+            boolean _notEquals = (!Objects.equal(c_1, _lastOrNull));
             if (_notEquals) {
               final Procedure1<FormattingDataInit> _function_13 = (FormattingDataInit it) -> {
                 it.newLine();
@@ -2308,7 +2308,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
               };
               Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend_6 = this._formattingDataFactory.prepend(cnode_1, _function_19);
               format.operator_add(_prepend_6);
-              if (((expr.getDefault() != null) || (!Objects.equal(c_2, IterableExtensions.<XCasePart>last(expr.getCases()))))) {
+              if (((expr.getDefault() != null) || (!Objects.equal(c_2, IterableExtensions.<XCasePart>lastOrNull(expr.getCases()))))) {
                 final Procedure1<FormattingDataInit> _function_20 = (FormattingDataInit it) -> {
                   it.newLine();
                 };
@@ -2338,7 +2338,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
                 Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend_7 = this._formattingDataFactory.prepend(cnode_1, _function_23);
                 format.operator_add(_prepend_7);
               }
-              if (((expr.getDefault() != null) || (!Objects.equal(c_2, IterableExtensions.<XCasePart>last(expr.getCases()))))) {
+              if (((expr.getDefault() != null) || (!Objects.equal(c_2, IterableExtensions.<XCasePart>lastOrNull(expr.getCases()))))) {
                 final Procedure1<FormattingDataInit> _function_24 = (FormattingDataInit it) -> {
                   it.newLine();
                   it.decreaseIndentation();
@@ -2539,8 +2539,8 @@ public class XbaseFormatter2 extends AbstractFormatter {
         };
         Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _prepend_2 = this._formattingDataFactory.prepend(semicolon, _function_5);
         format.operator_add(_prepend_2);
-        XExpression _last = IterableExtensions.<XExpression>last(children);
-        boolean _notEquals = (!Objects.equal(c, _last));
+        XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(children);
+        boolean _notEquals = (!Objects.equal(c, _lastOrNull));
         if (_notEquals) {
           INode _elvis = null;
           if (semicolon != null) {
@@ -2653,7 +2653,7 @@ public class XbaseFormatter2 extends AbstractFormatter {
       final Procedure1<FormattingDataInit> _function_2 = (FormattingDataInit it) -> {
         it.decreaseIndentation();
       };
-      Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append_1 = this._formattingDataFactory.append(this._nodeModelAccess.nodeForEObject(IterableExtensions.<XExpression>last(children)), _function_2);
+      Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> _append_1 = this._formattingDataFactory.append(this._nodeModelAccess.nodeForEObject(IterableExtensions.<XExpression>lastOrNull(children)), _function_2);
       format.operator_add(_append_1);
     }
     final Procedure1<FormattingDataInit> _function_3 = (FormattingDataInit it) -> {

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XbaseFormatter.java
@@ -145,7 +145,7 @@ public class XbaseFormatter extends XtypeFormatter {
           final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it) -> {
             it.newLine();
           };
-          format.<EObject>append(IterableExtensions.last(elements), _function_2);
+          format.<EObject>append(IterableExtensions.lastOrNull(elements), _function_2);
           final Procedure1<IHiddenRegionFormatter> _function_3 = (IHiddenRegionFormatter it) -> {
             it.indent();
           };
@@ -302,18 +302,18 @@ public class XbaseFormatter extends XtypeFormatter {
 
   protected XClosure builder(final List<XExpression> params) {
     XClosure _xifexpression = null;
-    XExpression _last = IterableExtensions.<XExpression>last(params);
-    boolean _tripleNotEquals = (_last != null);
+    XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(params);
+    boolean _tripleNotEquals = (_lastOrNull != null);
     if (_tripleNotEquals) {
       XClosure _xblockexpression = null;
       {
-        final EObject grammarElement = this.grammarElement(IterableExtensions.<XExpression>last(params));
+        final EObject grammarElement = this.grammarElement(IterableExtensions.<XExpression>lastOrNull(params));
         XClosure _xifexpression_1 = null;
         if (((Objects.equal(grammarElement, this.grammar.getXMemberFeatureCallAccess().getMemberCallArgumentsXClosureParserRuleCall_1_1_4_0()) || 
           Objects.equal(grammarElement, this.grammar.getXFeatureCallAccess().getFeatureCallArgumentsXClosureParserRuleCall_4_0())) || 
           Objects.equal(grammarElement, this.grammar.getXConstructorCallAccess().getArgumentsXClosureParserRuleCall_5_0()))) {
-          XExpression _last_1 = IterableExtensions.<XExpression>last(params);
-          _xifexpression_1 = ((XClosure) _last_1);
+          XExpression _lastOrNull_1 = IterableExtensions.<XExpression>lastOrNull(params);
+          _xifexpression_1 = ((XClosure) _lastOrNull_1);
         }
         _xblockexpression = _xifexpression_1;
       }
@@ -828,7 +828,7 @@ public class XbaseFormatter extends XtypeFormatter {
           it.noSpace();
         };
         format.<JvmFormalParameter>format(format.<JvmFormalParameter>append(format.<JvmFormalParameter>prepend(cc.getDeclaredParam(), _function_1), _function_2));
-        if (((!Objects.equal(cc, IterableExtensions.<XCatchClause>last(expr.getCatchClauses()))) || (expr.getFinallyExpression() != null))) {
+        if (((!Objects.equal(cc, IterableExtensions.<XCatchClause>lastOrNull(expr.getCatchClauses()))) || (expr.getFinallyExpression() != null))) {
           this.formatBodyInline(cc.getExpression(), true, format);
         } else {
           this.formatBody(cc.getExpression(), true, format);
@@ -945,8 +945,8 @@ public class XbaseFormatter extends XtypeFormatter {
               it.oneSpace();
             };
             format.<XExpression>prepend(c_1.getThen(), _function_8);
-            XCasePart _last = IterableExtensions.<XCasePart>last(expr.getCases());
-            boolean _notEquals = (!Objects.equal(c_1, _last));
+            XCasePart _lastOrNull = IterableExtensions.<XCasePart>lastOrNull(expr.getCases());
+            boolean _notEquals = (!Objects.equal(c_1, _lastOrNull));
             if (_notEquals) {
               final Procedure1<IHiddenRegionFormatter> _function_9 = (IHiddenRegionFormatter it) -> {
                 it.newLine();
@@ -1165,8 +1165,8 @@ public class XbaseFormatter extends XtypeFormatter {
                     it_1.noSpace();
                   };
                   final Procedure1<IHiddenRegionFormatter> _function_7 = (IHiddenRegionFormatter it_1) -> {
-                    XExpression _last = IterableExtensions.<XExpression>last(children);
-                    boolean _equals = Objects.equal(c, _last);
+                    XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(children);
+                    boolean _equals = Objects.equal(c, _lastOrNull);
                     if (_equals) {
                       it_1.noSpace();
                     } else {
@@ -1176,8 +1176,8 @@ public class XbaseFormatter extends XtypeFormatter {
                   it.append(it.prepend(semicolon, _function_6), _function_7);
                 } else {
                   final Procedure1<IHiddenRegionFormatter> _function_8 = (IHiddenRegionFormatter it_1) -> {
-                    XExpression _last = IterableExtensions.<XExpression>last(children);
-                    boolean _equals = Objects.equal(c, _last);
+                    XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(children);
+                    boolean _equals = Objects.equal(c, _lastOrNull);
                     if (_equals) {
                       it_1.noSpace();
                     } else {

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XtypeFormatter.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/formatting2/XtypeFormatter.java
@@ -133,8 +133,8 @@ public class XtypeFormatter extends AbstractJavaFormatter {
     for (final XImportDeclaration imp : _importDeclarations) {
       {
         format.<XImportDeclaration>format(imp);
-        XImportDeclaration _last = IterableExtensions.<XImportDeclaration>last(section.getImportDeclarations());
-        boolean _notEquals = (!Objects.equal(imp, _last));
+        XImportDeclaration _lastOrNull = IterableExtensions.<XImportDeclaration>lastOrNull(section.getImportDeclarations());
+        boolean _notEquals = (!Objects.equal(imp, _lastOrNull));
         if (_notEquals) {
           format.<XImportDeclaration>append(imp, XbaseFormatterPreferenceKeys.blankLinesBetweenImports);
         } else {

--- a/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/imports/ImportsCollector.java
+++ b/org.eclipse.xtext.xbase/xtend-gen/org/eclipse/xtext/xbase/imports/ImportsCollector.java
@@ -130,7 +130,7 @@ public class ImportsCollector {
   protected void _visit(final JvmGenericType jvmType, final INode originNode, final ImportsAcceptor acceptor) {
     boolean _isAnonymous = jvmType.isAnonymous();
     if (_isAnonymous) {
-      this.visit(IterableExtensions.<JvmTypeReference>last(jvmType.getSuperTypes()).getType(), originNode, acceptor);
+      this.visit(IterableExtensions.<JvmTypeReference>lastOrNull(jvmType.getSuperTypes()).getType(), originNode, acceptor);
     } else {
       this._visit(((JvmDeclaredType) jvmType), originNode, acceptor);
     }

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TypeReference.java
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/TypeReference.java
@@ -163,7 +163,7 @@ public class TypeReference {
 		} else {
 			List<String> packageSegments = segments.subList(0, segments.size() - 1);
 			while (!packageSegments.isEmpty()) {
-				if (Character.isUpperCase(IterableExtensions.last(packageSegments).charAt(0))) {
+				if (Character.isUpperCase(IterableExtensions.lastOrNull(packageSegments).charAt(0))) {
 					packageSegments = packageSegments.subList(0, packageSegments.size() - 1);
 				} else {
 					return Joiner.on(".").join(packageSegments);
@@ -229,7 +229,7 @@ public class TypeReference {
 	}
 
 	public String getSimpleName() {
-		return IterableExtensions.last(simpleNames);
+		return IterableExtensions.lastOrNull(simpleNames);
 	}
 
 	public String getPath() {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/EqualAmbiguousTransitions.java
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/EqualAmbiguousTransitions.java
@@ -93,7 +93,7 @@ public class EqualAmbiguousTransitions implements Comparable<EqualAmbiguousTrans
 
 	private boolean isStop(GrammarAlias.TokenAlias it) {
 		return (it.getToken() == null && it.getParent() instanceof GrammarAlias.GroupAlias
-				&& Objects.equal(it, IterableExtensions.<GrammarAlias.AbstractElementAlias>last(
+				&& Objects.equal(it, IterableExtensions.<GrammarAlias.AbstractElementAlias>lastOrNull(
 						((GrammarAlias.GroupAlias) it.getParent()).getChildren())));
 	}
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/DomainmodelParsingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/DomainmodelParsingTest.xtend
@@ -107,7 +107,7 @@ class DomainmodelParsingTest{
 		'''.parse
 		val pack = model.elements.head as PackageDeclaration
 		val entity = pack.elements.head as Entity
-		val op = entity.features.last as Operation
+		val op = entity.features.lastOrNull as Operation
 		val method = op.jvmElements.head as JvmOperation
 		Assert.assertEquals("String", method.returnType.simpleName)
 	}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/DomainmodelParsingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/DomainmodelParsingTest.java
@@ -183,8 +183,8 @@ public class DomainmodelParsingTest {
     final PackageDeclaration pack = ((PackageDeclaration) _head);
     AbstractElement _head_1 = IterableExtensions.<AbstractElement>head(pack.getElements());
     final Entity entity = ((Entity) _head_1);
-    Feature _last = IterableExtensions.<Feature>last(entity.getFeatures());
-    final Operation op = ((Operation) _last);
+    Feature _lastOrNull = IterableExtensions.<Feature>lastOrNull(entity.getFeatures());
+    final Operation op = ((Operation) _lastOrNull);
     EObject _head_2 = IterableExtensions.<EObject>head(this._iJvmModelAssociations.getJvmElements(op));
     final JvmOperation method = ((JvmOperation) _head_2);
     Assert.assertEquals("String", method.getReturnType().getSimpleName());

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.xtend
@@ -51,9 +51,9 @@ class RuleEngineFormatter extends XbaseFormatter {
 			val sem = child.immediatelyFollowing.keyword(";")
 			if (sem !== null) {
 				sem.prepend[noSpace]
-				if (child != expr.expressions.last)
+				if (child != expr.expressions.lastOrNull)
 					sem.append[newLine]
-			} else if (child != expr.expressions.last)
+			} else if (child != expr.expressions.lastOrNull)
 				child.append[newLine]
 			child.format
 		}
@@ -74,7 +74,7 @@ class RuleEngineFormatter extends XbaseFormatter {
 			}
 			c.regionFor.feature(XCASE_PART__FALL_THROUGH).prepend[noSpace].append[newLine]
 			c.^case.format
-			if (c == expr.cases.last && expr.^default === null)
+			if (c == expr.cases.lastOrNull && expr.^default === null)
 				c.then.formatBody(true, document)
 			else
 				c.then.formatBodyParagraph(document)

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.java
@@ -131,8 +131,8 @@ public class RuleEngineFormatter extends XbaseFormatter {
             it.noSpace();
           };
           document.prepend(sem, _function_1);
-          XExpression _last = IterableExtensions.<XExpression>last(expr.getExpressions());
-          boolean _notEquals = (!Objects.equal(child, _last));
+          XExpression _lastOrNull = IterableExtensions.<XExpression>lastOrNull(expr.getExpressions());
+          boolean _notEquals = (!Objects.equal(child, _lastOrNull));
           if (_notEquals) {
             final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it) -> {
               it.newLine();
@@ -140,8 +140,8 @@ public class RuleEngineFormatter extends XbaseFormatter {
             document.append(sem, _function_2);
           }
         } else {
-          XExpression _last_1 = IterableExtensions.<XExpression>last(expr.getExpressions());
-          boolean _notEquals_1 = (!Objects.equal(child, _last_1));
+          XExpression _lastOrNull_1 = IterableExtensions.<XExpression>lastOrNull(expr.getExpressions());
+          boolean _notEquals_1 = (!Objects.equal(child, _lastOrNull_1));
           if (_notEquals_1) {
             final Procedure1<IHiddenRegionFormatter> _function_3 = (IHiddenRegionFormatter it) -> {
               it.newLine();
@@ -210,7 +210,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
         };
         document.append(document.prepend(this.regionFor(c).feature(XbasePackage.Literals.XCASE_PART__FALL_THROUGH), _function_8), _function_9);
         document.<XExpression>format(c.getCase());
-        if ((Objects.equal(c, IterableExtensions.<XCasePart>last(expr.getCases())) && (expr.getDefault() == null))) {
+        if ((Objects.equal(c, IterableExtensions.<XCasePart>lastOrNull(expr.getCases())) && (expr.getDefault() == null))) {
           this.formatBody(c.getThen(), true, document);
         } else {
           this.formatBodyParagraph(c.getThen(), document);


### PR DESCRIPTION
Closes #2981

I have updated the occurrences in our code base, but NOT in the input files of our tests.