### PR TITLE
DetectVMInstallationsJob.disabled as system property of tycho-surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -695,6 +695,10 @@
 							<exclude />
 						</excludes>
 						<failIfNoTests>true</failIfNoTests>
+						<systemProperties>
+							<!-- https://github.com/eclipse/xtext/issues/3057 -->
+							<DetectVMInstallationsJob.disabled>true</DetectVMInstallationsJob.disabled>
+						</systemProperties>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
The option seems to reduce the chances that flakes fail; at least in my experiments in macOS and Windows there are still flakes but they finally succeed

For https://github.com/eclipse/xtext/issues/3057