### PR TITLE
Explicit dep on `org.eclipse.xtext.common.types` in `org.eclipse.xtext.testlanguages`

### DIFF
--- a/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
@@ -8,8 +8,6 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext;bundle-version="2.35.0",
  org.eclipse.xtext.xtext.generator;bundle-version="2.35.0";resolution:=optional;x-installation:=greedy,
  org.eclipse.emf.codegen.ecore;bundle-version="2.29.0";resolution:=optional;x-installation:=greedy,
- org.eclipse.emf.mwe.utils;bundle-version="1.10.0";resolution:=optional;x-installation:=greedy,
- org.eclipse.emf.mwe2.launch;bundle-version="2.17.0";resolution:=optional;x-installation:=greedy,
  org.eclipse.emf.ecore;bundle-version="2.26.0",
  org.eclipse.emf.common;bundle-version="2.24.0",
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",

--- a/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.xtext;bundle-version="2.35.0",
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  org.eclipse.xtext.xbase.lib;bundle-version="2.35.0",
  org.eclipse.xtend.lib;bundle-version="2.35.0",
- org.eclipse.xtext.testing;bundle-version="2.35.0"
+ org.eclipse.xtext.testing;bundle-version="2.35.0",
+ org.eclipse.xtext.common.types;bundle-version="2.35.0"
 Import-Package: org.apache.log4j;version="1.2.24",
  org.hamcrest.core,
  org.junit;version="4.13.2",

--- a/org.eclipse.xtext.testlanguages/build.properties
+++ b/org.eclipse.xtext.testlanguages/build.properties
@@ -6,4 +6,7 @@ bin.includes = model/generated/,\
 source.. = src-gen,\
            src
 src.includes = about.html
-additional.bundles = org.apache.commons.logging
+additional.bundles = org.eclipse.emf.mwe.utils,\
+                     org.eclipse.emf.mwe2.launch,\
+                     org.eclipse.emf.mwe2.lib,\
+                     org.apache.commons.logging


### PR DESCRIPTION
Closes #2982 

First of all, I reproduced locally the problem of #2982 with Tycho 4.0.7; after applying the changes of this PR, the problem went away.

I think I understand what the problem was:

- `org.eclipse.xtext.tests` depends on `org.eclipse.emf.mwe2.launch` (see its MANIFEST)
- `org.eclipse.emf.mwe2.launch` depends on `org.eclipse.xtext.common.types`
- `org.eclipse.xtext.testlanguages` does the same
- `org.eclipse.xtext.tests` also depends on `org.eclipse.xtext.testlanguages`

In the reactor, `org.eclipse.xtext.testlanguages` is built before `org.eclipse.xtext.tests`, but `org.eclipse.xtext.common.types` is built later, since it is not a direct dependency. Thus, it is taken from the target platform through `org.eclipse.emf.mwe2.launch`. Since new we are building 2.35.0.M1, I guess Maven/Tycho gets confused and cannot find it anywhere. In standard builds, not even in nightly release, this is not a problem because we use `-SNAPSHOT`.

For my local experiments, I simulated a release of M0.

See the early warnings (also the second one about implicit projects not referenced) when building `testlanguages`:

```
[INFO] ---------< org.eclipse.xtext:org.eclipse.xtext.testlanguages >----------
[INFO] Building Common Xtext Testlanguages - Runtime 2.35.0.M0         [22/126]
[INFO] ---------------------------[ eclipse-plugin ]---------------------------
...
[WARNING] Your build is not self-contained! Project org.eclipse.xtext:org.eclipse.xtext.testlanguages:eclipse-plugin:2.35.0.M0 depends implicitly on reactor project org.eclipse.xtext:org.eclipse.xtext.common.types:eclipse-plugin:2.35.0.M0 through target requirements eclipse-plugin:org.eclipse.emf.mwe2.launch:2.18.0.v20240405-0451 that are not part of the reactor, offending dependency chain is eclipse-plugin:org.eclipse.xtext.testlanguages:2.35.0.v20240409-0618 (reactor project) --> eclipse-plugin:org.eclipse.emf.mwe2.launch:2.18.0.v20240405-0451 (target dependency) --> eclipse-plugin:org.eclipse.xtext.common.types:2.35.0.v20240409-0618 (reactor project)
[WARNING] The following implicit projects are not referenced: 
org.eclipse.xtext:org.eclipse.xtext.common.types:eclipse-plugin:2.35.0.M0
```

also the reactor shows `common.types` would be built too late:

```
[INFO] Common Xtext Testlanguages - Runtime 2.35.0.M0 ..... SUCCESS [  3.056 s]
[INFO] Tests for Xtext Testing Library 2.35.0.M0 .......... SUCCESS [  0.815 s]
[INFO] Junit 5 Tests for Xtext Testing Library 2.35.0.M0 .. SUCCESS [  0.769 s]
[INFO] Xtext Core Runtime Tests 2.35.0.M0 ................. FAILURE [  0.794 s]
[INFO] Common Xtext Testlanguages - IDE Features 2.35.0.M0  SKIPPED
[INFO] Xtext IDE Tests 2.35.0.M0 .......................... SKIPPED
[INFO] Xtext Core Runtime JUnit5 Tests 2.35.0.M0 .......... SKIPPED
[INFO] Bootstrap project for the Xtext language 2.35.0.M0 . SKIPPED
[INFO] Xtext JSR-45 Smap Installer 2.35.0.M0 .............. SKIPPED
[INFO] Common Types Runtime Library 2.35.0.M0 ............. SKIPPED
```

The PR fixes the problem by adding an explicit dependency in `testlanguages` to `commont.types` (https://github.com/eclipse/xtext/compare/lb_2982?expand=1#diff-340220dc9dc01fdb48395ac234aba0e19cadec2c5bc2221e6f7c13e99ba39067R17) solving also the problem in `xtext.tests`.

No warning is printed anymore and `common.types` is built before `testlanguages`:

```
[INFO] ----------< org.eclipse.xtext:org.eclipse.xtext.common.types >----------
[INFO] Building Common Types Runtime Library 2.35.0.M0                 [22/126]

[INFO] ---------< org.eclipse.xtext:org.eclipse.xtext.testlanguages >----------
[INFO] Building Common Xtext Testlanguages - Runtime 2.35.0.M0         [23/126]

[INFO] -------------< org.eclipse.xtext:org.eclipse.xtext.tests >--------------
[INFO] Building Xtext Core Runtime Tests 2.35.0.M0                     [26/126]
```
