### PR TITLE
Remove deprecated Eclipse-LazyStart headers

### DIFF
--- a/org.eclipse.xtend.doc/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.doc/META-INF/MANIFEST.MF
@@ -6,5 +6,4 @@ Bundle-SymbolicName: org.eclipse.xtend.doc;singleton:=true
 Bundle-Version: 2.35.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.help;bundle-version="3.9.100"
-Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.xtext.doc/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.doc/META-INF/MANIFEST.MF
@@ -6,5 +6,4 @@ Bundle-SymbolicName: org.eclipse.xtext.doc;singleton:=true
 Bundle-Version: 2.35.0.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.help;bundle-version="3.9.100"
-Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
It is deprecated in favor of 'Bundle-ActivationPolicy: lazy', which is already present.