### PR TITLE
Oomph clean build onlyNewProjects="true"

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -565,6 +565,7 @@
     <setupTask
         xsi:type="projects:ProjectsBuildTask"
         id="clean-xtext-lib-complete"
+        onlyNewProjects="true"
         refresh="true"
         clean="true"/>
     <stream


### PR DESCRIPTION
This should deal with the problem of always getting a clean build in Windows, each time you open the development workspace.

See https://github.com/eclipse/xtext/issues/2778#issuecomment-2071963236