### PR TITLE
Regenerated Xtend files

### DIFF
--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/InsertParameterMiniHelperAnnoProcessor.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/InsertParameterMiniHelperAnnoProcessor.java
@@ -8,7 +8,7 @@
  */
 package org.eclipse.xtend.core.tests.macro;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 import org.eclipse.xtend.lib.macro.AbstractClassProcessor;
 import org.eclipse.xtend.lib.macro.TransformationContext;
 import org.eclipse.xtend.lib.macro.declaration.AnnotationReference;
@@ -24,7 +24,7 @@ public class InsertParameterMiniHelperAnnoProcessor extends AbstractClassProcess
   @Override
   public void doTransform(final MutableClassDeclaration clazz, @Extension final TransformationContext context) {
     final Function1<AnnotationReference, Boolean> _function = (AnnotationReference a) -> {
-      return Boolean.valueOf((Objects.equal(a.getAnnotationTypeDeclaration().getSimpleName(), InsertParameterMiniHelperAnno.class.getSimpleName()) && (a.getClassValue("classRef") != null)));
+      return Boolean.valueOf((Objects.equals(a.getAnnotationTypeDeclaration().getSimpleName(), InsertParameterMiniHelperAnno.class.getSimpleName()) && (a.getClassValue("classRef") != null)));
     };
     AnnotationReference _findFirst = IterableExtensions.findFirst(clazz.getAnnotations(), _function);
     TypeReference _classValue = null;
@@ -35,7 +35,7 @@ public class InsertParameterMiniHelperAnnoProcessor extends AbstractClassProcess
     final Function1<AnnotationReference, Boolean> _function_1 = (AnnotationReference a) -> {
       String _simpleName = a.getAnnotationTypeDeclaration().getSimpleName();
       String _simpleName_1 = InsertParameterMiniHelperAnno.class.getSimpleName();
-      return Boolean.valueOf(Objects.equal(_simpleName, _simpleName_1));
+      return Boolean.valueOf(Objects.equals(_simpleName, _simpleName_1));
     };
     final int position = IterableExtensions.findFirst(clazz.getAnnotations(), _function_1).getIntValue("position");
     Iterable<? extends MutableMethodDeclaration> _declaredMethods = clazz.getDeclaredMethods();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/TransformationContextImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/TransformationContextImpl.java
@@ -106,8 +106,8 @@ public class TransformationContextImpl implements TransformationContext {
     return this.getProblemSupport().getProblems(element);
   }
 
-  public void validateLater(final Procedure0 validationCallback) {
-    this.getProblemSupport().validateLater(validationCallback);
+  public void validateLater(final Procedure0 arg0) {
+    this.getProblemSupport().validateLater(arg0);
   }
 
   public MutableAnnotationTypeDeclaration findAnnotationType(final String qualifiedName) {
@@ -226,32 +226,32 @@ public class TransformationContextImpl implements TransformationContext {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference);
   }
 
-  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference, initializer);
+  public AnnotationReference newAnnotationReference(final AnnotationReference arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
   }
 
   public AnnotationReference newAnnotationReference(final Class<?> annotationClass) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass);
   }
 
-  public AnnotationReference newAnnotationReference(final Class<?> annotationClass, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass, initializer);
+  public AnnotationReference newAnnotationReference(final Class<?> arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
   }
 
   public AnnotationReference newAnnotationReference(final String annotationTypeName) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName);
   }
 
-  public AnnotationReference newAnnotationReference(final String annotationTypeName, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName, initializer);
+  public AnnotationReference newAnnotationReference(final String arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
   }
 
   public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration);
   }
 
-  public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration, initializer);
+  public AnnotationReference newAnnotationReference(final Type arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
   }
 
   public boolean exists(final Path path) {

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ValidationContextImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ValidationContextImpl.java
@@ -99,8 +99,8 @@ public class ValidationContextImpl implements ValidationContext {
     return this.getProblemSupport().getProblems(element);
   }
 
-  public void validateLater(final Procedure0 validationCallback) {
-    this.getProblemSupport().validateLater(validationCallback);
+  public void validateLater(final Procedure0 arg0) {
+    this.getProblemSupport().validateLater(arg0);
   }
 
   public MutableAnnotationTypeDeclaration findAnnotationType(final String qualifiedName) {
@@ -219,32 +219,32 @@ public class ValidationContextImpl implements ValidationContext {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference);
   }
 
-  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference, initializer);
+  public AnnotationReference newAnnotationReference(final AnnotationReference arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
   }
 
   public AnnotationReference newAnnotationReference(final Class<?> annotationClass) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass);
   }
 
-  public AnnotationReference newAnnotationReference(final Class<?> annotationClass, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass, initializer);
+  public AnnotationReference newAnnotationReference(final Class<?> arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
   }
 
   public AnnotationReference newAnnotationReference(final String annotationTypeName) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName);
   }
 
-  public AnnotationReference newAnnotationReference(final String annotationTypeName, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName, initializer);
+  public AnnotationReference newAnnotationReference(final String arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
   }
 
   public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration);
   }
 
-  public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration, initializer);
+  public AnnotationReference newAnnotationReference(final Type arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(arg0, arg1);
   }
 
   public boolean exists(final Path path) {


### PR DESCRIPTION
After installing the new Xtend in Eclipse I get a few changed files.

While this https://github.com/eclipse/xtext/commit/341050e055a9054582e74efea4b2b0da781c2dda comes surely from https://github.com/eclipse/xtext/pull/2993 (cc @HannesWell) I'm not quite sure about https://github.com/eclipse/xtext/commit/bc51517d56ee56516c095a097875185c8f35cfc5. Can it be due to https://github.com/eclipse/xtext/pull/2784? (cc @dvojtise)