### PR TITLE
[#3007] Content Assistant test infrastructure improvements.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractContentAssistTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractContentAssistTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,10 +10,12 @@ package org.eclipse.xtext.ui.testing;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -26,8 +28,11 @@ import org.eclipse.xtext.common.types.access.jdt.JdtTypeProviderFactory;
 import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.XtextResourceSet;
+import org.eclipse.xtext.ui.XtextProjectHelper;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.ui.testing.util.ResourceLoadHelper;
+import org.eclipse.xtext.util.Strings;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.jupiter.api.AfterAll;
@@ -53,11 +58,18 @@ public abstract class AbstractContentAssistTest implements ResourceLoadHelper, I
 	private Injector injector;
 
 	private static IJavaProject javaProject;
+	
+	/**
+	 * cursor position marker
+	 * @since 2.35 
+	 */
+	protected String c = "<|>";
 
 	@BeforeClass
 	@BeforeAll
 	public static void setUp() throws CoreException {
 		javaProject = JavaProjectSetupUtil.createJavaProject("contentAssistTest");
+		IResourcesSetupUtil.addNature(javaProject.getProject(), XtextProjectHelper.NATURE_ID);
 	}
 
 	@AfterClass
@@ -72,13 +84,33 @@ public abstract class AbstractContentAssistTest implements ResourceLoadHelper, I
 		XtextResourceSet resourceSet = resourceSetProvider.get();
 		initializeTypeProvider(resourceSet);
 		try {
-			URI resourceUri = URI.createURI("Test." + fileExtensionProvider.getPrimaryFileExtension());
-			Resource resource = resourceSet.createResource(resourceUri);
+			String projectFullPath = javaProject.getProject().getFullPath().toString();
+			URI resourceUri = URI.createPlatformResourceURI(projectFullPath + "/" + getProjectRelativePath() + "/" + "Test." + fileExtensionProvider.getPrimaryFileExtension(), true);
+
+			/*
+			 * Avoid the following java.lang.IllegalStateException:
+			 * A different resource with the URI 'platform:/resource/contentAssistTest/Test....' was already registered.
+			 */
+			Resource resource = resourceSet.getResource(resourceUri, false);
+			if (resource == null) {
+				resource = resourceSet.createResource(resourceUri);
+			}
 			resource.load(stream, null);
 			return (XtextResource) resource;
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	/**
+	 * Returns the project relative path where the files should be created.
+	 * The default implementation creates them directly in the src folder.
+	 * Clients may override.
+	 *
+	 * @since 2.35 
+	 */
+	protected String getProjectRelativePath() {
+		return "src";
 	}
 
 	@Override
@@ -104,4 +136,135 @@ public abstract class AbstractContentAssistTest implements ResourceLoadHelper, I
 		resourceSet.setClasspathURIContext(getJavaProject(resourceSet));
 	}
 
+	/**
+	 * Creates a dsl file.
+	 * 
+	 * @param fileName
+	 * 		The name of the file (without the file extension).
+	 * 		It is also possible to customize the project relative path, see {@link #getProjectRelativePath()}.
+	 * 		To use workspace relative path, use {@link IResourcesSetupUtil#createFile(String, String)} instead.
+	 * 
+	 * @param content
+	 * 		The content of the file.
+	 * 
+	 * @since 2.35
+	 */
+	protected IFile createDslFile(String fileName, CharSequence content) {
+		return createDslFile(fileName, fileExtensionProvider.getPrimaryFileExtension(), content);
+	}
+
+	/**
+	 * Creates a dsl file.
+	 * 
+	 * @param fileName
+	 * 		The name of the file (without the file extension).
+	 * 		It is also possible to customize the project relative path, see {@link #getProjectRelativePath()}.
+	 * 		To use workspace relative path, use {@link IResourcesSetupUtil#createFile(String, String)} instead.
+	 * 
+	 * @param fileExtension
+	 * 		The extension of the file.
+	 * 
+	 * @param content
+	 * 		The content of the file.
+	 * 
+	 * @since 2.35
+	 */
+	protected IFile createDslFile(String fileName, String fileExtension, CharSequence content) {
+		try {
+			return IResourcesSetupUtil.createFile(javaProject.getElementName(), getProjectRelativePath() + "/" + fileName, fileExtension, content.toString());
+		} catch (InvocationTargetException | CoreException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Verifies whether the content assistant provides the expected proposals on the given cursor position.
+	 * 
+	 * @param text
+	 * 		The editor's input text. The text must contain the {@link #c} special symbol indicating the current cursor position.
+	 * 
+	 * @param expectedProposals
+	 * 		The proposals (separated by new lines) that are expected to be offered whenever the content assistant is triggered on the given cursor position.
+	 * 
+	 * @since 2.35
+	 */
+	protected void assertContentAssistant(CharSequence text, CharSequence expectedProposals) {
+		assertContentAssistant(text, expectedProposals, null, null);
+	}
+	
+	/**
+	 * Verifies whether the content assistant provides the expected proposals on the given cursor position.
+	 * 
+	 * @param text
+	 * 		The editor's input text. The text must contain the {@link #c} special symbol indicating the current cursor position.
+	 * 
+	 * @param expectedProposals
+	 * 		The proposals that are expected to be offered whenever the content assistant is triggered on the given cursor position.
+	 * 
+	 * @since 2.35
+	 */
+	protected void assertContentAssistant(CharSequence text, String[] expectedProposals) {
+		assertContentAssistant(text, expectedProposals, null, null);
+	}
+
+	/**
+	 * Verifies whether the content assistant provides the expected proposals on the given cursor position.
+	 * Furthermore, it applies the proposalToApply - if it is given - and verifies the expected content afterwards.
+	 * 
+	 * @param text
+	 * 		The editor's input text. The text must contain the {@link #c} special symbol indicating the current cursor position.
+	 * 
+	 * @param expectedProposals
+	 * 		The proposals (separated by new lines) that are expected to be offered whenever the content assistant is triggered on the given cursor position. 
+	 * 
+	 * @param proposalToApply
+	 * 		The proposal to apply from the list of the expected proposals.
+	 * 
+	 * @param expectedContent
+	 * 		The expected editor content after the given proposal has been applied.
+	 * 
+	 * @since 2.35
+	 */
+	protected void assertContentAssistant(CharSequence text, CharSequence expectedProposals, String proposalToApply, String expectedContent) {
+		String[] expectedProposalsArray = Strings.toUnixLineSeparator(expectedProposals.toString()).split("\n");
+		assertContentAssistant(text, expectedProposalsArray, proposalToApply, expectedContent);
+	}
+	
+	/**
+	 * Verifies whether the content assistant provides the expected proposals on the given cursor position.
+	 * Furthermore, it applies the proposalToApply - if it is given - and verifies the expected content afterwards.
+	 * 
+	 * @param text
+	 * 		The editor's input text. The text must contain the {@link #c} special symbol indicating the current cursor position.
+	 * 
+	 * @param expectedProposals
+	 * 		The proposals that are expected to be offered whenever the content assistant is triggered on the given cursor position. 
+	 * 
+	 * @param proposalToApply
+	 * 		The proposal to apply from the list of the expected proposals.
+	 * 
+	 * @param expectedContent
+	 * 		The expected editor content after the given proposal has been applied.
+	 * 
+	 * @since 2.35
+	 */
+	protected void assertContentAssistant(CharSequence text, String[] expectedProposals, String proposalToApply, String expectedContent) {
+
+		int cursorPosition = text.toString().indexOf(c);
+		if (cursorPosition == -1) {
+			throw new RuntimeException("Can't locate cursor position symbols '" + c + "' in the input text.");
+		}
+
+		String content = text.toString().replace(c, "");
+
+		try {
+			ContentAssistProcessorTestBuilder builder = newBuilder().append(content).assertTextAtCursorPosition(cursorPosition, expectedProposals);
+	
+			if (proposalToApply != null) {
+				builder.applyProposal(cursorPosition, proposalToApply).expectContent(expectedContent);
+			}
+		} catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+	}
 }

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ContentAssistWithSeveralResourcesTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ContentAssistWithSeveralResourcesTest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ui.tests.editor.contentassist;
+
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractContentAssistTest;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
+import org.eclipse.xtext.ui.tests.linking.ui.tests.ImportUriUiTestLanguageUiInjectorProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(ImportUriUiTestLanguageUiInjectorProvider.class)
+public class ContentAssistWithSeveralResourcesTest extends AbstractContentAssistTest {
+
+	@Test public void test_with_one_resource() {
+		assertContentAssistant("type A extends " + c, new String[]{("A")});
+	}
+	
+	@Test public void test_with_two_resources() {
+		createDslFile("types", "type A extends A");
+		IResourcesSetupUtil.waitForBuild();
+		assertContentAssistant("import \"types.importuriuitestlanguage\" type B extends " + c, "A\nB");
+	}
+	
+	@Test public void test_with_three_resources() {
+		createDslFile("types1", "type A extends A");
+		createDslFile("types2", "type B extends B");
+		IResourcesSetupUtil.waitForBuild();
+		assertContentAssistant("import \"types1.importuriuitestlanguage\" import \"types2.importuriuitestlanguage\" type C extends " + c, new String[]{"A", "B", "C"});
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/ContentAssistTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/ContentAssistTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,7 +8,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.example.domainmodel.ui.tests
 
-import java.util.List
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.ui.testing.AbstractContentAssistTest
@@ -21,9 +20,6 @@ import org.junit.runner.RunWith
 @RunWith(XtextRunner)
 @InjectWith(DomainmodelUiInjectorProvider)
 class ContentAssistTest extends AbstractContentAssistTest {
-
-	// cursor position marker
-	val c = '''<|>'''
 
 	@Test def void testImportCompletion() throws Exception {
 		newBuilder.append('import java.util.Da').assertText('java.util.Date')
@@ -56,7 +52,7 @@ class ContentAssistTest extends AbstractContentAssistTest {
 			entity E {
 				«c»
 			}
-		'''.testContentAssistant(#[
+		'''.assertContentAssistant(#[
 			'Operation - template for an Operation',
 			'Property - template for a Property',
 			'op'
@@ -72,7 +68,7 @@ class ContentAssistTest extends AbstractContentAssistTest {
 			entity E {
 				«c»
 			}
-		'''.testContentAssistant(#[
+		'''.assertContentAssistant(#[
 			'Operation - template for an Operation',
 			'Property - template for a Property',
 			'op'
@@ -83,16 +79,5 @@ class ContentAssistTest extends AbstractContentAssistTest {
 				}
 			}
 		''')
-	}
-
-	private def void testContentAssistant(CharSequence text, List<String> expectedProposals, String proposalToApply, String expectedContent) throws Exception {
-
-		val cursorPosition = text.toString.indexOf(c)
-		val content = text.toString.replace(c, "")
-
-		newBuilder.append(content).
-		assertTextAtCursorPosition(cursorPosition, expectedProposals).
-		applyProposal(cursorPosition, proposalToApply).
-		expectContent(expectedContent)
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/ContentAssistTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/ContentAssistTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2019 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,16 +8,11 @@
  */
 package org.eclipse.xtext.example.domainmodel.ui.tests;
 
-import java.util.Collections;
-import java.util.List;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.testing.AbstractContentAssistTest;
 import org.eclipse.xtext.ui.testing.ContentAssistProcessorTestBuilder;
-import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Conversions;
-import org.eclipse.xtext.xbase.lib.Functions.Function0;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,15 +23,6 @@ import org.junit.runner.RunWith;
 @InjectWith(DomainmodelUiInjectorProvider.class)
 @SuppressWarnings("all")
 public class ContentAssistTest extends AbstractContentAssistTest {
-  private final String c = new Function0<String>() {
-    @Override
-    public String apply() {
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("<|>");
-      return _builder.toString();
-    }
-  }.apply();
-
   @Test
   public void testImportCompletion() throws Exception {
     this.newBuilder().append("import java.util.Da").assertText("java.util.Date");
@@ -94,8 +80,8 @@ public class ContentAssistTest extends AbstractContentAssistTest {
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("Operation - template for an Operation", "Property - template for a Property", "op")), "Property - template for a Property", _builder_1.toString());
+    this.assertContentAssistant(_builder, 
+      new String[] { "Operation - template for an Operation", "Property - template for a Property", "op" }, "Property - template for a Property", _builder_1.toString());
   }
 
   @Test
@@ -121,13 +107,7 @@ public class ContentAssistTest extends AbstractContentAssistTest {
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("Operation - template for an Operation", "Property - template for a Property", "op")), "Operation - template for an Operation", _builder_1.toString());
-  }
-
-  private void testContentAssistant(final CharSequence text, final List<String> expectedProposals, final String proposalToApply, final String expectedContent) throws Exception {
-    final int cursorPosition = text.toString().indexOf(this.c);
-    final String content = text.toString().replace(this.c, "");
-    this.newBuilder().append(content).assertTextAtCursorPosition(cursorPosition, ((String[])Conversions.unwrapArray(expectedProposals, String.class))).applyProposal(cursorPosition, proposalToApply).expectContent(expectedContent);
+    this.assertContentAssistant(_builder, 
+      new String[] { "Operation - template for an Operation", "Property - template for a Property", "op" }, "Operation - template for an Operation", _builder_1.toString());
   }
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineContentAssistTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineContentAssistTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,15 +8,11 @@
  */
 package org.eclipse.xtext.example.fowlerdsl.ui.tests;
 
-import java.util.Collections;
-import java.util.List;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.testing.AbstractContentAssistTest;
-import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Conversions;
-import org.eclipse.xtext.xbase.lib.Functions.Function0;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -27,15 +23,6 @@ import org.junit.runner.RunWith;
 @InjectWith(StatemachineUiInjectorProvider.class)
 @SuppressWarnings("all")
 public class StatemachineContentAssistTest extends AbstractContentAssistTest {
-  private final String c = new Function0<String>() {
-    @Override
-    public String apply() {
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("<|>");
-      return _builder.toString();
-    }
-  }.apply();
-
   @Test
   public void empty() throws Exception {
     StringConcatenation _builder = new StringConcatenation();
@@ -44,8 +31,8 @@ public class StatemachineContentAssistTest extends AbstractContentAssistTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("resetEvents");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("commands", "events", "resetEvents", "state")), "resetEvents", _builder_1.toString());
+    this.assertContentAssistant(_builder, 
+      new String[] { "commands", "events", "resetEvents", "state" }, "resetEvents", _builder_1.toString());
   }
 
   @Test
@@ -106,8 +93,8 @@ public class StatemachineContentAssistTest extends AbstractContentAssistTest {
     _builder_1.newLine();
     _builder_1.append("end");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("doorClosed", "drawerOpened", "lightOn", "doorOpened", "panelClosed")), "doorOpened", _builder_1.toString());
+    this.assertContentAssistant(_builder, 
+      new String[] { "doorClosed", "drawerOpened", "lightOn", "doorOpened", "panelClosed" }, "doorOpened", _builder_1.toString());
   }
 
   @Test
@@ -164,8 +151,8 @@ public class StatemachineContentAssistTest extends AbstractContentAssistTest {
     _builder_1.newLine();
     _builder_1.append("end");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("unlockPanel", "lockPanel", "lockDoor", "unlockDoor", "{")), "unlockDoor", _builder_1.toString());
+    this.assertContentAssistant(_builder, 
+      new String[] { "unlockPanel", "lockPanel", "lockDoor", "unlockDoor", "{" }, "unlockDoor", _builder_1.toString());
   }
 
   @Test
@@ -282,8 +269,8 @@ public class StatemachineContentAssistTest extends AbstractContentAssistTest {
     _builder_1.newLine();
     _builder_1.append("end");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("Transition - Template for a Transition", "doorClosed", "drawerOpened", "lightOn", "doorOpened", "panelClosed", "end")), "doorClosed", _builder_1.toString());
+    this.assertContentAssistant(_builder, 
+      new String[] { "Transition - Template for a Transition", "doorClosed", "drawerOpened", "lightOn", "doorOpened", "panelClosed", "end" }, "doorClosed", _builder_1.toString());
   }
 
   @Test
@@ -477,8 +464,8 @@ public class StatemachineContentAssistTest extends AbstractContentAssistTest {
     _builder_1.newLine();
     _builder_1.append("end");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("idle", "active", "waitingForLight", "waitingForDrawer", "unlockedPanel")), "idle", _builder_1.toString());
+    this.assertContentAssistant(_builder, 
+      new String[] { "idle", "active", "waitingForLight", "waitingForDrawer", "unlockedPanel" }, "idle", _builder_1.toString());
   }
 
   @Test
@@ -549,13 +536,61 @@ public class StatemachineContentAssistTest extends AbstractContentAssistTest {
     _builder_1.newLine();
     _builder_1.append("end");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("doorClosed", "drawerOpened", "lightOn", "doorOpened", "panelClosed", "actions", "end", "Transition - Template for a Transition")), "Transition - Template for a Transition", _builder_1.toString());
+    this.assertContentAssistant(_builder, 
+      new String[] { "doorClosed", "drawerOpened", "lightOn", "doorOpened", "panelClosed", "actions", "end", "Transition - Template for a Transition" }, "Transition - Template for a Transition", _builder_1.toString());
   }
 
-  private void testContentAssistant(final CharSequence text, final List<String> expectedProposals, final String proposalToApply, final String expectedContent) throws Exception {
-    final int cursorPosition = text.toString().indexOf(this.c);
-    final String content = text.toString().replace(this.c, "");
-    this.newBuilder().append(content).assertTextAtCursorPosition(cursorPosition, ((String[])Conversions.unwrapArray(expectedProposals, String.class))).applyProposal(cursorPosition, proposalToApply).expectContent(expectedContent);
+  @Test
+  public void events_from_another_file() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("events");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed   D1CL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened D2OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      L1ON");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened   D1OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed  PNCL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    this.createDslFile("events", _builder);
+    IResourcesSetupUtil.waitForBuild();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("resetEvents");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append(this.c, "\t");
+    _builder_1.newLineIfNotEmpty();
+    _builder_1.append("end");
+    _builder_1.newLine();
+    StringConcatenation _builder_2 = new StringConcatenation();
+    _builder_2.append("doorClosed");
+    _builder_2.newLine();
+    _builder_2.append("drawerOpened");
+    _builder_2.newLine();
+    _builder_2.append("lightOn");
+    _builder_2.newLine();
+    _builder_2.append("doorOpened");
+    _builder_2.newLine();
+    _builder_2.append("panelClosed");
+    _builder_2.newLine();
+    StringConcatenation _builder_3 = new StringConcatenation();
+    _builder_3.append("resetEvents");
+    _builder_3.newLine();
+    _builder_3.append("\t");
+    _builder_3.append("doorOpened");
+    _builder_3.newLine();
+    _builder_3.append("end");
+    _builder_3.newLine();
+    this.assertContentAssistant(_builder_1, _builder_2, "doorOpened", _builder_3.toString());
   }
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineContentAssistTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineContentAssistTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,7 +8,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.example.homeautomation.ui.tests
 
-import java.util.List
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.ui.testing.AbstractContentAssistTest
@@ -22,13 +21,10 @@ import org.junit.runner.RunWith
 @InjectWith(RuleEngineUiInjectorProvider)
 class RuleEngineContentAssistTest extends AbstractContentAssistTest {
 
-	// cursor position marker
-	val c = '''<|>'''
-
 	@Test def empty() throws Exception {
 		'''
 			«c»
-		'''.testContentAssistant(#[
+		'''.assertContentAssistant(#[
 			'Device',
 			'Rule'
 		], 'Device', '''
@@ -42,7 +38,7 @@ class RuleEngineContentAssistTest extends AbstractContentAssistTest {
 			Device Heater can be on, off, error
 			
 			Rule 'rule1' when «c»
-		'''.testContentAssistant(#[
+		'''.assertContentAssistant(#[
 			'Window.open',
 			'Window.closed',
 			'Heater.on',
@@ -62,7 +58,7 @@ class RuleEngineContentAssistTest extends AbstractContentAssistTest {
 			Device Heater can be on, off, error
 			
 			Rule 'rule1' when Win«c»
-		'''.testContentAssistant(#[
+		'''.assertContentAssistant(#[
 			'Window.open',
 			'Window.closed'
 		], 'Window.open', '''
@@ -80,7 +76,7 @@ class RuleEngineContentAssistTest extends AbstractContentAssistTest {
 			
 			Rule 'rule1' when Window.open then
 				«c»
-		'''.testContentAssistant(#[
+		'''.assertContentAssistant(#[
 			'do',
 			'false',
 			'for',
@@ -113,7 +109,7 @@ class RuleEngineContentAssistTest extends AbstractContentAssistTest {
 			
 			Rule 'rule1' when Window.open then
 				fire(Heater.o«c»)
-		'''.testContentAssistant(#[
+		'''.assertContentAssistant(#[
 			'on',
 			'off'
 		], 'off', '''
@@ -123,17 +119,5 @@ class RuleEngineContentAssistTest extends AbstractContentAssistTest {
 			Rule 'rule1' when Window.open then
 				fire(Heater.off)
 		''')
-	}
-
-	private def void testContentAssistant(CharSequence text, List<String> expectedProposals,
-		String proposalToApply, String expectedContent) throws Exception {
-		
-		val cursorPosition = text.toString.indexOf(c)
-		val content = text.toString.replace(c, "")
-		
-		newBuilder.append(content).
-		assertTextAtCursorPosition(cursorPosition, expectedProposals).
-		applyProposal(cursorPosition, proposalToApply).
-		expectContent(expectedContent)
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineContentAssistTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineContentAssistTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,15 +8,10 @@
  */
 package org.eclipse.xtext.example.homeautomation.ui.tests;
 
-import java.util.Collections;
-import java.util.List;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.testing.AbstractContentAssistTest;
-import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Conversions;
-import org.eclipse.xtext.xbase.lib.Functions.Function0;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -27,15 +22,6 @@ import org.junit.runner.RunWith;
 @InjectWith(RuleEngineUiInjectorProvider.class)
 @SuppressWarnings("all")
 public class RuleEngineContentAssistTest extends AbstractContentAssistTest {
-  private final String c = new Function0<String>() {
-    @Override
-    public String apply() {
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("<|>");
-      return _builder.toString();
-    }
-  }.apply();
-
   @Test
   public void empty() throws Exception {
     StringConcatenation _builder = new StringConcatenation();
@@ -44,8 +30,8 @@ public class RuleEngineContentAssistTest extends AbstractContentAssistTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("Device");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("Device", "Rule")), "Device", _builder_1.toString());
+    this.assertContentAssistant(_builder, 
+      new String[] { "Device", "Rule" }, "Device", _builder_1.toString());
   }
 
   @Test
@@ -67,8 +53,8 @@ public class RuleEngineContentAssistTest extends AbstractContentAssistTest {
     _builder_1.newLine();
     _builder_1.append("Rule \'rule1\' when Window.open");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("Window.open", "Window.closed", "Heater.on", "Heater.off", "Heater.error")), "Window.open", _builder_1.toString());
+    this.assertContentAssistant(_builder, 
+      new String[] { "Window.open", "Window.closed", "Heater.on", "Heater.off", "Heater.error" }, "Window.open", _builder_1.toString());
   }
 
   @Test
@@ -90,8 +76,8 @@ public class RuleEngineContentAssistTest extends AbstractContentAssistTest {
     _builder_1.newLine();
     _builder_1.append("Rule \'rule1\' when Window.open");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("Window.open", "Window.closed")), "Window.open", _builder_1.toString());
+    this.assertContentAssistant(_builder, 
+      new String[] { "Window.open", "Window.closed" }, "Window.open", _builder_1.toString());
   }
 
   @Test
@@ -118,8 +104,8 @@ public class RuleEngineContentAssistTest extends AbstractContentAssistTest {
     _builder_1.append("\t");
     _builder_1.append("switch");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("do", "false", "for", "if", "new", "null", "return", "switch", "synchronized", "throw", "true", "try", "typeof", "val", "var", "while")), "switch", _builder_1.toString());
+    this.assertContentAssistant(_builder, 
+      new String[] { "do", "false", "for", "if", "new", "null", "return", "switch", "synchronized", "throw", "true", "try", "typeof", "val", "var", "while" }, "switch", _builder_1.toString());
   }
 
   @Test
@@ -148,13 +134,7 @@ public class RuleEngineContentAssistTest extends AbstractContentAssistTest {
     _builder_1.append("\t");
     _builder_1.append("fire(Heater.off)");
     _builder_1.newLine();
-    this.testContentAssistant(_builder, 
-      Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("on", "off")), "off", _builder_1.toString());
-  }
-
-  private void testContentAssistant(final CharSequence text, final List<String> expectedProposals, final String proposalToApply, final String expectedContent) throws Exception {
-    final int cursorPosition = text.toString().indexOf(this.c);
-    final String content = text.toString().replace(this.c, "");
-    this.newBuilder().append(content).assertTextAtCursorPosition(cursorPosition, ((String[])Conversions.unwrapArray(expectedProposals, String.class))).applyProposal(cursorPosition, proposalToApply).expectContent(expectedContent);
+    this.assertContentAssistant(_builder, 
+      new String[] { "on", "off" }, "off", _builder_1.toString());
   }
 }


### PR DESCRIPTION
- Extend the Content Assistant test infrastructure to test proposals from several resources: modify the AbstractContentAssistTest getResourceFor method to ensure that the test file points to a file in the test project.
- Uplift the testContentAssistant method from the project example classes into the AbstractContentAssistTest and rename it to assertContentAssistant.
- Add the events_from_another_file() test case to the StatemachineContentAssistTest test cases to demonstrate how to test the content assistant with several resources.
- Also add the ContentAssistWithSeveralResourcesTest test cases that are continuously executed by the CI build.

Closes #3007