### PR TITLE
Replace Guava's Objects by java.util.Objects

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
@@ -14,6 +14,7 @@ import static org.eclipse.xtext.util.Strings.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -109,7 +110,6 @@ import org.eclipse.xtext.xbase.ui.document.DocumentSourceAppender.Factory.Option
 import org.eclipse.xtext.xbase.ui.imports.OrganizeImportsHandler;
 import org.eclipse.xtext.xbase.ui.quickfix.XbaseQuickfixProvider;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
@@ -623,7 +623,7 @@ public class XtendQuickfixProvider extends XbaseQuickfixProvider {
 								if (obj instanceof JvmDeclaredType) {
 									JvmDeclaredType type = (JvmDeclaredType) obj;
 									String typePackage = type.getPackageName();
-									if (Objects.equal(typePackage, oldPackageName) || typePackage != null && typePackage.startsWith(oldPackageName + ".")) {
+									if (Objects.equals(typePackage, oldPackageName) || typePackage != null && typePackage.startsWith(oldPackageName + ".")) {
 										type.internalSetIdentifier(null);
 										type.setPackageName(newPackageName);
 									}

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/indentation/AbstractCompletePrefixProviderTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/indentation/AbstractCompletePrefixProviderTest.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.xtext.ide.tests.indentation;
 
+import java.util.Objects;
+
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.Action;
@@ -23,7 +25,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
@@ -903,7 +904,7 @@ public abstract class AbstractCompletePrefixProviderTest {
 				try {
 					return true;
 				} finally {
-					found = Objects.equal(t, element);
+					found = Objects.equals(t, element);
 				}
 			}
 		}

--- a/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.java
+++ b/org.eclipse.xtext.ide.tests/src/org/eclipse/xtext/ide/tests/server/concurrent/RequestManagerTest.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.xtext.ide.tests.server.concurrent;
 
+import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -36,7 +37,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.google.common.base.Objects;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -355,7 +355,7 @@ public class RequestManagerTest {
 			@Override
 			protected void addRequest(AbstractRequest<?> request) {
 				if (((request instanceof WriteRequest)
-						&& Objects.equal(Thread.currentThread(), readerThreadRef.get()))) {
+						&& Objects.equals(Thread.currentThread(), readerThreadRef.get()))) {
 					super.addRequest(request);
 					addedFromReader.countDown();
 					Uninterruptibles.awaitUninterruptibly(submittedFromMain, 100, TimeUnit.MILLISECONDS);
@@ -366,7 +366,7 @@ public class RequestManagerTest {
 
 			@Override
 			protected void submitRequest(AbstractRequest<?> request) {
-				if (((request instanceof WriteRequest) && Objects.equal(Thread.currentThread(), mainThread))) {
+				if (((request instanceof WriteRequest) && Objects.equals(Thread.currentThread(), mainThread))) {
 					super.submitRequest(request);
 					submittedFromMain.countDown();
 				} else {
@@ -376,7 +376,7 @@ public class RequestManagerTest {
 
 			@Override
 			protected CompletableFuture<Void> cancel() {
-				if (Objects.equal(Thread.currentThread(), mainThread)) {
+				if (Objects.equals(Thread.currentThread(), mainThread)) {
 					Uninterruptibles.awaitUninterruptibly(addedFromReader, 100, TimeUnit.MILLISECONDS);
 				}
 				return super.cancel();

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/serializer/PartialSerializationTestLanguageReferenceUpdater.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/ide/serializer/PartialSerializationTestLanguageReferenceUpdater.java
@@ -11,6 +11,7 @@ package org.eclipse.xtext.ide.tests.testlanguage.ide.serializer;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -25,7 +26,6 @@ import org.eclipse.xtext.naming.IQualifiedNameConverter;
 import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 
@@ -56,7 +56,7 @@ public class PartialSerializationTestLanguageReferenceUpdater extends ReferenceU
 						.head(delta.getSnapshot().getDescriptions()).getQualifiedName();
 				QualifiedName modified = IterableExtensions.head(delta.getDescriptions())
 						.getQualifiedName();
-				if (!Objects.equal(original, modified)) {
+				if (!Objects.equals(original, modified)) {
 					Import imp = imports.get(original);
 					if (imp != null) {
 						toChange.put(imp, modified);

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/rename/TestLanguageRenameService.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/rename/TestLanguageRenameService.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.xtext.ide.tests.testlanguage.rename;
 
+import java.util.Objects;
+
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.ide.server.rename.RenameService2;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
@@ -19,7 +21,6 @@ import org.eclipse.xtext.parser.IParseResult;
 import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
 import org.eclipse.xtext.resource.XtextResource;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 
 public class TestLanguageRenameService extends RenameService2 {
@@ -43,8 +44,8 @@ public class TestLanguageRenameService extends RenameService2 {
 								QualifiedName fqn = nameProvider.getFullyQualifiedName(element);
 								if (fqn != null) {
 									String leafText = NodeModelUtils.getTokenText(leaf);
-									if (fqn.getSegmentCount() == 1 && Objects.equal(fqn.toString(), leafText)
-											|| Objects.equal(fqn.getLastSegment(), leafText)) {
+									if (fqn.getSegmentCount() == 1 && Objects.equals(fqn.toString(), leafText)
+											|| Objects.equals(fqn.getLastSegment(), leafText)) {
 										return element;
 									}
 								}

--- a/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/signatureHelp/SignatureHelpServiceImpl.java
+++ b/org.eclipse.xtext.ide.tests/testlang-src/org/eclipse/xtext/ide/tests/testlanguage/signatureHelp/SignatureHelpServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.lsp4j.ParameterInformation;
@@ -39,7 +40,6 @@ import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
@@ -199,7 +199,7 @@ public class SignatureHelpServiceImpl implements ISignatureHelpService {
 						scopeProvider.getScope(object, TestLanguagePackage.Literals.OPERATION_CALL__OPERATION)
 								.getAllElements(),
 						(IEObjectDescription it) -> it.getEClass() == TestLanguagePackage.Literals.OPERATION),
-						(IEObjectDescription it) -> Objects.equal(it.getQualifiedName().getLastSegment(), name)),
+						(IEObjectDescription it) -> Objects.equals(it.getQualifiedName().getLastSegment(), name)),
 				IEObjectDescription::getEObjectOrProxy), Operation.class);
 	}
 

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/IdeContentProposalPriorities.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/contentassist/IdeContentProposalPriorities.java
@@ -8,9 +8,10 @@
  */
 package org.eclipse.xtext.ide.editor.contentassist;
 
+import java.util.Objects;
+
 import org.eclipse.xtext.resource.IEObjectDescription;
 
-import com.google.common.base.Objects;
 import com.google.inject.Singleton;
 
 /**
@@ -34,7 +35,7 @@ public class IdeContentProposalPriorities {
 		if (!Character.isLetter(entry.getProposal().charAt(0))) {
 			adjustedPriority = adjustedPriority - 30;
 		}
-		if (Objects.equal(entry.getProposal(), entry.getPrefix())) {
+		if (Objects.equals(entry.getProposal(), entry.getPrefix())) {
 			adjustedPriority = adjustedPriority - 20;
 		}
 		return adjustedPriority;

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/FoldingRange.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/folding/FoldingRange.java
@@ -8,9 +8,9 @@
  *******************************************************************************/
 package org.eclipse.xtext.ide.editor.folding;
 
-import org.eclipse.xtext.util.ITextRegion;
+import java.util.Objects;
 
-import com.google.common.base.Objects;
+import org.eclipse.xtext.util.ITextRegion;
 
 /**
  * Represents an abstraction for different folding implementations.
@@ -70,15 +70,15 @@ public class FoldingRange {
 		if (other instanceof FoldingRange) {
 			FoldingRange range = (FoldingRange) other;
 			return offset == range.offset && length == range.length && initiallyFolded == range.initiallyFolded
-					&& Objects.equal(kind, range.kind)
-					&& Objects.equal(visualPlaceholderRegion, range.visualPlaceholderRegion);
+					&& Objects.equals(kind, range.kind)
+					&& Objects.equals(visualPlaceholderRegion, range.visualPlaceholderRegion);
 		}
 		return false;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hashCode(offset, length, initiallyFolded, kind, visualPlaceholderRegion);
+		return Objects.hash(offset, length, initiallyFolded, kind, visualPlaceholderRegion);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/hierarchy/AbstractHierarchyBuilder.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/hierarchy/AbstractHierarchyBuilder.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.xtext.ide.editor.hierarchy;
 
+import java.util.Objects;
+
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
@@ -24,7 +26,6 @@ import org.eclipse.xtext.resource.IResourceServiceProvider;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -65,7 +66,7 @@ public abstract class AbstractHierarchyBuilder implements IHierarchyBuilder {
 			return null;
 		}
 		for (IEObjectDescription o : resourceDescription.getExportedObjects()) {
-			if (Objects.equal(o.getEObjectURI(), objectURI)) {
+			if (Objects.equals(o.getEObjectURI(), objectURI)) {
 				return o;
 			}
 		}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/hierarchy/DefaultHierarchyNode.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/editor/hierarchy/DefaultHierarchyNode.java
@@ -10,12 +10,11 @@ package org.eclipse.xtext.ide.editor.hierarchy;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.util.Wrapper;
-
-import com.google.common.base.Objects;
 
 /**
  * @author kosyakov - Initial contribution and API
@@ -54,7 +53,7 @@ public class DefaultHierarchyNode implements IHierarchyNode {
 		while (node != null) {
 			URI nodeElementUri = node.getElement().getEObjectURI();
 			URI elementUri = this.element.getEObjectURI();
-			if (Objects.equal(nodeElementUri, elementUri)) {
+			if (Objects.equals(nodeElementUri, elementUri)) {
 				return true;
 			}
 			node = node.getParent();

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/EObjectDescriptionDeltaProvider.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/EObjectDescriptionDeltaProvider.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -23,7 +24,6 @@ import org.eclipse.xtext.ide.serializer.hooks.IResourceSnapshot;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.util.Arrays;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -131,7 +131,7 @@ public class EObjectDescriptionDeltaProvider {
 					return false;
 				String oldValue = oldObj.getUserData(key);
 				String newValue = newObj.getUserData(key);
-				if (!Objects.equal(oldValue, newValue))
+				if (!Objects.equals(oldValue, newValue))
 					return false;
 			}
 			return true;

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/ReferenceUpdater.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/serializer/impl/ReferenceUpdater.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.ide.serializer.impl;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
@@ -39,7 +40,6 @@ import org.eclipse.xtext.scoping.IScope;
 import org.eclipse.xtext.scoping.IScopeProvider;
 import org.eclipse.xtext.serializer.tokens.SerializerScopeProviderBinding;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 
 /**
@@ -196,7 +196,7 @@ public class ReferenceUpdater implements IReferenceUpdater {
 			return true;
 		}
 		Delta sourceDelta = findContainingDelta(deltas, ref.getSourceEObject());
-		return !Objects.equal(sourceDelta, targetDelta);
+		return !Objects.equals(sourceDelta, targetDelta);
 	}
 
 	@Override

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/LanguageServerImpl.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -145,7 +146,6 @@ import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.xbase.lib.Pair;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -248,7 +248,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 	protected boolean clientSupportsWorkspaceFolders() {
 		return this.initializeParams.getCapabilities() != null 
 				&& this.initializeParams.getCapabilities().getWorkspace() != null 
-				&& Objects.equal(this.initializeParams.getCapabilities().getWorkspace().getWorkspaceFolders(), Boolean.TRUE);
+				&& Objects.equals(this.initializeParams.getCapabilities().getWorkspace().getWorkspaceFolders(), Boolean.TRUE);
 	}
 
 	/**
@@ -312,7 +312,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 		if (rename != null) {
 			prepareSupport = rename.getPrepareSupport();
 		}
-		boolean clientPrepareSupport = Objects.equal(Boolean.TRUE, prepareSupport);
+		boolean clientPrepareSupport = Objects.equals(Boolean.TRUE, prepareSupport);
 		if (clientPrepareSupport && allLanguages.stream()
 				.anyMatch(serviceProvider -> serviceProvider.get(IRenameService2.class) != null)) {
 			RenameOptions renameOptions = new RenameOptions();
@@ -1123,7 +1123,7 @@ public class LanguageServerImpl implements LanguageServer, WorkspaceService, Tex
 									+ "\' can not be an extension as it is already defined in the LSP standard.");
 						} else {
 							JsonRpcMethod existing = extensions.put(entry.getKey(), entry.getValue());
-							if (existing != null && !Objects.equal(existing, entry.getValue())) {
+							if (existing != null && !Objects.equals(existing, entry.getValue())) {
 								LOG.error("An incompatible LSP extension \'" + entry.getKey()
 										+ "\' has already been registered. Using 1 ignoring 2. \n1 : " + existing
 										+ " \n2 : " + entry.getValue());

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ServerLauncher.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/ServerLauncher.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.util.Objects;
 import java.util.concurrent.Future;
 
 import org.eclipse.lsp4j.jsonrpc.Launcher;
@@ -22,7 +23,6 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.InputOutput;
 
-import com.google.common.base.Objects;
 import com.google.common.io.ByteStreams;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -119,7 +119,7 @@ public class ServerLauncher {
 
 	public static boolean testArg(String arg, String... values) {
 		for(String value : values) {
-			if (Objects.equal(value, arg)) {
+			if (Objects.equals(value, arg)) {
 				return true;
 			}
 		}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/SocketServerLauncher.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/SocketServerLauncher.java
@@ -15,13 +15,13 @@ import java.net.InetSocketAddress;
 import java.nio.channels.AsynchronousServerSocketChannel;
 import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.Channels;
+import java.util.Objects;
 
 import org.apache.log4j.Logger;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.xtext.xbase.lib.ArrayExtensions;
 
-import com.google.common.base.Objects;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
@@ -119,7 +119,7 @@ public class SocketServerLauncher {
 
 	protected String getValue(String[] args, String argName) {
 		for (int i = 0; (i < (args.length - 1)); i++) {
-			if (Objects.equal(args[i], argName)) {
+			if (Objects.equals(args[i], argName)) {
 				return args[i + 1];
 			}
 		}

--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/RenameService2.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/rename/RenameService2.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.ide.server.rename;
 
 import java.io.FileNotFoundException;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.log4j.Logger;
@@ -55,7 +56,6 @@ import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
@@ -252,7 +252,7 @@ public class RenameService2 implements IRenameService2 {
 							String convertedNameValue = getConvertedValue(leaf.getGrammarElement(), leaf);
 							String elementName = getElementName(element);
 							if (!Strings.isEmpty(convertedNameValue) && !Strings.isEmpty(elementName)
-									&& Objects.equal(convertedNameValue, elementName)) {
+									&& Objects.equals(convertedNameValue, elementName)) {
 								Position start = document.getPosition(leaf.getOffset());
 								Position end = document.getPosition(leaf.getEndOffset());
 								return Either3.forFirst(new Range(start, end));

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/logging/LoggingTester.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/logging/LoggingTester.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -28,7 +29,6 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 import org.junit.Assert;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.primitives.Longs;
 
@@ -62,7 +62,7 @@ public class LoggingTester {
 
 		public void assertNumberOfLogEntries(int number, Level level, String... messageParts) {
 			Iterable<LogEntry> passed = Iterables.filter(logEntries, (LogEntry log) -> {
-				return (level == null || Objects.equal(log.level, level)) && 
+				return (level == null || Objects.equals(log.level, level)) &&
 					IterableExtensions.forall(messageParts == null ? null : Arrays.asList(messageParts), (String it) -> log.message.contains(it));
 			});
 			if (Iterables.size(passed) != number) {
@@ -252,7 +252,7 @@ public class LoggingTester {
 
 		@Override
 		public int decide(LoggingEvent event) {
-			if (Objects.equal(event.getLoggerName(), source.getName())) {
+			if (Objects.equals(event.getLoggerName(), source.getName())) {
 				return Filter.DENY;
 			} else {
 				return Filter.NEUTRAL;
@@ -336,7 +336,7 @@ public class LoggingTester {
 		List<Filter> filtersToKeep = new ArrayList<>();
 		Filter present = appender.getFilter();
 		while (present != null) {
-			if (!Objects.equal(present, filter)) {
+			if (!Objects.equals(present, filter)) {
 				filtersToKeep.add(present);
 			}
 			present = present.getNext();

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/build/IncrementalBuilderTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/build/IncrementalBuilderTest.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.xtext.build;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -25,7 +26,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
@@ -188,13 +188,13 @@ public class IncrementalBuilderTest extends AbstractIncrementalBuilderTest {
 		build(newBuildRequest((BuildRequest it) -> {
 			it.setDeletedFiles(Lists.newArrayList(uri("src/B.indextestlanguage")));
 			it.setAfterValidate((URI uri, Iterable<Issue> issues) -> {
-				if (Objects.equal(uri("src/A.indextestlanguage"), uri)) {
+				if (Objects.equals(uri("src/A.indextestlanguage"), uri)) {
 					Assert.assertTrue(issues.toString(), Iterables.<Issue>getFirst(issues, null).getMessage()
 							.contains("Couldn't resolve reference to Type 'foo.B'"));
 					validateCalled.set(true);
 					return false;
 				} else {
-					if (Objects.equal(uri("src/B.indextestlanguage"), uri)) {
+					if (Objects.equals(uri("src/B.indextestlanguage"), uri)) {
 						Assert.assertEquals("zero issues expected", 0, Iterables.size(issues));
 						return true;
 					} else {
@@ -226,14 +226,14 @@ public class IncrementalBuilderTest extends AbstractIncrementalBuilderTest {
 		build(newBuildRequest((BuildRequest it) -> {
 			it.setDeletedFiles(Lists.newArrayList(uri("src/B.indextestlanguage")));
 			it.setAfterValidate((URI uri, Iterable<Issue> issues) -> {
-				if (Objects.equal(uri("src/A.indextestlanguage"), uri)) {
+				if (Objects.equals(uri("src/A.indextestlanguage"), uri)) {
 					Assert.assertTrue(issues.toString(),
 							!Iterables.isEmpty(issues) && Iterables.<Issue>getFirst(issues, null).getMessage()
 									.contains("Couldn't resolve reference to Type 'foo.B'"));
 					validateCalled.set(true);
 					return false;
 				} else {
-					if (Objects.equal(uri("src/B.indextestlanguage"), uri)) {
+					if (Objects.equals(uri("src/B.indextestlanguage"), uri)) {
 						Assert.assertEquals("zero issues expected", 0, Iterables.size(issues));
 						return true;
 					} else {

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/parser/AntlrGrammarComparator.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/parser/AntlrGrammarComparator.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.generator.parser;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -17,7 +18,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function0;
 import org.eclipse.xtext.xbase.lib.Pair;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 
 /**
@@ -217,7 +217,7 @@ public class AntlrGrammarComparator {
 			} else {
 				matchReference = "««eof»»";
 			}
-			if (!Objects.equal(matchReference, match)) {
+			if (!Objects.equals(matchReference, match)) {
 				errorHandler.handleMismatch(match, matchReference, errorContext);
 			}
 		}

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/trace/TraceRegionToStringTester.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/generator/trace/TraceRegionToStringTester.java
@@ -10,10 +10,9 @@ package org.eclipse.xtext.generator.trace;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.xtext.util.ITextRegion;
-
-import com.google.common.base.Objects;
 
 public class TraceRegionToStringTester extends AbstractTraceRegionToString {
 	public static class Location extends LocationData {
@@ -63,10 +62,10 @@ public class TraceRegionToStringTester extends AbstractTraceRegionToString {
 
 	@Override
 	protected String getRemoteText(SourceRelativeURI uri) {
-		if (Objects.equal(uri, uri1)) {
+		if (Objects.equals(uri, uri1)) {
 			return remote1;
 		}
-		if (Objects.equal(uri, uri2)) {
+		if (Objects.equals(uri, uri2)) {
 			return remote2;
 		}
 		return null;

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/AbstractResourceSetTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/resource/AbstractResourceSetTest.java
@@ -9,14 +9,13 @@
 package org.eclipse.xtext.resource;
 
 import java.io.File;
+import java.util.Objects;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.base.Objects;
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -54,7 +53,7 @@ public abstract class AbstractResourceSetTest {
 		new ResourceSetImpl.ResourceLocator(rs) {
 			@Override
 			public Resource getResource(URI uri, boolean loadOnDemand) {
-				if (Objects.equal(uri, resource.getURI())) {
+				if (Objects.equals(uri, resource.getURI())) {
 					return resource;
 				}
 				throw new IllegalArgumentException(uri.toString());

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextLinkerTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextLinkerTest.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.xtext.xtext;
 
+import java.util.Objects;
+
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.InternalEObject;
@@ -35,7 +37,6 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 
@@ -194,16 +195,16 @@ public class XtextLinkerTest extends AbstractXtextTests {
 		AbstractRule firstRule = Iterables.getFirst(grammar.getRules(), null);
 		AbstractRule idRule = GrammarUtil.findRuleForName(Iterables.getFirst(grammar.getUsedGrammars(), null), "ID");
 		Assert.assertTrue(IterableExtensions.forall(GrammarUtil.containedRuleCalls(firstRule),
-				(RuleCall it) -> Objects.equal(it.getRule(), idRule)));
+				(RuleCall it) -> Objects.equals(it.getRule(), idRule)));
 		AbstractRule secondRule = Iterables.getFirst(IterableExtensions.tail(grammar.getRules()), null);
 		AbstractRule stringRule = Iterables.getLast(grammar.getRules());
 		Assert.assertTrue(IterableExtensions.forall(GrammarUtil.containedRuleCalls(secondRule),
-				(RuleCall it) -> Objects.equal(it.getRule(), stringRule)));
+				(RuleCall it) -> Objects.equals(it.getRule(), stringRule)));
 		AbstractRule thirdRule = Iterables.getFirst(IterableExtensions.drop(grammar.getRules(), 2), null);
 		AbstractRule inheritedString = GrammarUtil.findRuleForName(Iterables.getFirst(grammar.getUsedGrammars(), null),
 				"STRING");
 		Assert.assertTrue(IterableExtensions.forall(GrammarUtil.containedRuleCalls(thirdRule),
-				(RuleCall it) -> Objects.equal(it.getRule(), inheritedString)));
+				(RuleCall it) -> Objects.equals(it.getRule(), inheritedString)));
 	}
 
 	@Test

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/wizard/WizardConfigurationTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/wizard/WizardConfigurationTest.java
@@ -11,6 +11,7 @@ package org.eclipse.xtext.xtext.wizard;
 import static org.junit.Assert.*;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.xtext.util.JavaVersion;
 import org.eclipse.xtext.util.XtextVersion;
@@ -18,7 +19,6 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -154,9 +154,9 @@ public class WizardConfigurationTest {
 				.getExternalDependencies()) {
 			assertTrue(IterableExtensions.exists(config.getRuntimeProject().getExternalDependencies(),
 					(ExternalDependency it) -> {
-						return Objects.equal(it.getMaven().getArtifactId(), testDependency.getMaven().getArtifactId())
-								&& Objects.equal(it.getP2().getBundleId(), testDependency.getP2().getBundleId())
-								&& Objects.equal(it.getP2().getPackages(), testDependency.getP2().getPackages());
+						return Objects.equals(it.getMaven().getArtifactId(), testDependency.getMaven().getArtifactId())
+								&& Objects.equals(it.getP2().getBundleId(), testDependency.getP2().getBundleId())
+								&& Objects.equals(it.getP2().getPackages(), testDependency.getP2().getPackages());
 					}));
 		}
 	}

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/DirtyStateEditorSupportIntegrationTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/DirtyStateEditorSupportIntegrationTest.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.ui.tests.editor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -31,7 +32,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -145,7 +145,7 @@ public class DirtyStateEditorSupportIntegrationTest extends AbstractEditorTest {
 		textWidget.notifyListeners(SWT.KeyUp, event2);
 		int maxTries = 10;
 		while (maxTries-- > 0) {
-			if (!Objects.equal(editor.getDocument().get(), textBefore)) {
+			if (!Objects.equals(editor.getDocument().get(), textBefore)) {
 				syncUtil.waitForReconciler(editor);
 				return;
 			}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/FixedScopedPreferenceStore.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/FixedScopedPreferenceStore.java
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.editor.preferences;
 import java.io.IOException;
+import java.util.Objects;
 
 import org.eclipse.core.commands.common.EventManager;
 import org.eclipse.core.runtime.Assert;
@@ -25,8 +26,6 @@ import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.jface.util.SafeRunnable;
 import org.osgi.service.prefs.BackingStoreException;
-
-import com.google.common.base.Objects;
 
 /**
  * Mainly copied from {@link org.eclipse.ui.preferences.ScopedPreferenceStore}.
@@ -712,7 +711,7 @@ public class FixedScopedPreferenceStore extends EventManager implements IPersist
 			// removing a non-existing preference is a no-op so call the Core
 			// API directly
 			getStorePreferences().remove(name);
-			if (!Objects.equal(oldValue, defaultValue)) {
+			if (!Objects.equals(oldValue, defaultValue)) {
 				dirty = true;
 				firePropertyChangeEvent(name, oldValue, defaultValue);
 			}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/AbstractDeclarativeQuickfixProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/AbstractDeclarativeQuickfixProvider.java
@@ -10,11 +10,11 @@ package org.eclipse.xtext.ui.editor.quickfix;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.log4j.Logger;
 import org.eclipse.xtext.validation.Issue;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -38,7 +38,7 @@ public class AbstractDeclarativeQuickfixProvider implements IssueResolutionProvi
 			@Override
 			public boolean apply(Method input) {
 				for (Fix annotation : input.getAnnotationsByType(Fix.class)) {
-					boolean result = annotation != null && Objects.equal(annotation.value(), issueCode)
+					boolean result = annotation != null && Objects.equals(annotation.value(), issueCode)
 							&& input.getParameterTypes().length == 2 && Void.TYPE == input.getReturnType()
 							&& input.getParameterTypes()[0].isAssignableFrom(Issue.class)
 							&& input.getParameterTypes()[1].isAssignableFrom(IssueResolutionAcceptor.class);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/TextualMultiModificationWorkbenchMarkerResolutionAdapter.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/TextualMultiModificationWorkbenchMarkerResolutionAdapter.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IMarker;
@@ -33,7 +34,6 @@ import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.validation.Issue;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.name.Named;
@@ -152,7 +152,7 @@ public class TextualMultiModificationWorkbenchMarkerResolutionAdapter extends Wo
 				for (IMarker candidate : markers) {
 					if (languageResourceHelper.isLanguageResource(marker.getResource()) && candidate != marker) {
 						Object canidateCodeKey = candidate.getAttribute(Issue.CODE_KEY);
-						if (Objects.equal(markerCodeKey, canidateCodeKey)) {
+						if (Objects.equals(markerCodeKey, canidateCodeKey)) {
 							result.add(candidate);
 							if (result.size() >= MAX_QUICKFIXES) {
 								break;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/EditorDocumentUndoChange.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/EditorDocumentUndoChange.java
@@ -8,6 +8,8 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.refactoring.impl;
 
+import java.util.Objects;
+
 import org.apache.log4j.Logger;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -27,8 +29,6 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.xtext.ui.util.DisplayRunnableWithResult;
-
-import com.google.common.base.Objects;
 
 /**
  * The reverse of an {@link EditorDocumentChange}.
@@ -64,7 +64,7 @@ public class EditorDocumentUndoChange extends Change {
 	protected ITextEditor getEditor() {
 		try {
 			IEditorPart editor = page.findEditor(editorInput);
-			if (editor != null && Objects.equal(editor.getSite().getId(), editorID))
+			if (editor != null && Objects.equals(editor.getSite().getId(), editorID))
 				return (ITextEditor) editor;
 			else
 				return (ITextEditor) page.openEditor(editorInput, editorID, true, IWorkbenchPage.MATCH_INPUT | IWorkbenchPage.MATCH_ID);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/Storage2UriMapperJavaImpl.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/Storage2UriMapperJavaImpl.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
@@ -53,7 +54,6 @@ import org.eclipse.xtext.ui.workspace.WorkspaceLockAccess;
 import org.eclipse.xtext.util.Pair;
 import org.eclipse.xtext.util.Tuples;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ForwardingMap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -272,7 +272,7 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 	}
 	
 	protected boolean isUpToDate(PackageFragmentRootData data, IPackageFragmentRoot root) {
-		return Objects.equal(data.modificationStamp, computeModificationStamp(root));
+		return Objects.equals(data.modificationStamp, computeModificationStamp(root));
 	}
 	
 	protected Object computeModificationStamp(IPackageFragmentRoot root) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/workspace/EclipseSourceFolder.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/workspace/EclipseSourceFolder.java
@@ -8,11 +8,11 @@
  */
 package org.eclipse.xtext.ui.workspace;
 
+import java.util.Objects;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.workspace.ISourceFolder;
-
-import com.google.common.base.Objects;
 
 public class EclipseSourceFolder implements ISourceFolder {
 
@@ -50,7 +50,7 @@ public class EclipseSourceFolder implements ISourceFolder {
 		if (obj instanceof EclipseSourceFolder) {
 			URI path1 = this.getPath();
 			URI path2 = ((EclipseSourceFolder) obj).getPath();
-			return Objects.equal(path1, path2);
+			return Objects.equals(path1, path2);
 		}
 		return false;
 	}

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/MergeableManifest.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/MergeableManifest.java
@@ -23,11 +23,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 
 /**
@@ -257,7 +257,7 @@ public class MergeableManifest extends Manifest {
 	 */
 	public void setBREE(String bree) {
 		String oldValue = getBREE();
-		if (Objects.equal(oldValue, bree)) {
+		if (Objects.equals(oldValue, bree)) {
 			return;
 		}
 		getMainAttributes().put(BUNDLE_REQUIRED_EXECUTION_ENV, bree);
@@ -276,7 +276,7 @@ public class MergeableManifest extends Manifest {
 	 */
 	public void setBundleActivator(String activator) {
 		String oldValue = getBundleActivator();
-		if (Objects.equal(oldValue, activator)) {
+		if (Objects.equals(oldValue, activator)) {
 			return;
 		}
 		getMainAttributes().put(BUNDLE_ACTIVATOR, activator);

--- a/org.eclipse.xtext.util/src/org/eclipse/xtext/util/formallang/NfaUtil.java
+++ b/org.eclipse.xtext.util/src/org/eclipse/xtext/util/formallang/NfaUtil.java
@@ -15,6 +15,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
 
@@ -22,7 +23,6 @@ import org.eclipse.xtext.util.IAcceptor;
 
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
@@ -355,7 +355,7 @@ public class NfaUtil {
 	public <S> boolean equalsIgnoreOrder(Nfa<S> nfa1, Nfa<S> nfa2, Function<S, ? extends Object> keyFunc) {
 		if (nfa1 == nfa2)
 			return true;
-		if (!Objects.equal(keyFunc.apply(nfa1.getStart()), keyFunc.apply(nfa2.getStart())))
+		if (!Objects.equals(keyFunc.apply(nfa1.getStart()), keyFunc.apply(nfa2.getStart())))
 			return false;
 		return equalsIgnoreOrder(nfa1, nfa2, nfa1.getStart(), nfa2.getStart(), keyFunc, Sets.<S> newHashSet());
 	}

--- a/org.eclipse.xtext.web.servlet/src/main/java/org/eclipse/xtext/web/servlet/XtextServlet.java
+++ b/org.eclipse.xtext.web.servlet/src/main/java/org/eclipse/xtext/web/servlet/XtextServlet.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.web.servlet;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Set;
 
 import jakarta.servlet.ServletException;
@@ -26,7 +27,6 @@ import org.eclipse.xtext.web.server.InvalidRequestException;
 import org.eclipse.xtext.web.server.XtextServiceDispatcher;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.inject.Injector;
@@ -92,7 +92,7 @@ public class XtextServlet extends HttpServlet {
 	protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 		XtextServiceDispatcher.ServiceDescriptor service = getService(req);
 		String type = service.getContext().getParameter(IServiceContext.SERVICE_TYPE);
-		if (!service.isHasConflict() && !Objects.equal(type, "update")) {
+		if (!service.isHasConflict() && !Objects.equals(type, "update")) {
 			super.doPut(req, resp);
 		} else {
 			doService(service, resp);
@@ -104,7 +104,7 @@ public class XtextServlet extends HttpServlet {
 		XtextServiceDispatcher.ServiceDescriptor service = getService(req);
 		String type = service.getContext().getParameter(IServiceContext.SERVICE_TYPE);
 		if (!service.isHasConflict()
-				&& (!service.isHasSideEffects() && !hasTextInput(service) || Objects.equal(type, "update"))) {
+				&& (!service.isHasSideEffects() && !hasTextInput(service) || Objects.equals(type, "update"))) {
 			super.doPost(req, resp);
 		} else {
 			doService(service, resp);

--- a/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/hover/HoverService.java
+++ b/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/hover/HoverService.java
@@ -11,6 +11,7 @@ package org.eclipse.xtext.web.server.hover;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtend2.lib.StringConcatenation;
@@ -38,7 +39,6 @@ import org.eclipse.xtext.web.server.util.ElementAtOffsetUtil;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
@@ -99,7 +99,7 @@ public class HoverService {
 							public void accept(ContentAssistEntry entry, int priority) {
 								operationCanceledManager.checkCanceled(cancelIndicator);
 								if (entry != null && entry.getSource() != null
-										&& Objects.equal(entry.getProposal(), proposal)) {
+										&& Objects.equals(entry.getProposal(), proposal)) {
 									proposedElement.set(entry.getSource());
 								}
 							}

--- a/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/model/XtextWebDocumentAccess.java
+++ b/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/model/XtextWebDocumentAccess.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.xtext.web.server.model;
 
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
@@ -23,7 +24,6 @@ import org.eclipse.xtext.web.server.InvalidRequestException;
 import org.eclipse.xtext.web.server.InvalidRequestException.InvalidDocumentStateException;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -143,7 +143,7 @@ public class XtextWebDocumentAccess {
 	}
 
 	protected void checkStateId() throws InvalidRequestException.InvalidDocumentStateException {
-		if (requiredStateId != null && !Objects.equal(requiredStateId, document.getStateId())) {
+		if (requiredStateId != null && !Objects.equals(requiredStateId, document.getStateId())) {
 			throw new InvalidRequestException.InvalidDocumentStateException(
 					"The given state id does not match the current state.");
 		}

--- a/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/occurrences/OccurrencesService.java
+++ b/org.eclipse.xtext.web/src/main/java/org/eclipse/xtext/web/server/occurrences/OccurrencesService.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.xtext.web.server.occurrences;
 
+import java.util.Objects;
+
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
@@ -26,7 +28,6 @@ import org.eclipse.xtext.web.server.model.XtextWebDocumentAccess;
 import org.eclipse.xtext.web.server.util.CancelIndicatorProgressMonitor;
 import org.eclipse.xtext.web.server.util.ElementAtOffsetUtil;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
@@ -77,7 +78,7 @@ public class OccurrencesService {
 					};
 					referenceFinder.findReferences(targetURIs, doc.getResource(), acceptor,
 							new CancelIndicatorProgressMonitor(cancelIndicator));
-					if (Objects.equal(element.eResource(), doc.getResource())) {
+					if (Objects.equals(element.eResource(), doc.getResource())) {
 						ITextRegion definitionRegion = locationInFileProvider.getSignificantTextRegion(element);
 						if (definitionRegion != null
 								&& definitionRegion != ITextRegionWithLineInformation.EMPTY_REGION) {

--- a/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/contentassist/ClasspathBasedIdeTypesProposalProvider.java
+++ b/org.eclipse.xtext.xbase.ide/src/org/eclipse/xtext/xbase/ide/contentassist/ClasspathBasedIdeTypesProposalProvider.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.xbase.ide.contentassist;
 
 import java.lang.reflect.Modifier;
 import java.util.Collections;
+import java.util.Objects;
 
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -31,7 +32,6 @@ import org.eclipse.xtext.xtype.XImportDeclaration;
 import org.eclipse.xtext.xtype.XImportSection;
 import org.eclipse.xtext.xtype.XtypePackage;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -154,7 +154,7 @@ public class ClasspathBasedIdeTypesProposalProvider implements IIdeTypesProposal
 							if (it.getImportedType() != null) {
 								importFqn = it.getImportedType().getQualifiedName();
 							}
-							return Objects.equal(importFqn, qualifiedName);
+							return Objects.equals(importFqn, qualifiedName);
 						}));
 	}
 

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/MapExtensions.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/MapExtensions.java
@@ -11,6 +11,7 @@ package org.eclipse.xtext.xbase.lib;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.Functions.Function2;
@@ -20,7 +21,6 @@ import org.eclipse.xtext.xbase.lib.internal.FunctionDelegate;
 import org.eclipse.xtext.xbase.lib.internal.UnmodifiableMergingMapView;
 
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -229,7 +229,7 @@ import com.google.common.collect.Maps;
 		//TODO use the JRE 1.8 API: map.remove(entry.getKey(), entry.getValue());
 		final K key = entry.getKey();
 		final V storedValue = map.get(entry.getKey());
-	        if (!Objects.equal(storedValue, entry.getValue())
+	        if (!Objects.equals(storedValue, entry.getValue())
 			|| (storedValue == null && !map.containsKey(key))) {
 	            return false;
         	}
@@ -278,7 +278,7 @@ import com.google.common.collect.Maps;
 		return Maps.filterEntries(left, new Predicate<Entry<K, V>>() {
 			@Override
 			public boolean apply(Entry<K, V> input) {
-				return !Objects.equal(input.getKey(), right.getKey()) || !Objects.equal(input.getValue(), right.getValue());
+				return !Objects.equals(input.getKey(), right.getKey()) || !Objects.equals(input.getValue(), right.getValue());
 			}
 		});
 	}
@@ -303,7 +303,7 @@ import com.google.common.collect.Maps;
 		return Maps.filterKeys(map, new Predicate<K>() {
 			@Override
 			public boolean apply(K input) {
-				return !Objects.equal(input, key);
+				return !Objects.equals(input, key);
 			}
 		});
 	}
@@ -341,7 +341,7 @@ import com.google.common.collect.Maps;
 				if (value == null) {
 					return input.getValue() == null && right.containsKey(input.getKey());
 				}
-				return !Objects.equal(input.getValue(), value);
+				return !Objects.equals(input.getValue(), value);
 			}
 		});
 	}

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/Pair.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/Pair.java
@@ -9,9 +9,9 @@
 package org.eclipse.xtext.xbase.lib;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.base.Objects;
 
 /**
  * An immutable pair of {@link #getKey() key} and {@link #getValue() value}. A pair is considered to be
@@ -87,7 +87,7 @@ import com.google.common.base.Objects;
 		if (!(o instanceof Pair))
 			return false;
 		Pair<?, ?> e = (Pair<?, ?>) o;
-		return Objects.equal(k, e.getKey()) && Objects.equal(v, e.getValue());
+		return Objects.equals(k, e.getKey()) && Objects.equals(v, e.getValue());
 	}
 
 	@Override

--- a/org.eclipse.xtext.xbase.testdata/src/testdata/AssertJLikeAssertions.java
+++ b/org.eclipse.xtext.xbase.testdata/src/testdata/AssertJLikeAssertions.java
@@ -9,7 +9,7 @@
 
 package testdata;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 public class AssertJLikeAssertions {
 
@@ -40,7 +40,7 @@ public class AssertJLikeAssertions {
 
 		@Override
 		public IntegerAssert isEqualTo(int expected) {
-			if (!Objects.equal(expected, value)) {
+			if (!Objects.equals(expected, value)) {
 				throw new AssertJLikeException(expected + " != " + value);
 			}
 			return this;

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/ExpressionScopeTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/typesystem/ExpressionScopeTest.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.xtext.xbase.tests.typesystem;
 
+import java.util.Objects;
+
 import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.scoping.IScope;
@@ -26,7 +28,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 
@@ -48,7 +49,7 @@ public class ExpressionScopeTest extends AbstractXbaseTestCase {
 		String toString = elements.toString();
 		assertNotNull(toString, scope.getSingleElement(name));
 		assertFalse(toString, Iterables.isEmpty(scope.getElements(name)));
-		assertTrue(toString, IterableExtensions.exists(elements, it -> Objects.equal(it.getName(), name)));
+		assertTrue(toString, IterableExtensions.exists(elements, it -> Objects.equals(it.getName(), name)));
 	}
 
 	protected void containsNot(IExpressionScope scope, String name) {
@@ -60,7 +61,7 @@ public class ExpressionScopeTest extends AbstractXbaseTestCase {
 		String toString = elements.toString();
 		assertNull(toString, scope.getSingleElement(name));
 		assertTrue(toString, Iterables.isEmpty(scope.getElements(name)));
-		assertFalse(toString, IterableExtensions.exists(elements, it -> Objects.equal(it.getName(), name)));
+		assertFalse(toString, IterableExtensions.exists(elements, it -> Objects.equals(it.getName(), name)));
 	}
 
 	@Test

--- a/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/AbstractFormatter.java
+++ b/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/AbstractFormatter.java
@@ -9,14 +9,13 @@
 package org.eclipse.xtext.xbase.formatting;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.formatting2.AbstractFormatter2;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.Pure;
-
-import com.google.common.base.Objects;
 
 /**
  * @deprecated use {@link AbstractFormatter2}
@@ -45,7 +44,7 @@ public abstract class AbstractFormatter implements IBasicFormatter {
 			return edits;
 		} else {
 			return IterableExtensions.toList(IterableExtensions.filter(edits, (TextReplacement it) -> {
-				return !Objects.equal(doc.substring(it.getOffset(), (it.getOffset() + it.getLength())), it.getText());
+				return !Objects.equals(doc.substring(it.getOffset(), (it.getOffset() + it.getLength())), it.getText());
 			}));
 		}
 	}

--- a/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/HiddenLeafAccess.java
+++ b/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/HiddenLeafAccess.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.xbase.formatting;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.xtext.formatting2.regionaccess.ITextRegionAccess;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
@@ -20,7 +21,6 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
 
@@ -150,7 +150,7 @@ public class HiddenLeafAccess {
 			NodeIterator ni = new NodeIterator(current);
 			while (ni.hasPrevious()) {
 				INode previous = ni.previous();
-				if (!Objects.equal(previous, current) && previous instanceof ILeafNode) {
+				if (!Objects.equals(previous, current) && previous instanceof ILeafNode) {
 					if (((ILeafNode) previous).isHidden()) {
 						result.add((ILeafNode) previous);
 					} else { // if(!result.empty)

--- a/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/NodeModelAccess.java
+++ b/org.eclipse.xtext.xbase/deprecated/org/eclipse/xtext/xbase/formatting/NodeModelAccess.java
@@ -8,8 +8,10 @@
  */
 package org.eclipse.xtext.xbase.formatting;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
+
+import java.util.Objects;
+
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.xtext.Keyword;
@@ -34,15 +36,15 @@ public class NodeModelAccess {
 	public ILeafNode nodeForKeyword(EObject obj, String kw) {
 		ICompositeNode node = NodeModelUtils.findActualNodeFor(obj);
 		return (ILeafNode) IterableExtensions.findFirst(node.getAsTreeIterable(),
-				(INode it) -> Objects.equal(it.getSemanticElement(), obj) && it.getGrammarElement() instanceof Keyword
-						&& Objects.equal(it.getText(), kw));
+				(INode it) -> Objects.equals(it.getSemanticElement(), obj) && it.getGrammarElement() instanceof Keyword
+						&& Objects.equals(it.getText(), kw));
 	}
 
 	public Iterable<ILeafNode> nodesForKeyword(EObject obj, String kw) {
 		ICompositeNode node = NodeModelUtils.findActualNodeFor(obj);
 		Iterable<ILeafNode> leafNodes = Iterables.filter(node.getAsTreeIterable(), ILeafNode.class);
-		return Iterables.filter(leafNodes, n -> Objects.equal(n.getSemanticElement(), obj)
-				&& n.getGrammarElement() instanceof Keyword && Objects.equal(n.getText(), kw));
+		return Iterables.filter(leafNodes, n -> Objects.equals(n.getSemanticElement(), obj)
+				&& n.getGrammarElement() instanceof Keyword && Objects.equals(n.getText(), kw));
 	}
 
 	public INode nodeForFeature(EObject obj, EStructuralFeature feature) {
@@ -64,8 +66,8 @@ public class NodeModelAccess {
 		}
 		INode current1 = current;
 		ILeafNode result = findNextLeaf(current1,
-				n -> !Objects.equal(current1, n) && n.getGrammarElement() instanceof Keyword);
-		if (result != null && Objects.equal(result.getText(), kw)) {
+				n -> !Objects.equals(current1, n) && n.getGrammarElement() instanceof Keyword);
+		if (result != null && Objects.equals(result.getText(), kw)) {
 			return result;
 		}
 		return null;

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/ErrorSafeExtensions.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/ErrorSafeExtensions.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.xtext.xbase.compiler;
 
+import java.util.Objects;
+
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.common.types.JvmAnnotationReference;
 import org.eclipse.xtext.common.types.JvmSpecializedTypeReference;
@@ -22,7 +24,6 @@ import org.eclipse.xtext.xbase.lib.ObjectExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure2;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 
@@ -100,7 +101,7 @@ public class ErrorSafeExtensions {
 	}
 
 	protected ITreeAppendable closeErrorAppendable(ITreeAppendable parent, ITreeAppendable child) {
-		if (child instanceof ErrorTreeAppendable && !Objects.equal(child, parent)) {
+		if (child instanceof ErrorTreeAppendable && !Objects.equals(child, parent)) {
 			child.append(" */");
 		}
 		return parent;

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/output/ImportingStringConcatenation.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/output/ImportingStringConcatenation.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.xbase.compiler.output;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.common.types.JvmType;
@@ -21,8 +22,6 @@ import org.eclipse.xtext.xbase.typesystem.references.ITypeReferenceOwner;
 import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReference;
 import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReferenceFactory;
 import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReferenceSerializer;
-
-import com.google.common.base.Objects;
 
 /**
  * A specialized {@link StringConcatenation} that will properly convert
@@ -73,7 +72,7 @@ public class ImportingStringConcatenation extends StringConcatenation {
 	@Override
 	protected List<String> getSignificantContent() {
 		List<String> result = super.getSignificantContent();
-		if (result.size() >= 1 && Objects.equal(getLineDelimiter(), IterableExtensions.lastOrNull(result))) {
+		if (result.size() >= 1 && Objects.equals(getLineDelimiter(), IterableExtensions.lastOrNull(result))) {
 			return result.subList(0, result.size() - 1);
 		}
 		return result;

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/controlflow/EarlyExitInterpreter.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/controlflow/EarlyExitInterpreter.java
@@ -8,11 +8,11 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.controlflow;
 
+import java.util.Objects;
+
 import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.interpreter.ConstantExpressionEvaluationException;
 import org.eclipse.xtext.xbase.interpreter.SwitchConstantExpressionsInterpreter;
-
-import com.google.common.base.Objects;
 
 /**
  * @author Sebastian Zarnekow - Initial contribution and API
@@ -21,7 +21,7 @@ public class EarlyExitInterpreter extends SwitchConstantExpressionsInterpreter {
 	public boolean isConstant(XExpression it, Object value) {
 		try {
 			Object constant = evaluate(it);
-			return Objects.equal(value, constant);
+			return Objects.equals(value, constant);
 		} catch (ConstantExpressionEvaluationException e) {
 			return false;
 		}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/RewritableImportSection.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/imports/RewritableImportSection.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.xtext.common.types.JvmDeclaredType;
@@ -42,7 +43,6 @@ import org.eclipse.xtext.xtype.XImportDeclaration;
 import org.eclipse.xtext.xtype.XImportSection;
 import org.eclipse.xtext.xtype.XtypeFactory;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -611,7 +611,7 @@ public class RewritableImportSection {
 		for (XImportDeclaration importDeclr : addedImportDeclarations) {
 			String identifier = importDeclr.getImportedTypeName();
 			if (importDeclr.isStatic() && typeName.equals(identifier)) {
-				if (Objects.equal(importDeclr.getMemberName(), memberName) || importDeclr.isWildcard() || "*".equals(importDeclr.getMemberName())) {
+				if (Objects.equals(importDeclr.getMemberName(), memberName) || importDeclr.isWildcard() || "*".equals(importDeclr.getMemberName())) {
 					return true;
 				}
 			}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/UniqueClassNameValidator.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/UniqueClassNameValidator.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.xbase.validation;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.emf.common.util.URI;
@@ -31,7 +32,6 @@ import org.eclipse.xtext.validation.EValidatorRegistrar;
 import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociations;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 
@@ -64,7 +64,7 @@ public class UniqueClassNameValidator extends AbstractDeclarativeValidator {
 	public void checkUniqueName(EObject root) {
 		if (root.eContainer() == null) {
 			Resource resource = root.eResource();
-			if (Objects.equal(Iterables.getFirst(resource.getContents(), null), root)) {
+			if (Objects.equals(Iterables.getFirst(resource.getContents(), null), root)) {
 				for (EObject o : resource.getContents()) {
 					if (o instanceof JvmDeclaredType) {
 						doCheckUniqueName((JvmDeclaredType) o);
@@ -97,7 +97,7 @@ public class UniqueClassNameValidator extends AbstractDeclarativeValidator {
 		}
 		if (resourceURIs.size() > 1) {
 			for (URI uri : resourceURIs) {
-				if (!Objects.equal(uri, type.eResource().getURI())) {
+				if (!Objects.equals(uri, type.eResource().getURI())) {
 					addIssue(type, uri.lastSegment());
 					break;
 				}

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/XbaseValidator.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/validation/XbaseValidator.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.emf.common.notify.Adapter;
@@ -136,7 +137,6 @@ import org.eclipse.xtext.xtype.XImportSection;
 import org.eclipse.xtext.xtype.XtypePackage;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
@@ -1207,7 +1207,7 @@ public class XbaseValidator extends AbstractXbaseValidator {
 				}
 				continue;
 			}
-			if (Objects.equal(member.getSimpleName(), staticImportDeclaration.getMemberName())) {
+			if (Objects.equals(member.getSimpleName(), staticImportDeclaration.getMemberName())) {
 				indexToRemove = i;
 				break;
 			}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.java
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/XtextGenerator.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
@@ -41,7 +42,6 @@ import org.eclipse.xtext.xtext.generator.model.PluginXmlAccess;
 import org.eclipse.xtext.xtext.generator.model.project.BundleProjectConfig;
 import org.eclipse.xtext.xtext.generator.model.project.IXtextProjectConfig;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -409,7 +409,7 @@ public class XtextGenerator extends AbstractWorkflowComponent2 {
 					if (textFile != null) {
 						textFileContent = textFile.toString();
 					}
-					if (!Objects.equal(textFileContent, pluginXml.getContentString())) {
+					if (!Objects.equals(textFileContent, pluginXml.getContentString())) {
 						if (pluginXml.getPath().endsWith(".xml")) {
 							pluginXml.setPath(pluginXml.getPath() + "_gen");
 							pluginXml.writeTo(root);

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/GuiceModuleAccess.java
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/GuiceModuleAccess.java
@@ -13,13 +13,12 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.eclipse.xtend2.lib.StringConcatenationClient;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
-
-import com.google.common.base.Objects;
 
 /**
  * Configuration object for Guice modules based on
@@ -41,8 +40,8 @@ public class GuiceModuleAccess {
 		@Override
 		public boolean equals(Object other) {
 			if (other instanceof GuiceModuleAccess.BindKey) {
-				return Objects.equal(this.name, ((GuiceModuleAccess.BindKey) other).name)
-						&& Objects.equal(this.type, ((GuiceModuleAccess.BindKey) other).type);
+				return Objects.equals(this.name, ((GuiceModuleAccess.BindKey) other).name)
+						&& Objects.equals(this.type, ((GuiceModuleAccess.BindKey) other).type);
 			} else {
 				return false;
 			}
@@ -188,7 +187,7 @@ public class GuiceModuleAccess {
 		@Override
 		public boolean equals(Object other) {
 			if (other instanceof GuiceModuleAccess.Binding) {
-				return Objects.equal(this.key, ((GuiceModuleAccess.Binding) other).key);
+				return Objects.equals(this.key, ((GuiceModuleAccess.Binding) other).key);
 			} else {
 				return false;
 			}
@@ -401,7 +400,7 @@ public class GuiceModuleAccess {
 			boolean found = false;
 			while (iterator.hasNext() && !found) {
 				GuiceModuleAccess.Binding oldBinding = iterator.next();
-				if (Objects.equal(oldBinding, newBinding)) {
+				if (Objects.equals(oldBinding, newBinding)) {
 					if (oldBinding.isFinal) {
 						if (newBinding.isFinal) {
 							throw new IllegalStateException(

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/StandardProjectConfig.java
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/model/project/StandardProjectConfig.java
@@ -8,10 +8,10 @@
  */
 package org.eclipse.xtext.xtext.generator.model.project;
 
+import java.util.Objects;
+
 import org.eclipse.emf.mwe2.runtime.Mandatory;
 import org.eclipse.xtext.xtext.generator.Issues;
-
-import com.google.common.base.Objects;
 
 /**
  * Specialized project configuration that uses standard names and paths. Usually
@@ -110,25 +110,25 @@ public class StandardProjectConfig extends XtextProjectConfig {
 	}
 
 	protected String computeName(SubProjectConfig project) {
-		if (Objects.equal(project, getRuntime())) {
+		if (Objects.equals(project, getRuntime())) {
 			return baseName;
-		} else if (Objects.equal(project, getRuntimeTest())) {
+		} else if (Objects.equals(project, getRuntimeTest())) {
 			if (!mavenLayout) {
 				return baseName + ".tests";
 			} else {
 				return baseName;
 			}
-		} else if (Objects.equal(project, getGenericIde())) {
+		} else if (Objects.equals(project, getGenericIde())) {
 			return baseName + ".ide";
-		} else if (Objects.equal(project, getEclipsePlugin())) {
+		} else if (Objects.equals(project, getEclipsePlugin())) {
 			return baseName + ".ui";
-		} else if (Objects.equal(project, getEclipsePluginTest())) {
+		} else if (Objects.equals(project, getEclipsePluginTest())) {
 			if (!mavenLayout) {
 				return baseName + ".ui.tests";
 			} else {
 				return baseName + ".ui";
 			}
-		} else if (Objects.equal(project, getWeb())) {
+		} else if (Objects.equals(project, getWeb())) {
 			return baseName + ".web";
 		}
 		return null;

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/EqualAmbiguousTransitions.java
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/serializer/EqualAmbiguousTransitions.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.xtext.generator.serializer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.xtext.AbstractElement;
 import org.eclipse.xtext.grammaranalysis.impl.GrammarElementTitleSwitch;
@@ -19,7 +20,6 @@ import org.eclipse.xtext.util.formallang.Production;
 import org.eclipse.xtext.util.formallang.ProductionFormatter;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 
 /**
@@ -62,7 +62,7 @@ public class EqualAmbiguousTransitions implements Comparable<EqualAmbiguousTrans
 				@Override
 				public String format(Production<GrammarAlias.AbstractElementAlias, AbstractElement> adapter,
 						GrammarAlias.AbstractElementAlias grammarElement, boolean needParenthesis) {
-					if (Objects.equal(grammarElement, elementAlias)) {
+					if (Objects.equals(grammarElement, elementAlias)) {
 						return "(ambiguity)";
 					}
 					if (grammarElement instanceof GrammarAlias.TokenAlias) {
@@ -87,13 +87,13 @@ public class EqualAmbiguousTransitions implements Comparable<EqualAmbiguousTrans
 	}
 
 	private boolean isStart(GrammarAlias.TokenAlias it) {
-		return (it.getToken() == null && it.getParent() instanceof GrammarAlias.GroupAlias && Objects.equal(it,
+		return (it.getToken() == null && it.getParent() instanceof GrammarAlias.GroupAlias && Objects.equals(it,
 				Iterables.getFirst(((GrammarAlias.GroupAlias) it.getParent()).getChildren(), null)));
 	}
 
 	private boolean isStop(GrammarAlias.TokenAlias it) {
 		return (it.getToken() == null && it.getParent() instanceof GrammarAlias.GroupAlias
-				&& Objects.equal(it, IterableExtensions.<GrammarAlias.AbstractElementAlias>lastOrNull(
+				&& Objects.equals(it, IterableExtensions.<GrammarAlias.AbstractElementAlias>lastOrNull(
 						((GrammarAlias.GroupAlias) it.getParent()).getChildren())));
 	}
 

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/util/GenModelUtil2.java
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/util/GenModelUtil2.java
@@ -8,6 +8,8 @@
  */
 package org.eclipse.xtext.xtext.generator.util;
 
+import java.util.Objects;
+
 import org.eclipse.emf.codegen.ecore.genmodel.GenClass;
 import org.eclipse.emf.codegen.ecore.genmodel.GenClassifier;
 import org.eclipse.emf.codegen.ecore.genmodel.GenDataType;
@@ -28,7 +30,6 @@ import org.eclipse.emf.ecore.plugin.EcorePlugin;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.xtext.generator.ecore.EMFGeneratorFragment2;
-import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 
 public class GenModelUtil2 {
@@ -39,7 +40,7 @@ public class GenModelUtil2 {
 	public static GenClassifier getGenClassifier(EClassifier cls, ResourceSet resourceSet) {
 		GenPackage genPackage = GenModelUtil2.getGenPackage(cls.getEPackage(), resourceSet);
 		for (GenClassifier genCls : genPackage.getGenClassifiers()) {
-			if (Objects.equal(cls.getName(), genCls.getEcoreClassifier().getName())) {
+			if (Objects.equals(cls.getName(), genCls.getEcoreClassifier().getName())) {
 				return genCls;
 			}
 		}
@@ -57,7 +58,7 @@ public class GenModelUtil2 {
 	public static GenFeature getGenFeature(EStructuralFeature feature, ResourceSet resourceSet) {
 		GenClass genCls = (GenClass) GenModelUtil2.getGenClassifier(feature.getEContainingClass(), resourceSet);
 		for (GenFeature genFeat : genCls.getGenFeatures()) {
-			if (Objects.equal(feature.getName(), genFeat.getEcoreFeature().getName())) {
+			if (Objects.equals(feature.getName(), genFeat.getEcoreFeature().getName())) {
 				return genFeat;
 			}
 		}
@@ -95,7 +96,7 @@ public class GenModelUtil2 {
 			ResourceSet resourceSet) {
 		URI genModelURI = EcorePlugin.getEPackageNsURIToGenModelLocationMap(false).get(nsURI);
 		if (genModelURI == null) {
-			if (Objects.equal(EcorePackage.eNS_URI, nsURI)) { // If we really want to use the registered ecore ...
+			if (Objects.equals(EcorePackage.eNS_URI, nsURI)) { // If we really want to use the registered ecore ...
 				return null; // look into the resource set to find a genpackage
 								// for the given URI
 			}
@@ -107,7 +108,7 @@ public class GenModelUtil2 {
 				for (EObject obj : res.getContents()) {
 					if (obj instanceof GenModel) {
 						for (GenPackage genPackage : ((GenModel) obj).getGenPackages()) {
-							if (Objects.equal(genPackage.getNSURI(), nsURI)) {
+							if (Objects.equals(genPackage.getNSURI(), nsURI)) {
 								return genPackage.eResource();
 							}
 						}
@@ -187,10 +188,10 @@ public class GenModelUtil2 {
 	public static String getGetAccessor(GenFeature genFeature, ResourceSet resourceSet) {
 		GenClass genClass = genFeature.getGenClass();
 		if (genClass.isMapEntry()) {
-			if (Objects.equal(genFeature, genClass.getMapEntryKeyFeature())) {
+			if (Objects.equals(genFeature, genClass.getMapEntryKeyFeature())) {
 				return "getKey";
 			}
-			if (Objects.equal(genFeature, genClass.getMapEntryValueFeature())) {
+			if (Objects.equals(genFeature, genClass.getMapEntryValueFeature())) {
 				return "getValue";
 			}
 		}

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/util/GrammarUtil2.java
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/util/GrammarUtil2.java
@@ -8,16 +8,16 @@
  */
 package org.eclipse.xtext.xtext.generator.util;
 
+import java.util.Objects;
+
 import org.eclipse.xtext.Grammar;
 import org.eclipse.xtext.GrammarUtil;
-
-import com.google.common.base.Objects;
 
 public class GrammarUtil2 extends GrammarUtil {
 	public static final String TERMINALS = "org.eclipse.xtext.common.Terminals";
 
 	public static boolean inherits(Grammar grammar, String languageID) {
-		if (Objects.equal(grammar.getName(), languageID)) {
+		if (Objects.equals(grammar.getName(), languageID)) {
 			return true;
 		}
 		for (Grammar g : grammar.getUsedGrammars()) {

--- a/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/util/SyntheticTerminalDetector.java
+++ b/org.eclipse.xtext.xtext.generator/src/org/eclipse/xtext/xtext/generator/util/SyntheticTerminalDetector.java
@@ -12,8 +12,6 @@ import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.TerminalRule;
 import org.eclipse.xtext.xtext.generator.parser.antlr.AntlrGrammarGenUtil;
 
-import com.google.common.base.Objects;
-
 /** 
  * Helper to identify synthetic terminal rules.
  * This implementation answers <code>true</code> for any terminal rule that has a body in the form
@@ -32,7 +30,7 @@ public class SyntheticTerminalDetector {
 		if (rule.getAlternatives() instanceof Keyword) {
 			String value = ((Keyword) rule.getAlternatives()).getValue();
 			String sytheticValue = "synthetic:" + AntlrGrammarGenUtil.getOriginalElement(rule).getName();
-			return Objects.equal(sytheticValue, value);
+			return sytheticValue.equals(value);
 		}
 		return false;
 	}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.example.arithmetics.ui.autoedit;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentCommand;
@@ -22,7 +23,6 @@ import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 
@@ -36,7 +36,7 @@ public class InterpreterAutoEdit implements IAutoEditStrategy {
 	@Override
 	public void customizeDocumentCommand(IDocument document, DocumentCommand command) {
 		for (String lineDelimiter : document.getLegalLineDelimiters()) {
-			if (Objects.equal(command.text, lineDelimiter)) {
+			if (Objects.equals(command.text, lineDelimiter)) {
 				try {
 					int line = document.getLineOfOffset(command.offset);
 					int lineStart = document.getLineOffset(line);

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/formatting2/StatemachineFormatter.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/formatting2/StatemachineFormatter.java
@@ -13,6 +13,7 @@ import static org.eclipse.xtext.example.fowlerdsl.statemachine.StatemachinePacka
 import static org.eclipse.xtext.example.fowlerdsl.statemachine.StatemachinePackage.Literals.STATE__NAME;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.xtext.example.fowlerdsl.services.StatemachineGrammarAccess;
 import org.eclipse.xtext.example.fowlerdsl.statemachine.Command;
@@ -25,7 +26,6 @@ import org.eclipse.xtext.formatting2.IFormattableDocument;
 import org.eclipse.xtext.formatting2.regionaccess.ISemanticRegion;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -194,7 +194,7 @@ public class StatemachineFormatter extends AbstractJavaFormatter {
 
 	private boolean isLastState(State state) {
 		Statemachine statemachine = (Statemachine) state.eContainer();
-		return Objects.equal(state, Iterables.getLast(statemachine.getStates()));
+		return Objects.equals(state, Iterables.getLast(statemachine.getStates()));
 	}
 
 }

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestedProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TestedProjectDescriptor.java
@@ -11,11 +11,11 @@ package org.eclipse.xtext.xtext.wizard;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 
 public abstract class TestedProjectDescriptor extends ProjectDescriptor {
@@ -52,7 +52,7 @@ public abstract class TestedProjectDescriptor extends ProjectDescriptor {
 		if (getTestProject().isInlined()) {
 			Iterable<? extends AbstractFile> filtered = IterableExtensions.filter(getTestProject().getFiles(),
 					(AbstractFile fileFromTestProject) -> files.stream()
-							.noneMatch(f -> Objects.equal(f.getRelativePath(), fileFromTestProject.getRelativePath())));
+							.noneMatch(f -> Objects.equals(f.getRelativePath(), fileFromTestProject.getRelativePath())));
 			Iterables.addAll(files, filtered);
 		}
 		return files;

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextExtensions.java
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ecore2xtext/Ecore2XtextExtensions.java
@@ -26,7 +26,6 @@ import org.eclipse.xtext.xtext.wizard.EPackageInfo;
 import org.eclipse.xtext.xtext.wizard.Ecore2XtextConfiguration;
 
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -249,11 +248,11 @@ public class Ecore2XtextExtensions {
 	}
 
 	public static boolean isPrefixBooleanFeature(EStructuralFeature it) {
-		return isBoolean(it.getEType()) && !it.isMany() && !Objects.equal(it.getDefaultValueLiteral(), "true");
+		return isBoolean(it.getEType()) && !it.isMany() && !"true".equals(it.getDefaultValueLiteral());
 	}
 
 	public static boolean isString(EClassifier it) {
-		return it instanceof EDataType && Objects.equal(it.getName(), "EString") && isEcoreType(it);
+		return it instanceof EDataType && "EString".equals(it.getName()) && isEcoreType(it);
 	}
 
 	public static boolean isEcoreType(EClassifier it) {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/IShouldGenerate.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/IShouldGenerate.java
@@ -11,6 +11,7 @@ package org.eclipse.xtext.generator;
 import static org.eclipse.xtext.xbase.lib.IterableExtensions.*;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.diagnostics.Severity;
@@ -20,7 +21,6 @@ import org.eclipse.xtext.validation.IResourceValidator;
 import org.eclipse.xtext.validation.Issue;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -45,7 +45,7 @@ public interface IShouldGenerate {
 				return false;
 			}
 			List<Issue> issues = resourceValidator.validate(resource, CheckMode.NORMAL_AND_FAST, cancelIndicator);
-			return !exists(issues, (Issue issue) -> Objects.equal(issue.getSeverity(), Severity.ERROR));
+			return !exists(issues, (Issue issue) -> Objects.equals(issue.getSeverity(), Severity.ERROR));
 		}
 	}
 

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/OutputConfiguration.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/OutputConfiguration.java
@@ -8,9 +8,9 @@
  *******************************************************************************/
 package org.eclipse.xtext.generator;
 
+import java.util.Objects;
 import java.util.Set;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 
@@ -317,7 +317,7 @@ public class OutputConfiguration {
 		public boolean equals(Object obj) {
 			if (obj instanceof SourceMapping) {
 				SourceMapping other = (SourceMapping) obj;
-				return Objects.equal(sourceFolder, other.sourceFolder);
+				return Objects.equals(sourceFolder, other.sourceFolder);
 			}
 			return false;
 		}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/AbsoluteURI.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/AbsoluteURI.java
@@ -8,11 +8,11 @@
  */
 package org.eclipse.xtext.generator.trace;
 
+import java.util.Objects;
+
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.workspace.IProjectConfig;
 import org.eclipse.xtext.workspace.ISourceFolder;
-
-import com.google.common.base.Objects;
 
 /**
  * An absolute URI that allows to obtain a resource in a {@link IProjectConfig project}.
@@ -50,7 +50,7 @@ public class AbsoluteURI extends AbstractURIWrapper {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj != null && !Objects.equal(obj.getClass(), AbsoluteURI.class)) {
+		if (obj != null && !Objects.equals(obj.getClass(), AbsoluteURI.class)) {
 			throw new IllegalArgumentException(obj.toString() + " instanceof " + obj.getClass().getName());
 		}
 		return super.equals(obj);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/SourceRelativeURI.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/generator/trace/SourceRelativeURI.java
@@ -8,9 +8,9 @@
  */
 package org.eclipse.xtext.generator.trace;
 
-import org.eclipse.emf.common.util.URI;
+import java.util.Objects;
 
-import com.google.common.base.Objects;
+import org.eclipse.emf.common.util.URI;
 
 /**
  * A source relative URI.
@@ -38,7 +38,7 @@ public class SourceRelativeURI extends AbstractURIWrapper {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj != null && !Objects.equal(obj.getClass(), SourceRelativeURI.class)) {
+		if (obj != null && !Objects.equals(obj.getClass(), SourceRelativeURI.class)) {
 			throw new IllegalArgumentException(obj.toString() + " instanceof " + obj.getClass().getName());
 		}
 		return super.equals(obj);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/serializer/analysis/GrammarAlias.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/serializer/analysis/GrammarAlias.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.serializer.analysis;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.xtext.AbstractElement;
@@ -19,7 +20,6 @@ import org.eclipse.xtext.util.formallang.ProductionFactory;
 import org.eclipse.xtext.util.formallang.ProductionFormatter;
 
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -234,7 +234,7 @@ public class GrammarAlias {
 			if (obj == null || obj.getClass() != getClass())
 				return false;
 			TokenAlias other = (TokenAlias) obj;
-			return many == other.many && optional == other.optional && Objects.equal(token, other.token);
+			return many == other.many && optional == other.optional && Objects.equals(token, other.token);
 		}
 
 		public AbstractElement getToken() {

--- a/org.eclipse.xtext/src/org/eclipse/xtext/serializer/analysis/SerializationContext.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/serializer/analysis/SerializationContext.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.serializer.analysis;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.emf.common.util.EList;
@@ -27,7 +28,6 @@ import org.eclipse.xtext.serializer.ISerializationContext;
 import org.eclipse.xtext.xtext.ConditionEvaluator;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -253,13 +253,13 @@ public abstract class SerializationContext implements ISerializationContext {
 	}
 
 	private boolean equalsInternal(ISerializationContext other) {
-		if (!Objects.equal(getParserRule(), other.getParserRule()))
+		if (!Objects.equals(getParserRule(), other.getParserRule()))
 			return false;
-		if (!Objects.equal(getAssignedAction(), other.getAssignedAction()))
+		if (!Objects.equals(getAssignedAction(), other.getAssignedAction()))
 			return false;
-		if (!Objects.equal(getEnabledBooleanParameters(), other.getEnabledBooleanParameters()))
+		if (!Objects.equals(getEnabledBooleanParameters(), other.getEnabledBooleanParameters()))
 			return false;
-		if (!Objects.equal(getType(), other.getType()))
+		if (!Objects.equals(getType(), other.getType()))
 			return false;
 		return true;
 	}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/validation/CompositeEValidator.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/validation/CompositeEValidator.java
@@ -12,6 +12,7 @@ package org.eclipse.xtext.validation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.BasicDiagnostic;
@@ -25,7 +26,6 @@ import org.eclipse.emf.ecore.util.EObjectValidator;
 import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.service.OperationCanceledManager;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.name.Named;
@@ -65,7 +65,7 @@ public class CompositeEValidator implements EValidator, Cloneable {
 					AbstractInjectableValidator otherCasted = (AbstractInjectableValidator) otherDelegate;
 					if (casted.isLanguageSpecific() == otherCasted.isLanguageSpecific()) {
 						if (casted.isLanguageSpecific()) {
-							return Objects.equal(casted.getLanguageName(), otherCasted.getLanguageName());
+							return Objects.equals(casted.getLanguageName(), otherCasted.getLanguageName());
 						}
 						return true;
 					}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/workspace/FileProjectConfig.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/workspace/FileProjectConfig.java
@@ -12,12 +12,11 @@ import static org.eclipse.xtext.xbase.lib.IterableExtensions.*;
 
 import java.io.File;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.util.UriUtil;
-
-import com.google.common.base.Objects;
 
 public class FileProjectConfig implements IProjectConfig {
 	private final URI path;
@@ -76,7 +75,7 @@ public class FileProjectConfig implements IProjectConfig {
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof FileProjectConfig) {
-			return Objects.equal(path, ((FileProjectConfig) obj).path);
+			return Objects.equals(path, ((FileProjectConfig) obj).path);
 		}
 		return false;
 	}

--- a/org.eclipse.xtext/src/org/eclipse/xtext/workspace/FileSourceFolder.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/workspace/FileSourceFolder.java
@@ -8,9 +8,9 @@
  */
 package org.eclipse.xtext.workspace;
 
-import org.eclipse.emf.common.util.URI;
+import java.util.Objects;
 
-import com.google.common.base.Objects;
+import org.eclipse.emf.common.util.URI;
 
 public class FileSourceFolder implements ISourceFolder {
 	private final FileProjectConfig parent;
@@ -42,7 +42,7 @@ public class FileSourceFolder implements ISourceFolder {
 		if (obj instanceof FileSourceFolder) {
 			URI path1 = this.getPath();
 			URI path2 = ((FileSourceFolder) obj).getPath();
-			return Objects.equal(path1, path2);
+			return Objects.equals(path1, path2);
 		}
 		return false;
 	}


### PR DESCRIPTION
All changes are competently internal.

This change intentionally does not cover `XbaseCompiler` and `ObjectExtensions` (which were at least my actual goal). It will be covered in a separate PR together will all the Xtend generated Java sources and adjustments of the test expectations.

Part of https://github.com/eclipse/xtext/issues/2975