### PR TITLE
assertNoErrors/Issues in CompilationTestHelper.Result

### DIFF
--- a/org.eclipse.xtext.xbase.testing/src/org/eclipse/xtext/xbase/testing/CompilationTestHelper.java
+++ b/org.eclipse.xtext.xbase.testing/src/org/eclipse/xtext/xbase/testing/CompilationTestHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,8 +8,10 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.testing;
 
+import static com.google.common.collect.Iterables.isEmpty;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
@@ -27,6 +30,7 @@ import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.EcoreUtil2;
+import org.eclipse.xtext.diagnostics.Severity;
 import org.eclipse.xtext.generator.GeneratorContext;
 import org.eclipse.xtext.generator.GeneratorDelegate;
 import org.eclipse.xtext.generator.IGenerator;
@@ -402,6 +406,32 @@ public class CompilationTestHelper {
 		public List<Issue> getErrorsAndWarnings() {
 			doValidation();
 			return allErrorsAndWarnings;
+		}
+
+		/**
+		 * Ensures that no error has been detected through the triggered validation.
+		 * 
+		 * @since 2.35
+		 */
+		public void assertNoErrors() {
+			var errors = getErrorsAndWarnings().stream()
+				.filter(it -> it.getSeverity() == Severity.ERROR)
+				.collect(Collectors.toList());
+			if (!isEmpty(errors))
+				fail("Expected no errors, but got:\n" +
+					errors.stream().map(Object::toString).collect(Collectors.joining("\n")));
+		}
+
+		/**
+		 * Ensures that no issue has been detected through the triggered validation.
+		 * 
+		 * @since 2.35
+		 */
+		public void assertNoIssues() {
+			var issues = getErrorsAndWarnings();
+			if (!isEmpty(issues))
+				fail("Expected no issues, but got:\n" +
+					issues.stream().map(Object::toString).collect(Collectors.joining("\n")));
 		}
 
 		/**

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/CompilationTestHelperTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/CompilationTestHelperTest.java
@@ -208,4 +208,36 @@ public class CompilationTestHelperTest extends AbstractJvmModelTest {
 		});
 	}
 
+	@Test
+	public void testAssertNoErrorsWithErrors() throws Exception {
+		String source = "{var int i = true; }";
+		compilationTestHelper.compile(source, it -> {
+			var thrown = assertThrows(AssertionError.class, () -> it.assertNoErrors());
+			assertTrue(thrown.getMessage(),
+					thrown.getMessage().contains("cannot convert from boolean to int"));
+		});
+	}
+
+	@Test
+	public void testAssertNoErrors() throws Exception {
+		String source = "{ var int i = 0; null }";
+		compilationTestHelper.compile(source, it -> it.assertNoErrors());
+	}
+
+	@Test
+	public void testAssertNoIssuesWithWarnings() throws Exception {
+		String source = "{var int i = 0; null }";
+		compilationTestHelper.compile(source, it -> {
+			var thrown = assertThrows(AssertionError.class, () -> it.assertNoIssues());
+			assertTrue(thrown.getMessage(),
+					thrown.getMessage().contains("is not used"));
+		});
+	}
+
+	@Test
+	public void testAssertNoIssues() throws Exception {
+		String source = "{ \"a string\" }";
+		compilationTestHelper.compile(source, it -> it.assertNoIssues());
+	}
+
 }

--- a/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/CompilationTestHelperTest.java
+++ b/org.eclipse.xtext.xbase.tests/src/org/eclipse/xtext/xbase/tests/compiler/CompilationTestHelperTest.java
@@ -16,7 +16,6 @@ import org.eclipse.xtext.xbase.compiler.GeneratorConfig;
 import org.eclipse.xtext.xbase.compiler.GeneratorConfigProvider;
 import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.testing.CompilationTestHelper;
-import org.eclipse.xtext.xbase.testing.CompilationTestHelper.Result;
 import org.eclipse.xtext.xbase.testing.TemporaryFolder;
 import org.eclipse.xtext.xbase.tests.jvmmodel.AbstractJvmModelTest;
 import org.junit.Assert;
@@ -53,7 +52,7 @@ public class CompilationTestHelperTest extends AbstractJvmModelTest {
 				"		default: \"bar\"\n" +
 				"	}\n" +
 				"}\n";
-		compilationTestHelper.compile(source, (CompilationTestHelper.Result it) -> {
+		compilationTestHelper.compile(source, it -> {
 			String expectation =
 					"import java.util.Objects;\n" +
 					"\n" +
@@ -93,7 +92,7 @@ public class CompilationTestHelperTest extends AbstractJvmModelTest {
 				"		default: \"bar\"\n" +
 				"	}\n" +
 				"}\n";
-		compilationTestHelper.compile(source, (CompilationTestHelper.Result it) -> {
+		compilationTestHelper.compile(source, it -> {
 			String expectation =
 					"@SuppressWarnings(\"all\")\n" +
 					"public class Test {\n" +
@@ -131,7 +130,7 @@ public class CompilationTestHelperTest extends AbstractJvmModelTest {
 				"{\n" +
 				"	val f = [ int i | i + 1 ]\n" +
 				"}\n";
-		compilationTestHelper.compile(source, (CompilationTestHelper.Result it) -> {
+		compilationTestHelper.compile(source, it -> {
 			String expectation =
 					"import org.eclipse.xtext.xbase.lib.Functions.Function1;\n" +
 					"\n" +
@@ -160,7 +159,7 @@ public class CompilationTestHelperTest extends AbstractJvmModelTest {
 				"{\n" +
 				"	val f = [ int i | i + 1 ]\n" +
 				"}\n";
-		compilationTestHelper.compile(source, (CompilationTestHelper.Result it) -> {
+		compilationTestHelper.compile(source, it -> {
 			String expectation =
 					"import org.eclipse.xtext.xbase.lib.Functions.Function1;\n" +
 					"\n" +
@@ -192,7 +191,7 @@ public class CompilationTestHelperTest extends AbstractJvmModelTest {
 		GeneratorConfig generatorConfig = new GeneratorConfig();
 		generatorConfig.setGenerateSyntheticSuppressWarnings(false);
 		generatorConfigProvider.install(resourceSet, generatorConfig);
-		compilationTestHelper.compile(resourceSet, (Result it) -> {
+		compilationTestHelper.compile(resourceSet, it -> {
 			String expectation =
 					"import org.eclipse.xtext.xbase.lib.Functions.Function1;\n" +
 					"\n" +
@@ -208,4 +207,5 @@ public class CompilationTestHelperTest extends AbstractJvmModelTest {
 			Assert.assertEquals(expectation, Strings.toUnixLineSeparator(it.getSingleGeneratedCode()));
 		});
 	}
+
 }


### PR DESCRIPTION
I often check for errors/issues when using CompilationTestHelper, and I always have to retrieve errors/warnings, do the filtering, and check for emptiness.

I thought adding such methods to `Result` would be worthwhile.

`assertNoWarnings` doesn't seem necessary to me, but I can add it in case.