### PR TITLE
revert "Set UNIX-style linebreaks"

### DIFF
--- a/org.eclipse.xtend.core.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.core.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.core/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.core/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.doc/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.doc/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.examples/projects/xtend-annotation-examples-client/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.examples/projects/xtend-annotation-examples-client/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.examples/projects/xtend-euler/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.examples/projects/xtend-euler/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.examples/projects/xtend-examples/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.examples/projects/xtend-examples/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.ide.common/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.ide.common/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.ide.swtbot.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.ide.swtbot.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.ide.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.ide.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.m2e/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.m2e/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.maven.plugin/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.maven.plugin/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.performance.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.performance.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtend.sdk.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtend.sdk.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.activities/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.activities/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.builder.standalone.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.builder.standalone.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.builder.standalone/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.builder.standalone/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.builder.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.builder.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.builder/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.builder/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.buildship/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.buildship/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.common.types.eclipse.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.common.types.eclipse.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.common.types.edit/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.common.types.edit/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.common.types.shared.jdt38/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.common.types.shared.jdt38/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.common.types.shared/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.common.types.shared/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.common.types.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.common.types.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.common.types.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.common.types.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.common.types/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.common.types/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.doc/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.doc/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.docs.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.docs.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.eclipse.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.eclipse.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ecore/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ecore/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.examples.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.examples.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.extras.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.extras.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ide.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ide.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.java/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.java/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.junit4.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.junit4.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.junit4/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.junit4/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.junit5.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.junit5.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.logging/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.logging/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.m2e/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.m2e/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.purexbase.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.purexbase.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.purexbase.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.purexbase.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.purexbase/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.purexbase/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.redist.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.redist.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.runtime.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.runtime.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.sdk.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.sdk.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.smap/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.smap/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ui.codetemplates.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ui.codetemplates.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ui.codetemplates.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ui.codetemplates.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ui.codetemplates/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ui.codetemplates/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ui.ecore/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ui.ecore/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ui.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ui.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ui.shared/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ui.shared/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ui.testing/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ui.testing/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ui.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ui.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.util/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.util/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.web.example.entities.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.web.example.entities.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.web.example.entities/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.web.example.entities/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.junit/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.junit/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.lib.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.lib.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.lib/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.lib/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.testdata/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.testdata/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.testing/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.testing/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.testlanguages.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.testlanguages.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.testlanguages/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.testlanguages/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.ui.testing/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.ui.testing/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.ui.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.ui.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xbase/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xbase/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.generator/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.generator/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.examples/projects/xbase.tutorial/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/xbase.tutorial/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.graph.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.graph.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.graph/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.graph/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext.xtext.wizard/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext.xtext.wizard/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n

--- a/org.eclipse.xtext/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.xtext/.settings/org.eclipse.core.runtime.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-line.separator=\n


### PR DESCRIPTION
Take the EOL settings from the OS, so that Xtend generated Java files are not "dirty" when regenerated in a Windows system.

Closes https://github.com/eclipse/xtext/issues/2778