### PR TITLE
annotate dispatch method entry point with @Generated

### DIFF
--- a/org.eclipse.xtend.core.tests/batch-compiler-data/xtendClass/XtendA.xtend
+++ b/org.eclipse.xtend.core.tests/batch-compiler-data/xtendClass/XtendA.xtend
@@ -9,4 +9,7 @@
 
 class XtendA {
 	val public String foo = ""
+
+	def dispatch m(String s) {}
+	def dispatch m(int i) {}
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug423631Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug423631Test.xtend
@@ -30,7 +30,7 @@ class CompilerBug423631Test extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -42,7 +42,7 @@ class CompilerBug423631Test extends AbstractXtendCompilerTest {
 			    return null;
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public Object m(final A a) {
 			    if (a instanceof B) {
 			      return _m((B)a);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug423631Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug423631Test.xtend
@@ -30,6 +30,7 @@ class CompilerBug423631Test extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -41,6 +42,7 @@ class CompilerBug423631Test extends AbstractXtendCompilerTest {
 			    return null;
 			  }
 			
+			  @Generated
 			  public Object m(final A a) {
 			    if (a instanceof B) {
 			      return _m((B)a);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug427637Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug427637Test.xtend
@@ -1082,9 +1082,9 @@ class CompilerBug427637Test extends AbstractXtendCompilerTest {
 			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 			import org.eclipse.xtext.xbase.lib.Extension;
 			import org.eclipse.xtext.xbase.lib.Functions.Function1;
-			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.IterableExtensions;
 			import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			import org.eclipse.xtext.xbase.lib.util.ToStringHelper;
 			
 			@SuppressWarnings("all")
@@ -1590,7 +1590,7 @@ class CompilerBug427637Test extends AbstractXtendCompilerTest {
 			    return _function;
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  protected Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> newFormattingData(final HiddenLeafs leafs, final PreferenceKey key, final FormattingDataFactory.FormattingDataInit it) {
 			    if (key instanceof BlankLineKey) {
 			      return _newFormattingData(leafs, (BlankLineKey)key, it);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug427637Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug427637Test.xtend
@@ -1082,6 +1082,7 @@ class CompilerBug427637Test extends AbstractXtendCompilerTest {
 			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 			import org.eclipse.xtext.xbase.lib.Extension;
 			import org.eclipse.xtext.xbase.lib.Functions.Function1;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.IterableExtensions;
 			import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 			import org.eclipse.xtext.xbase.lib.util.ToStringHelper;
@@ -1589,6 +1590,7 @@ class CompilerBug427637Test extends AbstractXtendCompilerTest {
 			    return _function;
 			  }
 			
+			  @Generated
 			  protected Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> newFormattingData(final HiddenLeafs leafs, final PreferenceKey key, final FormattingDataFactory.FormattingDataInit it) {
 			    if (key instanceof BlankLineKey) {
 			      return _newFormattingData(leafs, (BlankLineKey)key, it);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug441096Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug441096Test.xtend
@@ -39,6 +39,7 @@ class CompilerBug441096Test extends AbstractXtendCompilerTest {
 			import java.util.Arrays;
 			import org.eclipse.xtend.lib.annotations.AccessorType;
 			import org.eclipse.xtend.lib.annotations.Accessors;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.Pure;
 			
 			@SuppressWarnings("all")
@@ -65,6 +66,7 @@ class CompilerBug441096Test extends AbstractXtendCompilerTest {
 			    }
 			  };
 			
+			  @Generated
 			  public void m(final Object expr, final Object seq) {
 			    if (expr == null
 			         && seq instanceof StringBuilder) {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug441096Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug441096Test.xtend
@@ -39,8 +39,8 @@ class CompilerBug441096Test extends AbstractXtendCompilerTest {
 			import java.util.Arrays;
 			import org.eclipse.xtend.lib.annotations.AccessorType;
 			import org.eclipse.xtend.lib.annotations.Accessors;
-			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.Pure;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -66,7 +66,7 @@ class CompilerBug441096Test extends AbstractXtendCompilerTest {
 			    }
 			  };
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void m(final Object expr, final Object seq) {
 			    if (expr == null
 			         && seq instanceof StringBuilder) {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug441099Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug441099Test.xtend
@@ -36,6 +36,7 @@ class CompilerBug441099Test extends AbstractXtendCompilerTest {
 		''', '''
 			import org.eclipse.xtend.lib.annotations.AccessorType;
 			import org.eclipse.xtend.lib.annotations.Accessors;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.Pure;
 			
 			@SuppressWarnings("all")
@@ -51,6 +52,7 @@ class CompilerBug441099Test extends AbstractXtendCompilerTest {
 			    return new D("");
 			  }
 			
+			  @Generated
 			  public Object m(final String x) {
 			    return _m(x);
 			  }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug441099Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug441099Test.xtend
@@ -36,8 +36,8 @@ class CompilerBug441099Test extends AbstractXtendCompilerTest {
 		''', '''
 			import org.eclipse.xtend.lib.annotations.AccessorType;
 			import org.eclipse.xtend.lib.annotations.Accessors;
-			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.Pure;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -52,7 +52,7 @@ class CompilerBug441099Test extends AbstractXtendCompilerTest {
 			    return new D("");
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public Object m(final String x) {
 			    return _m(x);
 			  }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug470768Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug470768Test.xtend
@@ -36,8 +36,8 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			import java.util.Iterator;
 			import java.util.List;
 			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.IterableExtensions;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class SOE {
@@ -59,7 +59,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			    return CollectionLiterals.<SOE.A>emptyList();
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public List<SOE.A> getList(final Object it) {
 			    if (it instanceof SOE.A) {
 			      return _getList((SOE.A)it);
@@ -94,8 +94,8 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			import java.util.Iterator;
 			import java.util.List;
 			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.IterableExtensions;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -114,7 +114,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			    return CollectionLiterals.<C>emptyList();
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public List<C> getList(final Object it) {
 			    if (it instanceof C) {
 			      return _getList((C)it);
@@ -151,8 +151,8 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			import java.util.Iterator;
 			import java.util.List;
 			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.IterableExtensions;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class SOE {
@@ -174,7 +174,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			    return IterableExtensions.<SOE.A>toList(new SOE.CustomItr());
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public List<SOE.A> getList(final Object it) {
 			    if (it instanceof SOE.A) {
 			      return _getList((SOE.A)it);
@@ -210,8 +210,8 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			import java.util.Iterator;
 			import java.util.List;
 			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.IterableExtensions;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class SOE {
@@ -233,7 +233,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			    return CollectionLiterals.<SOE.A>emptyList();
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public List<SOE.A> getList(final Object it) {
 			    if (it instanceof SOE.A) {
 			      return _getList((SOE.A)it);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug470768Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug470768Test.xtend
@@ -36,6 +36,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			import java.util.Iterator;
 			import java.util.List;
 			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.IterableExtensions;
 			
 			@SuppressWarnings("all")
@@ -58,6 +59,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			    return CollectionLiterals.<SOE.A>emptyList();
 			  }
 			
+			  @Generated
 			  public List<SOE.A> getList(final Object it) {
 			    if (it instanceof SOE.A) {
 			      return _getList((SOE.A)it);
@@ -92,6 +94,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			import java.util.Iterator;
 			import java.util.List;
 			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.IterableExtensions;
 			
 			@SuppressWarnings("all")
@@ -111,6 +114,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			    return CollectionLiterals.<C>emptyList();
 			  }
 			
+			  @Generated
 			  public List<C> getList(final Object it) {
 			    if (it instanceof C) {
 			      return _getList((C)it);
@@ -147,6 +151,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			import java.util.Iterator;
 			import java.util.List;
 			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.IterableExtensions;
 			
 			@SuppressWarnings("all")
@@ -169,6 +174,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			    return IterableExtensions.<SOE.A>toList(new SOE.CustomItr());
 			  }
 			
+			  @Generated
 			  public List<SOE.A> getList(final Object it) {
 			    if (it instanceof SOE.A) {
 			      return _getList((SOE.A)it);
@@ -204,6 +210,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			import java.util.Iterator;
 			import java.util.List;
 			import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			import org.eclipse.xtext.xbase.lib.IterableExtensions;
 			
 			@SuppressWarnings("all")
@@ -226,6 +233,7 @@ class CompilerBug470768Test extends AbstractXtendCompilerTest {
 			    return CollectionLiterals.<SOE.A>emptyList();
 			  }
 			
+			  @Generated
 			  public List<SOE.A> getList(final Object it) {
 			    if (it instanceof SOE.A) {
 			      return _getList((SOE.A)it);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBugDispatchWithOverrideTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBugDispatchWithOverrideTest.xtend
@@ -34,6 +34,7 @@ class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTest {
 			''',
 			'''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class Something extends AbstractSomething {
@@ -42,6 +43,7 @@ class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTest {
 			  }
 			
 			  @Override
+			  @Generated
 			  public void m(final Object x) {
 			    if (x instanceof Integer) {
 			      _m((Integer)x);
@@ -73,6 +75,7 @@ class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTest {
 			''',
 			'''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class Something extends AbstractSomething {
@@ -81,6 +84,7 @@ class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTest {
 			  }
 			
 			  @Override
+			  @Generated
 			  public void m(final Object x) {
 			    if (x instanceof Integer) {
 			      _m((Integer)x);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBugDispatchWithOverrideTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBugDispatchWithOverrideTest.xtend
@@ -34,7 +34,7 @@ class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTest {
 			''',
 			'''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Something extends AbstractSomething {
@@ -43,7 +43,7 @@ class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTest {
 			  }
 			
 			  @Override
-			  @Generated
+			  @XbaseGenerated
 			  public void m(final Object x) {
 			    if (x instanceof Integer) {
 			      _m((Integer)x);
@@ -75,7 +75,7 @@ class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTest {
 			''',
 			'''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Something extends AbstractSomething {
@@ -84,7 +84,7 @@ class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTest {
 			  }
 			
 			  @Override
-			  @Generated
+			  @XbaseGenerated
 			  public void m(final Object x) {
 			    if (x instanceof Integer) {
 			      _m((Integer)x);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBugInheritedDispatchTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBugInheritedDispatchTest.xtend
@@ -32,6 +32,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class D extends C {
@@ -41,6 +42,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			  protected void _m(final CharSequence o) {
 			  }
 			
+			  @Generated
 			  public void m(final Object o) {
 			    if (o instanceof Integer) {
 			      _m((Integer)o);
@@ -93,6 +95,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class Parent<T extends Object> {
@@ -104,6 +107,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			    return this.test(a.getDann());
 			  }
 			
+			  @Generated
 			  public T test(final Ausdruck a) {
 			    if (a instanceof Fallunterscheidung) {
 			      return _test((Fallunterscheidung)a);
@@ -145,6 +149,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class Child extends Parent<String> {
@@ -152,6 +157,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			    return null;
 			  }
 			
+			  @Generated
 			  public String test(final Ausdruck a) {
 			    if (a instanceof Fallunterscheidung) {
 			      return _test((Fallunterscheidung)a);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBugInheritedDispatchTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBugInheritedDispatchTest.xtend
@@ -32,7 +32,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class D extends C {
@@ -42,7 +42,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			  protected void _m(final CharSequence o) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void m(final Object o) {
 			    if (o instanceof Integer) {
 			      _m((Integer)o);
@@ -95,7 +95,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Parent<T extends Object> {
@@ -107,7 +107,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			    return this.test(a.getDann());
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public T test(final Ausdruck a) {
 			    if (a instanceof Fallunterscheidung) {
 			      return _test((Fallunterscheidung)a);
@@ -149,7 +149,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Child extends Parent<String> {
@@ -157,7 +157,7 @@ class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest {
 			    return null;
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public String test(final Ausdruck a) {
 			    if (a instanceof Fallunterscheidung) {
 			      return _test((Fallunterscheidung)a);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.xtend
@@ -680,7 +680,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			}
 		'''.tracesTo('''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 
 			@SuppressWarnings("all")
 			public class Zonk {
@@ -690,7 +690,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			  protected void _method(final Integer i) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void method(final Object i) {
 			    if (i instanceof Integer) {
 			      _method((Integer)i);
@@ -716,7 +716,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			}
 		'''.tracesTo('''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 
 			@SuppressWarnings("all")
 			public class Zonk {
@@ -726,7 +726,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			  protected void _method(final Integer i) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void #method#(final Object i) {
 			    if (i instanceof Integer) {
 			      _method((Integer)i);
@@ -752,7 +752,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			}
 		'''.tracesTo('''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 
 			@SuppressWarnings("all")
 			public class Zonk {
@@ -762,7 +762,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			  protected void _method(final Integer i) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void method(final Object i) {
 			    if (i instanceof Integer) {
 			      _method((Integer)i);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.xtend
@@ -680,6 +680,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			}
 		'''.tracesTo('''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 
 			@SuppressWarnings("all")
 			public class Zonk {
@@ -689,6 +690,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			  protected void _method(final Integer i) {
 			  }
 			
+			  @Generated
 			  public void method(final Object i) {
 			    if (i instanceof Integer) {
 			      _method((Integer)i);
@@ -714,6 +716,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			}
 		'''.tracesTo('''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 
 			@SuppressWarnings("all")
 			public class Zonk {
@@ -723,6 +726,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			  protected void _method(final Integer i) {
 			  }
 			
+			  @Generated
 			  public void #method#(final Object i) {
 			    if (i instanceof Integer) {
 			      _method((Integer)i);
@@ -748,6 +752,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			}
 		'''.tracesTo('''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 
 			@SuppressWarnings("all")
 			public class Zonk {
@@ -757,6 +762,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			  protected void _method(final Integer i) {
 			  }
 			
+			  @Generated
 			  public void method(final Object i) {
 			    if (i instanceof Integer) {
 			      _method((Integer)i);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/DispatchCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/DispatchCompilerTest.xtend
@@ -36,7 +36,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''','''
 		import java.util.Arrays;
-		import org.eclipse.xtext.xbase.lib.Generated;
+		import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 		
 		@SuppressWarnings("all")
 		public class Foo {
@@ -56,7 +56,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 		    return null;
 		  }
 		
-		  @Generated
+		  @XbaseGenerated
 		  public Object foo(final Object assert_) {
 		    if (assert_ instanceof String) {
 		      return _foo((String)assert_);
@@ -68,7 +68,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 		    }
 		  }
 		
-		  @Generated
+		  @XbaseGenerated
 		  public Object bar(final Object assert_, final String assert__1) {
 		    if (assert_ instanceof String) {
 		      return _bar((String)assert_, assert__1);
@@ -96,7 +96,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import org.eclipse.xtext.xbase.lib.Extension;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -104,7 +104,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return s.substring(4);
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public String m(final String s) {
 			    return _m(s);
 			  }
@@ -121,7 +121,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				}
 			}
 		''', '''
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -129,7 +129,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    throw new RuntimeException();
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void minus(final Object operand) {
 			    _minus(operand);
 			    return;
@@ -147,7 +147,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				}
 			}
 		''', '''
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -155,7 +155,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    throw new RuntimeException();
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public int minus(final Object operand) {
 			    return _minus(operand);
 			  }
@@ -178,7 +178,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 		''', '''
 			import java.util.Arrays;
 			import org.eclipse.xtext.xbase.lib.DoubleExtensions;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -197,7 +197,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return DoubleExtensions.operator_minus(e);
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public double minus(final Object e) {
 			    if (e instanceof Double) {
 			      return _minus((Double)e);
@@ -230,7 +230,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -246,7 +246,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    throw new RuntimeException();
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void minus(final Object e) {
 			    if (e instanceof Double) {
 			      _minus((Double)e);
@@ -280,7 +280,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			import java.util.Arrays;
 			import org.eclipse.xtext.xbase.lib.DoubleExtensions;
 			import org.eclipse.xtext.xbase.lib.Exceptions;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -301,7 +301,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return Double.valueOf(DoubleExtensions.operator_minus(e));
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public Number minus(final Object e) {
 			    if (e instanceof Double) {
 			      return _minus((Double)e);
@@ -332,7 +332,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			import java.util.Arrays;
 			import org.eclipse.xtext.xbase.lib.DoubleExtensions;
 			import org.eclipse.xtext.xbase.lib.Exceptions;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -353,7 +353,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return Double.valueOf(DoubleExtensions.operator_minus(e));
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public Number minus(final Object e) {
 			    if (e instanceof Double) {
 			      return _minus((Double)e);
@@ -383,7 +383,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -395,7 +395,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return null;
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public Object m(final Object sb, final int x) {
 			    if (sb instanceof StringBuffer) {
 			      return _m((StringBuffer)sb, x);
@@ -432,7 +432,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -452,7 +452,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return null;
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public Object m(final Number x) {
 			    if (x instanceof Double) {
 			      return _m((Double)x);
@@ -490,7 +490,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -506,7 +506,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return null;
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public Object m(final Object x) {
 			    if (x instanceof Integer) {
 			      return _m((Integer)x);
@@ -531,7 +531,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				def dispatch void doThing(Object o) {}
 			}
 		''', '''
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Test {
@@ -541,7 +541,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _doThing(final Object o) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void doThing(final Object v) {
 			    if (v == null) {
 			      _doThing((Void)null);
@@ -563,7 +563,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				def dispatch void doThing(String o) {}
 			}
 		''', '''
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Test {
@@ -573,7 +573,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _doThing(final String o) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void doThing(final String o) {
 			    if (o != null) {
 			      _doThing(o);
@@ -595,7 +595,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				def dispatch void doThing(Object p0, Void p1) {}
 			}
 		''', '''
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Test {
@@ -605,7 +605,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _doThing(final Object p0, final Void p1) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void doThing(final Object p0, final Object p1) {
 			    if (p0 == null
 			         && p1 != null) {
@@ -630,7 +630,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Test {
@@ -646,7 +646,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return "";
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public String toExpectation(final Object p1) {
 			    if (p1 instanceof Integer) {
 			      return _toExpectation((Integer)p1);
@@ -672,7 +672,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Test {
@@ -682,7 +682,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _doThing(final Object p0, final Integer p1) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void doThing(final Object p0, final Number p1) {
 			    if (p0 == null
 			         && p1 instanceof Float) {
@@ -708,14 +708,14 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				def dispatch void doThing(Object p0, Integer p1) {}
 			}
 		''', '''
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Test {
 			  protected void _doThing(final Object p0, final Integer p1) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void doThing(final Object p0, final Integer p1) {
 			    _doThing(p0, p1);
 			    return;
@@ -732,14 +732,14 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Test {
 			  protected void _doThing(final Void p0, final Integer p1) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void doThing(final Object p0, final Integer p1) {
 			    if (p0 == null) {
 			      _doThing((Void)null, p1);
@@ -761,14 +761,14 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Test {
 			  protected void _doThing(final Void p0, final Void p1) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void doThing(final Object p0, final Object p1) {
 			    if (p0 == null
 			         && p1 == null) {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/DispatchCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/DispatchCompilerTest.xtend
@@ -36,6 +36,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''','''
 		import java.util.Arrays;
+		import org.eclipse.xtext.xbase.lib.Generated;
 		
 		@SuppressWarnings("all")
 		public class Foo {
@@ -55,6 +56,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 		    return null;
 		  }
 		
+		  @Generated
 		  public Object foo(final Object assert_) {
 		    if (assert_ instanceof String) {
 		      return _foo((String)assert_);
@@ -66,6 +68,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 		    }
 		  }
 		
+		  @Generated
 		  public Object bar(final Object assert_, final String assert__1) {
 		    if (assert_ instanceof String) {
 		      return _bar((String)assert_, assert__1);
@@ -93,6 +96,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import org.eclipse.xtext.xbase.lib.Extension;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -100,6 +104,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return s.substring(4);
 			  }
 			
+			  @Generated
 			  public String m(final String s) {
 			    return _m(s);
 			  }
@@ -116,12 +121,15 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				}
 			}
 		''', '''
+			import org.eclipse.xtext.xbase.lib.Generated;
+			
 			@SuppressWarnings("all")
 			public class C {
 			  protected void _minus(final Object operand) {
 			    throw new RuntimeException();
 			  }
 			
+			  @Generated
 			  public void minus(final Object operand) {
 			    _minus(operand);
 			    return;
@@ -139,12 +147,15 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				}
 			}
 		''', '''
+			import org.eclipse.xtext.xbase.lib.Generated;
+			
 			@SuppressWarnings("all")
 			public class C {
 			  protected int _minus(final Object operand) {
 			    throw new RuntimeException();
 			  }
 			
+			  @Generated
 			  public int minus(final Object operand) {
 			    return _minus(operand);
 			  }
@@ -167,6 +178,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 		''', '''
 			import java.util.Arrays;
 			import org.eclipse.xtext.xbase.lib.DoubleExtensions;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -185,6 +197,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return DoubleExtensions.operator_minus(e);
 			  }
 			
+			  @Generated
 			  public double minus(final Object e) {
 			    if (e instanceof Double) {
 			      return _minus((Double)e);
@@ -217,6 +230,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -232,6 +246,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    throw new RuntimeException();
 			  }
 			
+			  @Generated
 			  public void minus(final Object e) {
 			    if (e instanceof Double) {
 			      _minus((Double)e);
@@ -265,6 +280,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			import java.util.Arrays;
 			import org.eclipse.xtext.xbase.lib.DoubleExtensions;
 			import org.eclipse.xtext.xbase.lib.Exceptions;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -285,6 +301,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return Double.valueOf(DoubleExtensions.operator_minus(e));
 			  }
 			
+			  @Generated
 			  public Number minus(final Object e) {
 			    if (e instanceof Double) {
 			      return _minus((Double)e);
@@ -315,6 +332,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			import java.util.Arrays;
 			import org.eclipse.xtext.xbase.lib.DoubleExtensions;
 			import org.eclipse.xtext.xbase.lib.Exceptions;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -335,6 +353,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return Double.valueOf(DoubleExtensions.operator_minus(e));
 			  }
 			
+			  @Generated
 			  public Number minus(final Object e) {
 			    if (e instanceof Double) {
 			      return _minus((Double)e);
@@ -364,6 +383,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -375,6 +395,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return null;
 			  }
 			
+			  @Generated
 			  public Object m(final Object sb, final int x) {
 			    if (sb instanceof StringBuffer) {
 			      return _m((StringBuffer)sb, x);
@@ -411,6 +432,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -430,6 +452,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return null;
 			  }
 			
+			  @Generated
 			  public Object m(final Number x) {
 			    if (x instanceof Double) {
 			      return _m((Double)x);
@@ -467,6 +490,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -482,6 +506,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return null;
 			  }
 			
+			  @Generated
 			  public Object m(final Object x) {
 			    if (x instanceof Integer) {
 			      return _m((Integer)x);
@@ -506,6 +531,8 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				def dispatch void doThing(Object o) {}
 			}
 		''', '''
+			import org.eclipse.xtext.xbase.lib.Generated;
+			
 			@SuppressWarnings("all")
 			public class Test {
 			  protected void _doThing(final Void v) {
@@ -514,6 +541,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _doThing(final Object o) {
 			  }
 			
+			  @Generated
 			  public void doThing(final Object v) {
 			    if (v == null) {
 			      _doThing((Void)null);
@@ -525,7 +553,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			  }
 			}
 		''')
-	}		
+	}
 
 	@Test
 	def testVoidAndStringDoNotGenerateUnusedCode() {
@@ -535,6 +563,8 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				def dispatch void doThing(String o) {}
 			}
 		''', '''
+			import org.eclipse.xtext.xbase.lib.Generated;
+			
 			@SuppressWarnings("all")
 			public class Test {
 			  protected void _doThing(final Void v) {
@@ -543,6 +573,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _doThing(final String o) {
 			  }
 			
+			  @Generated
 			  public void doThing(final String o) {
 			    if (o != null) {
 			      _doThing(o);
@@ -554,7 +585,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			  }
 			}
 		''')
-	}		
+	}
 
 	@Test
 	def testVoidAndObjectTwoParametersDoNotGenerateUnusedCode() {
@@ -564,6 +595,8 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				def dispatch void doThing(Object p0, Void p1) {}
 			}
 		''', '''
+			import org.eclipse.xtext.xbase.lib.Generated;
+			
 			@SuppressWarnings("all")
 			public class Test {
 			  protected void _doThing(final Void p0, final Object p1) {
@@ -572,6 +605,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _doThing(final Object p0, final Void p1) {
 			  }
 			
+			  @Generated
 			  public void doThing(final Object p0, final Object p1) {
 			    if (p0 == null
 			         && p1 != null) {
@@ -585,7 +619,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''')
 	}
-			
+
 	@Test
 	def testVoidNotAllCases() {
 		assertCompilesTo('''
@@ -596,6 +630,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class Test {
@@ -611,6 +646,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			    return "";
 			  }
 			
+			  @Generated
 			  public String toExpectation(final Object p1) {
 			    if (p1 instanceof Integer) {
 			      return _toExpectation((Integer)p1);
@@ -636,6 +672,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class Test {
@@ -645,6 +682,7 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _doThing(final Object p0, final Integer p1) {
 			  }
 			
+			  @Generated
 			  public void doThing(final Object p0, final Number p1) {
 			    if (p0 == null
 			         && p1 instanceof Float) {
@@ -670,11 +708,14 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 				def dispatch void doThing(Object p0, Integer p1) {}
 			}
 		''', '''
+			import org.eclipse.xtext.xbase.lib.Generated;
+			
 			@SuppressWarnings("all")
 			public class Test {
 			  protected void _doThing(final Object p0, final Integer p1) {
 			  }
 			
+			  @Generated
 			  public void doThing(final Object p0, final Integer p1) {
 			    _doThing(p0, p1);
 			    return;
@@ -691,12 +732,14 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class Test {
 			  protected void _doThing(final Void p0, final Integer p1) {
 			  }
 			
+			  @Generated
 			  public void doThing(final Object p0, final Integer p1) {
 			    if (p0 == null) {
 			      _doThing((Void)null, p1);
@@ -718,12 +761,14 @@ class DispatchCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class Test {
 			  protected void _doThing(final Void p0, final Void p1) {
 			  }
 			
+			  @Generated
 			  public void doThing(final Object p0, final Object p1) {
 			    if (p0 == null
 			         && p1 == null) {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
@@ -386,7 +386,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -398,7 +398,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return s.length();
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public int testFunction1(final CharSequence s) {
 			    if (s instanceof String) {
 			      return _testFunction1((String)s);
@@ -434,7 +434,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -446,7 +446,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return i.intValue();
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public int testFunction1(final Object i) {
 			    if (i instanceof Integer) {
 			      return _testFunction1((Integer)i);
@@ -479,7 +479,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class D extends C {
@@ -487,7 +487,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return d.intValue();
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public int testFunction1(final Object d) {
 			    if (d instanceof Double) {
 			      return _testFunction1((Double)d);
@@ -525,7 +525,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class D extends C {
@@ -537,7 +537,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return n.intValue();
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public int testFunction1(final Object d) {
 			    if (d instanceof Double) {
 			      return _testFunction1((Double)d);
@@ -577,7 +577,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -589,7 +589,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return i.intValue();
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public int testFunction1(final Object i) {
 			    if (i instanceof Integer) {
 			      return _testFunction1((Integer)i);
@@ -3088,7 +3088,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			package foo;
 			
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class NoSuchElementException {
@@ -3098,7 +3098,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _foo(final Object s) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void foo(final Object s) {
 			    if (s instanceof String) {
 			      _foo((String)s);
@@ -3128,7 +3128,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			package foo;
 			
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class MyType {
@@ -3141,7 +3141,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _foo(final Object s, final Object other) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void foo(final Object s, final Object other) {
 			    if (s instanceof String
 			         && other instanceof CharSequence) {
@@ -3177,7 +3177,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			package foo;
 			
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class MyType {
@@ -3190,7 +3190,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _foo(final String s, final CharSequence other) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void foo(final Object s, final Object other) {
 			    if (s instanceof String
 			         && other instanceof CharSequence) {
@@ -3225,7 +3225,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			package foo;
 			
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class MyType {
@@ -3235,7 +3235,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _foo(final StringBuffer s, final boolean b, final String other) {
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public void foo(final Object s, final boolean b, final String other) {
 			    if (s instanceof StringBuffer) {
 			      _foo((StringBuffer)s, b, other);
@@ -5266,7 +5266,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			class B implements Element<B> {}
 		'''.assertCompilesTo('''
 			import java.util.Arrays;
-			import org.eclipse.xtext.xbase.lib.Generated;
+			import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 			
 			@SuppressWarnings("all")
 			public class Bug {
@@ -5278,7 +5278,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return 1;
 			  }
 			
-			  @Generated
+			  @XbaseGenerated
 			  public int bug(final Element<?> a) {
 			    if (a instanceof A) {
 			      return _bug((A)a);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
@@ -386,6 +386,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -397,6 +398,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return s.length();
 			  }
 			
+			  @Generated
 			  public int testFunction1(final CharSequence s) {
 			    if (s instanceof String) {
 			      return _testFunction1((String)s);
@@ -432,6 +434,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -443,6 +446,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return i.intValue();
 			  }
 			
+			  @Generated
 			  public int testFunction1(final Object i) {
 			    if (i instanceof Integer) {
 			      return _testFunction1((Integer)i);
@@ -475,6 +479,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class D extends C {
@@ -482,6 +487,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return d.intValue();
 			  }
 			
+			  @Generated
 			  public int testFunction1(final Object d) {
 			    if (d instanceof Double) {
 			      return _testFunction1((Double)d);
@@ -519,6 +525,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class D extends C {
@@ -530,6 +537,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return n.intValue();
 			  }
 			
+			  @Generated
 			  public int testFunction1(final Object d) {
 			    if (d instanceof Double) {
 			      return _testFunction1((Double)d);
@@ -569,6 +577,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class C {
@@ -580,6 +589,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return i.intValue();
 			  }
 			
+			  @Generated
 			  public int testFunction1(final Object i) {
 			    if (i instanceof Integer) {
 			      return _testFunction1((Integer)i);
@@ -3076,9 +3086,10 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			package foo;
-
+			
 			import java.util.Arrays;
-
+			import org.eclipse.xtext.xbase.lib.Generated;
+			
 			@SuppressWarnings("all")
 			public class NoSuchElementException {
 			  protected void _foo(final String s) {
@@ -3087,6 +3098,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _foo(final Object s) {
 			  }
 			
+			  @Generated
 			  public void foo(final Object s) {
 			    if (s instanceof String) {
 			      _foo((String)s);
@@ -3114,9 +3126,10 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			package foo;
-
+			
 			import java.util.Arrays;
-
+			import org.eclipse.xtext.xbase.lib.Generated;
+			
 			@SuppressWarnings("all")
 			public class MyType {
 			  protected void _foo(final String s, final CharSequence other) {
@@ -3128,6 +3141,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _foo(final Object s, final Object other) {
 			  }
 			
+			  @Generated
 			  public void foo(final Object s, final Object other) {
 			    if (s instanceof String
 			         && other instanceof CharSequence) {
@@ -3161,9 +3175,10 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			}
 		''', '''
 			package foo;
-
+			
 			import java.util.Arrays;
-
+			import org.eclipse.xtext.xbase.lib.Generated;
+			
 			@SuppressWarnings("all")
 			public class MyType {
 			  protected void _foo(final Object s, final Object other) {
@@ -3175,6 +3190,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _foo(final String s, final CharSequence other) {
 			  }
 			
+			  @Generated
 			  public void foo(final Object s, final Object other) {
 			    if (s instanceof String
 			         && other instanceof CharSequence) {
@@ -3209,6 +3225,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			package foo;
 			
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class MyType {
@@ -3218,6 +3235,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			  protected void _foo(final StringBuffer s, final boolean b, final String other) {
 			  }
 			
+			  @Generated
 			  public void foo(final Object s, final boolean b, final String other) {
 			    if (s instanceof StringBuffer) {
 			      _foo((StringBuffer)s, b, other);
@@ -5248,6 +5266,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			class B implements Element<B> {}
 		'''.assertCompilesTo('''
 			import java.util.Arrays;
+			import org.eclipse.xtext.xbase.lib.Generated;
 			
 			@SuppressWarnings("all")
 			public class Bug {
@@ -5259,6 +5278,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    return 1;
 			  }
 			
+			  @Generated
 			  public int bug(final Element<?> a) {
 			    if (a instanceof A) {
 			      return _bug((A)a);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/batch/BatchCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/batch/BatchCompilerTest.xtend
@@ -486,7 +486,7 @@ class BatchCompilerTest {
 		assertTrue(batchCompiler.compile)
 		assertEquals(0, new File(TEMP_DIRECTORY).list.size)
 	}
-	
+
 	@Test
 	def void testNoSuppressWarningsAnnotations() {
 		batchCompiler.generateSyntheticSuppressWarnings = false
@@ -494,8 +494,15 @@ class BatchCompilerTest {
 		assertTrue(batchCompiler.compile)
 		assertFalse((OUTPUT_DIRECTORY + "/XtendA.java").contents.contains("@SuppressWarnings"))
 	}
-	
-	
+
+	@Test
+	def void testNoXbaseGenerated() {
+		batchCompiler.useXbaseGenerated = false
+		batchCompiler.sourcePath = "./batch-compiler-data/xtendClass"
+		assertTrue(batchCompiler.compile)
+		assertFalse((OUTPUT_DIRECTORY + "/XtendA.java").contents.contains("@XbaseGenerated"))
+	}
+
 	@Test(expected = IllegalArgumentException)
 	def void testJavaVersion5() {
 		batchCompiler.javaSourceVersion = "1.5"

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.xtend
@@ -1749,6 +1749,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				
 				import java.util.Arrays;
 				import myannotation.AddDispatchCase;
+				import org.eclipse.xtext.xbase.lib.Generated;
 				
 				@AddDispatchCase
 				@SuppressWarnings("all")
@@ -1757,6 +1758,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				    return null;
 				  }
 				
+				  @Generated
 				  public String m(final Object i) {
 				    if (i instanceof Integer) {
 				      return _m((Integer)i);
@@ -1856,12 +1858,14 @@ abstract class AbstractReusableActiveAnnotationTests {
 				package myusercode;
 				
 				import myannotation.Base;
+				import org.eclipse.xtext.xbase.lib.Generated;
 				
 				@SuppressWarnings("all")
 				public class D1 {
 				  protected void _m(final Base b) {
 				  }
 				
+				  @Generated
 				  public void m(final Base b) {
 				    _m(b);
 				    return;
@@ -1873,6 +1877,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				
 				import java.util.Arrays;
 				import myannotation.Base;
+				import org.eclipse.xtext.xbase.lib.Generated;
 				
 				@SuppressWarnings("all")
 				public class D2 extends D1 {
@@ -1885,6 +1890,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				  protected void _m(final Derived3 d) {
 				  }
 				
+				  @Generated
 				  public void m(final Base d) {
 				    if (d instanceof Derived1) {
 				      _m((Derived1)d);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.xtend
@@ -1749,7 +1749,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				
 				import java.util.Arrays;
 				import myannotation.AddDispatchCase;
-				import org.eclipse.xtext.xbase.lib.Generated;
+				import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 				
 				@AddDispatchCase
 				@SuppressWarnings("all")
@@ -1758,7 +1758,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				    return null;
 				  }
 				
-				  @Generated
+				  @XbaseGenerated
 				  public String m(final Object i) {
 				    if (i instanceof Integer) {
 				      return _m((Integer)i);
@@ -1858,14 +1858,14 @@ abstract class AbstractReusableActiveAnnotationTests {
 				package myusercode;
 				
 				import myannotation.Base;
-				import org.eclipse.xtext.xbase.lib.Generated;
+				import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 				
 				@SuppressWarnings("all")
 				public class D1 {
 				  protected void _m(final Base b) {
 				  }
 				
-				  @Generated
+				  @XbaseGenerated
 				  public void m(final Base b) {
 				    _m(b);
 				    return;
@@ -1877,7 +1877,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				
 				import java.util.Arrays;
 				import myannotation.Base;
-				import org.eclipse.xtext.xbase.lib.Generated;
+				import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 				
 				@SuppressWarnings("all")
 				public class D2 extends D1 {
@@ -1890,7 +1890,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				  protected void _m(final Derived3 d) {
 				  }
 				
-				  @Generated
+				  @XbaseGenerated
 				  public void m(final Base d) {
 				    if (d instanceof Derived1) {
 				      _m((Derived1)d);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug423631Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug423631Test.java
@@ -46,7 +46,7 @@ public class CompilerBug423631Test extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -74,7 +74,7 @@ public class CompilerBug423631Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object m(final A a) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug423631Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug423631Test.java
@@ -46,6 +46,8 @@ public class CompilerBug423631Test extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -70,6 +72,9 @@ public class CompilerBug423631Test extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object m(final A a) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug427637Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug427637Test.java
@@ -2531,11 +2531,11 @@ public class CompilerBug427637Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Functions.Function1;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
-    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.IterableExtensions;");
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.util.ToStringHelper;");
     _builder_1.newLine();
@@ -3996,7 +3996,7 @@ public class CompilerBug427637Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("protected Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> newFormattingData(final HiddenLeafs leafs, final PreferenceKey key, final FormattingDataFactory.FormattingDataInit it) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug427637Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug427637Test.java
@@ -2531,6 +2531,8 @@ public class CompilerBug427637Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Functions.Function1;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.IterableExtensions;");
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;");
@@ -3992,6 +3994,9 @@ public class CompilerBug427637Test extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("protected Function1<? super FormattableDocument, ? extends Iterable<FormattingData>> newFormattingData(final HiddenLeafs leafs, final PreferenceKey key, final FormattingDataFactory.FormattingDataInit it) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug441096Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug441096Test.java
@@ -74,6 +74,8 @@ public class CompilerBug441096Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtend.lib.annotations.Accessors;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Pure;");
     _builder_1.newLine();
     _builder_1.newLine();
@@ -134,6 +136,9 @@ public class CompilerBug441096Test extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("};");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void m(final Object expr, final Object seq) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug441096Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug441096Test.java
@@ -74,9 +74,9 @@ public class CompilerBug441096Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtend.lib.annotations.Accessors;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
-    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Pure;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -138,7 +138,7 @@ public class CompilerBug441096Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void m(final Object expr, final Object seq) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug441099Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug441099Test.java
@@ -62,9 +62,9 @@ public class CompilerBug441099Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtend.lib.annotations.Accessors;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
-    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Pure;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -99,7 +99,7 @@ public class CompilerBug441099Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object m(final String x) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug441099Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug441099Test.java
@@ -62,6 +62,8 @@ public class CompilerBug441099Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtend.lib.annotations.Accessors;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Pure;");
     _builder_1.newLine();
     _builder_1.newLine();
@@ -95,6 +97,9 @@ public class CompilerBug441099Test extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object m(final String x) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug470768Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug470768Test.java
@@ -68,6 +68,8 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.IterableExtensions;");
     _builder_1.newLine();
     _builder_1.newLine();
@@ -120,6 +122,9 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public List<SOE.A> getList(final Object it) {");
@@ -205,6 +210,8 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.IterableExtensions;");
     _builder_1.newLine();
     _builder_1.newLine();
@@ -250,6 +257,9 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public List<C> getList(final Object it) {");
@@ -340,6 +350,8 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.IterableExtensions;");
     _builder_1.newLine();
     _builder_1.newLine();
@@ -392,6 +404,9 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public List<SOE.A> getList(final Object it) {");
@@ -480,6 +495,8 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.IterableExtensions;");
     _builder_1.newLine();
     _builder_1.newLine();
@@ -532,6 +549,9 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public List<SOE.A> getList(final Object it) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug470768Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug470768Test.java
@@ -68,9 +68,9 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
-    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.IterableExtensions;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -124,7 +124,7 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public List<SOE.A> getList(final Object it) {");
@@ -210,9 +210,9 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
-    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.IterableExtensions;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -259,7 +259,7 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public List<C> getList(final Object it) {");
@@ -350,9 +350,9 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
-    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.IterableExtensions;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -406,7 +406,7 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public List<SOE.A> getList(final Object it) {");
@@ -495,9 +495,9 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.CollectionLiterals;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
-    _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.IterableExtensions;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -551,7 +551,7 @@ public class CompilerBug470768Test extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public List<SOE.A> getList(final Object it) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBugDispatchWithOverrideTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBugDispatchWithOverrideTest.java
@@ -45,7 +45,7 @@ public class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTe
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -66,7 +66,7 @@ public class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTe
     _builder_1.append("@Override");
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void m(final Object x) {");
@@ -133,7 +133,7 @@ public class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTe
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -154,7 +154,7 @@ public class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTe
     _builder_1.append("@Override");
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void m(final Object x) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBugDispatchWithOverrideTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBugDispatchWithOverrideTest.java
@@ -45,6 +45,8 @@ public class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTe
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -62,6 +64,9 @@ public class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTe
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("@Override");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void m(final Object x) {");
@@ -128,6 +133,8 @@ public class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTe
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -145,6 +152,9 @@ public class CompilerBugDispatchWithOverrideTest extends AbstractXtendCompilerTe
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("@Override");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void m(final Object x) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBugInheritedDispatchTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBugInheritedDispatchTest.java
@@ -53,7 +53,7 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -75,7 +75,7 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void m(final Object o) {");
@@ -210,7 +210,7 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -238,7 +238,7 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public T test(final Ausdruck a) {");
@@ -340,7 +340,7 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -358,7 +358,7 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public String test(final Ausdruck a) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBugInheritedDispatchTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBugInheritedDispatchTest.java
@@ -53,6 +53,8 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -71,6 +73,9 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void m(final Object o) {");
@@ -205,6 +210,8 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -229,6 +236,9 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public T test(final Ausdruck a) {");
@@ -330,6 +340,8 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -344,6 +356,9 @@ public class CompilerBugInheritedDispatchTest extends AbstractXtendCompilerTest 
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public String test(final Ausdruck a) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.java
@@ -1333,6 +1333,8 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -1351,6 +1353,9 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void method(final Object i) {");
@@ -1409,6 +1414,8 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -1427,6 +1434,9 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void #method#(final Object i) {");
@@ -1485,6 +1495,8 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -1503,6 +1515,9 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void method(final Object i) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.java
@@ -1333,7 +1333,7 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1355,7 +1355,7 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void method(final Object i) {");
@@ -1414,7 +1414,7 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1436,7 +1436,7 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void #method#(final Object i) {");
@@ -1495,7 +1495,7 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1517,7 +1517,7 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void method(final Object i) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/DispatchCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/DispatchCompilerTest.java
@@ -57,6 +57,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -103,6 +105,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
+    _builder_1.append("@Generated");
+    _builder_1.newLine();
+    _builder_1.append("  ");
     _builder_1.append("public Object foo(final Object assert_) {");
     _builder_1.newLine();
     _builder_1.append("    ");
@@ -132,6 +137,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object bar(final Object assert_, final String assert__1) {");
@@ -190,6 +198,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Extension;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -204,6 +214,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public String m(final String s) {");
@@ -236,6 +249,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
+    _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
     _builder_1.append("public class C {");
@@ -249,6 +265,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void minus(final Object operand) {");
@@ -284,6 +303,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
+    _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
     _builder_1.append("public class C {");
@@ -297,6 +319,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int minus(final Object operand) {");
@@ -345,6 +370,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.DoubleExtensions;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -388,6 +415,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public double minus(final Object e) {");
@@ -467,6 +497,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -501,6 +533,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void minus(final Object e) {");
@@ -581,6 +616,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Exceptions;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -630,6 +667,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Number minus(final Object e) {");
@@ -701,6 +741,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Exceptions;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -750,6 +792,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Number minus(final Object e) {");
@@ -820,6 +865,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -844,6 +891,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object m(final Object sb, final int x) {");
@@ -929,6 +979,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -973,6 +1025,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object m(final Number x) {");
@@ -1061,6 +1116,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -1095,6 +1152,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object m(final Object x) {");
@@ -1151,6 +1211,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
+    _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
     _builder_1.append("public class Test {");
@@ -1168,6 +1231,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object v) {");
@@ -1215,6 +1281,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
+    _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
     _builder_1.append("public class Test {");
@@ -1232,6 +1301,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final String o) {");
@@ -1279,6 +1351,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
+    _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
     _builder_1.append("public class Test {");
@@ -1296,6 +1371,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object p0, final Object p1) {");
@@ -1351,6 +1429,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -1385,6 +1465,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public String toExpectation(final Object p1) {");
@@ -1443,6 +1526,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -1461,6 +1546,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object p0, final Number p1) {");
@@ -1520,6 +1608,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
+    _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
     _builder_1.append("public class Test {");
@@ -1530,6 +1621,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object p0, final Integer p1) {");
@@ -1561,6 +1655,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -1572,6 +1668,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object p0, final Integer p1) {");
@@ -1618,6 +1717,8 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -1629,6 +1730,9 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object p0, final Object p1) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/DispatchCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/DispatchCompilerTest.java
@@ -57,7 +57,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -105,7 +105,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object foo(final Object assert_) {");
@@ -139,7 +139,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object bar(final Object assert_, final String assert__1) {");
@@ -198,7 +198,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Extension;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -216,7 +216,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public String m(final String s) {");
@@ -249,7 +249,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -267,7 +267,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void minus(final Object operand) {");
@@ -303,7 +303,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -321,7 +321,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int minus(final Object operand) {");
@@ -370,7 +370,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.DoubleExtensions;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -417,7 +417,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public double minus(final Object e) {");
@@ -497,7 +497,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -535,7 +535,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void minus(final Object e) {");
@@ -616,7 +616,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Exceptions;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -669,7 +669,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Number minus(final Object e) {");
@@ -741,7 +741,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import org.eclipse.xtext.xbase.lib.Exceptions;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -794,7 +794,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Number minus(final Object e) {");
@@ -865,7 +865,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -893,7 +893,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object m(final Object sb, final int x) {");
@@ -979,7 +979,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1027,7 +1027,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object m(final Number x) {");
@@ -1116,7 +1116,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1154,7 +1154,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public Object m(final Object x) {");
@@ -1211,7 +1211,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1233,7 +1233,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object v) {");
@@ -1281,7 +1281,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1303,7 +1303,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final String o) {");
@@ -1351,7 +1351,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1373,7 +1373,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object p0, final Object p1) {");
@@ -1429,7 +1429,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1467,7 +1467,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public String toExpectation(final Object p1) {");
@@ -1526,7 +1526,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1548,7 +1548,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object p0, final Number p1) {");
@@ -1608,7 +1608,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1623,7 +1623,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object p0, final Integer p1) {");
@@ -1655,7 +1655,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1670,7 +1670,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object p0, final Integer p1) {");
@@ -1717,7 +1717,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1732,7 +1732,7 @@ public class DispatchCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void doThing(final Object p0, final Object p1) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
@@ -847,6 +847,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -871,6 +873,9 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int testFunction1(final CharSequence s) {");
@@ -951,6 +956,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -975,6 +982,9 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int testFunction1(final Object i) {");
@@ -1052,6 +1062,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -1066,6 +1078,9 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int testFunction1(final Object d) {");
@@ -1158,6 +1173,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -1182,6 +1199,9 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int testFunction1(final Object d) {");
@@ -1280,6 +1300,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -1304,6 +1326,9 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int testFunction1(final Object i) {");
@@ -7043,6 +7068,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -7061,6 +7088,9 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void foo(final Object s) {");
@@ -7127,6 +7157,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -7152,6 +7184,9 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void foo(final Object s, final Object other) {");
@@ -7236,6 +7271,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -7261,6 +7298,9 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void foo(final Object s, final Object other) {");
@@ -7342,6 +7382,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -7360,6 +7402,9 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void foo(final Object s, final boolean b, final String other) {");
@@ -11557,6 +11602,8 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
     _builder_1.newLine();
@@ -11581,6 +11628,9 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.append("}");
     _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Generated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int bug(final Element<?> a) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
@@ -847,7 +847,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -875,7 +875,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int testFunction1(final CharSequence s) {");
@@ -956,7 +956,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -984,7 +984,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int testFunction1(final Object i) {");
@@ -1062,7 +1062,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1080,7 +1080,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int testFunction1(final Object d) {");
@@ -1173,7 +1173,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1201,7 +1201,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int testFunction1(final Object d) {");
@@ -1300,7 +1300,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -1328,7 +1328,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int testFunction1(final Object i) {");
@@ -7068,7 +7068,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -7090,7 +7090,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void foo(final Object s) {");
@@ -7157,7 +7157,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -7186,7 +7186,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void foo(final Object s, final Object other) {");
@@ -7271,7 +7271,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -7300,7 +7300,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void foo(final Object s, final Object other) {");
@@ -7382,7 +7382,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -7404,7 +7404,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public void foo(final Object s, final boolean b, final String other) {");
@@ -11602,7 +11602,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.util.Arrays;");
     _builder_1.newLine();
-    _builder_1.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("@SuppressWarnings(\"all\")");
@@ -11630,7 +11630,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("@Generated");
+    _builder_1.append("@XbaseGenerated");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("public int bug(final Element<?> a) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/batch/BatchCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/batch/BatchCompilerTest.java
@@ -730,6 +730,14 @@ public class BatchCompilerTest {
     Assert.assertFalse(this.getContents((BatchCompilerTest.OUTPUT_DIRECTORY + "/XtendA.java")).contains("@SuppressWarnings"));
   }
 
+  @Test
+  public void testNoXbaseGenerated() {
+    this.batchCompiler.setUseXbaseGenerated(false);
+    this.batchCompiler.setSourcePath("./batch-compiler-data/xtendClass");
+    Assert.assertTrue(this.batchCompiler.compile());
+    Assert.assertFalse(this.getContents((BatchCompilerTest.OUTPUT_DIRECTORY + "/XtendA.java")).contains("@XbaseGenerated"));
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testJavaVersion5() {
     this.batchCompiler.setJavaSourceVersion("1.5");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.java
@@ -3323,7 +3323,7 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_2.newLine();
     _builder_2.append("import myannotation.AddDispatchCase;");
     _builder_2.newLine();
-    _builder_2.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_2.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_2.newLine();
     _builder_2.newLine();
     _builder_2.append("@AddDispatchCase");
@@ -3343,7 +3343,7 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_2.newLine();
     _builder_2.newLine();
     _builder_2.append("  ");
-    _builder_2.append("@Generated");
+    _builder_2.append("@XbaseGenerated");
     _builder_2.newLine();
     _builder_2.append("  ");
     _builder_2.append("public String m(final Object i) {");
@@ -3535,7 +3535,7 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_5.newLine();
     _builder_5.append("import myannotation.Base;");
     _builder_5.newLine();
-    _builder_5.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_5.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_5.newLine();
     _builder_5.newLine();
     _builder_5.append("@SuppressWarnings(\"all\")");
@@ -3550,7 +3550,7 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_5.newLine();
     _builder_5.newLine();
     _builder_5.append("  ");
-    _builder_5.append("@Generated");
+    _builder_5.append("@XbaseGenerated");
     _builder_5.newLine();
     _builder_5.append("  ");
     _builder_5.append("public void m(final Base b) {");
@@ -3574,7 +3574,7 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_6.newLine();
     _builder_6.append("import myannotation.Base;");
     _builder_6.newLine();
-    _builder_6.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_6.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_6.newLine();
     _builder_6.newLine();
     _builder_6.append("@SuppressWarnings(\"all\")");
@@ -3603,7 +3603,7 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_6.newLine();
     _builder_6.newLine();
     _builder_6.append("  ");
-    _builder_6.append("@Generated");
+    _builder_6.append("@XbaseGenerated");
     _builder_6.newLine();
     _builder_6.append("  ");
     _builder_6.append("public void m(final Base d) {");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AbstractReusableActiveAnnotationTests.java
@@ -3323,6 +3323,8 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_2.newLine();
     _builder_2.append("import myannotation.AddDispatchCase;");
     _builder_2.newLine();
+    _builder_2.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_2.newLine();
     _builder_2.newLine();
     _builder_2.append("@AddDispatchCase");
     _builder_2.newLine();
@@ -3339,6 +3341,9 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_2.append("  ");
     _builder_2.append("}");
     _builder_2.newLine();
+    _builder_2.newLine();
+    _builder_2.append("  ");
+    _builder_2.append("@Generated");
     _builder_2.newLine();
     _builder_2.append("  ");
     _builder_2.append("public String m(final Object i) {");
@@ -3530,6 +3535,8 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_5.newLine();
     _builder_5.append("import myannotation.Base;");
     _builder_5.newLine();
+    _builder_5.append("import org.eclipse.xtext.xbase.lib.Generated;");
+    _builder_5.newLine();
     _builder_5.newLine();
     _builder_5.append("@SuppressWarnings(\"all\")");
     _builder_5.newLine();
@@ -3541,6 +3548,9 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_5.append("  ");
     _builder_5.append("}");
     _builder_5.newLine();
+    _builder_5.newLine();
+    _builder_5.append("  ");
+    _builder_5.append("@Generated");
     _builder_5.newLine();
     _builder_5.append("  ");
     _builder_5.append("public void m(final Base b) {");
@@ -3563,6 +3573,8 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_6.append("import java.util.Arrays;");
     _builder_6.newLine();
     _builder_6.append("import myannotation.Base;");
+    _builder_6.newLine();
+    _builder_6.append("import org.eclipse.xtext.xbase.lib.Generated;");
     _builder_6.newLine();
     _builder_6.newLine();
     _builder_6.append("@SuppressWarnings(\"all\")");
@@ -3589,6 +3601,9 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_6.append("  ");
     _builder_6.append("}");
     _builder_6.newLine();
+    _builder_6.newLine();
+    _builder_6.append("  ");
+    _builder_6.append("@Generated");
     _builder_6.newLine();
     _builder_6.append("  ");
     _builder_6.append("public void m(final Base d) {");

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/batch/Main.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/batch/Main.java
@@ -52,6 +52,8 @@ public class Main {
 				compiler.setJavaSourceVersion(arguments.next().trim());
 			} else if ("-noSuppressWarningsAnnotation".equals(argument)) {
 				compiler.setGenerateSyntheticSuppressWarnings(false);
+			} else if ("-noUseXbaseGenerated".equals(argument)) {
+				compiler.setUseXbaseGenerated(false);
 			} else if ("-generateGeneratedAnnotation".equals(argument)) {
 				compiler.setGenerateGeneratedAnnotation(true);
 			} else if ("-includeDateInGeneratedAnnnotation".equals(argument)) {
@@ -90,6 +92,7 @@ public class Main {
 		out.println("-encoding <encoding>                Specify character encoding used by source files");
 		out.println("-javaSourceVersion <version>        Create Java Source compatible to this version. Can be: " + allVersionQualifiers);
 		out.println("-noSuppressWarningsAnnotation       Don't put @SuppressWarnings() into generated Java Code");
+		out.println("-noUseXbaseGenerated                Don't put @XbaseGenerated() into generated Java Code");
 		out.println("-generateGeneratedAnnotation        Put @Generated into generated Java Code");
 		out.println("-includeDateInGeneratedAnnnotation  If -generateGeneratedAnnotation is used, add the current date/time.");
 		out.println("-generateAnnotationComment <string> If -generateGeneratedAnnotation is used, add a comment.");

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/batch/XtendBatchCompiler.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/batch/XtendBatchCompiler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2023, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -313,6 +313,20 @@ public class XtendBatchCompiler {
 	 */
 	public void setGenerateSyntheticSuppressWarnings(final boolean generateSyntheticSuppressWarnings) {
 		generatorConfig.setGenerateSyntheticSuppressWarnings(generateSyntheticSuppressWarnings);
+	}
+
+	/**
+	 * @since 2.36
+	 */
+	public boolean isUseXbaseGenerated() {
+		return generatorConfig.isUseXbaseGenerated();
+	}
+
+	/**
+	 * @since 2.36
+	 */
+	public void setUseXbaseGenerated(final boolean useXbaseGenerated) {
+		generatorConfig.setUseXbaseGenerated(useXbaseGenerated);
 	}
 
 	/**

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
@@ -85,6 +85,7 @@ import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociator;
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypeExtensions;
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypesBuilder;
 import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.Generated;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.resource.BatchLinkableResource;
 
@@ -485,15 +486,11 @@ public class XtendJvmModelInferrer extends AbstractModelInferrer {
 		ListMultimap<DispatchHelper.DispatchSignature, JvmOperation> methods = dispatchHelper.getDeclaredOrEnhancedDispatchMethods(target);
 		for (DispatchHelper.DispatchSignature signature : methods.keySet()) {
 			List<JvmOperation> operations = methods.get(signature);
-			Iterable<JvmOperation> localOperations = Iterables.filter(operations, new Predicate<JvmOperation>() {
-				@Override
-				public boolean apply(JvmOperation input) {
-					return target == input.eContainer();
-				}
-			});
+			Iterable<JvmOperation> localOperations = Iterables.filter(operations, input -> target == input.eContainer());
 			JvmOperation operation = deriveGenericDispatchOperationSignature(localOperations, target);
 			if (operation != null) {
 				dispatchHelper.markAsDispatcherFunction(operation);
+				operation.getAnnotations().add(_annotationTypesBuilder.annotationRef(Generated.class));
 				operation.setSimpleName(signature.getSimpleName());
 				operation.setReturnType(jvmTypesBuilder.inferredType());
 			}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
@@ -490,7 +490,9 @@ public class XtendJvmModelInferrer extends AbstractModelInferrer {
 			JvmOperation operation = deriveGenericDispatchOperationSignature(localOperations, target);
 			if (operation != null) {
 				dispatchHelper.markAsDispatcherFunction(operation);
-				operation.getAnnotations().add(_annotationTypesBuilder.annotationRef(XbaseGenerated.class));
+				if (generatorConfig.isUseXbaseGenerated()) {
+					operation.getAnnotations().add(_annotationTypesBuilder.annotationRef(XbaseGenerated.class));
+				}
 				operation.setSimpleName(signature.getSimpleName());
 				operation.setReturnType(jvmTypesBuilder.inferredType());
 			}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
@@ -85,7 +85,7 @@ import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociator;
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypeExtensions;
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypesBuilder;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.Generated;
+import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.resource.BatchLinkableResource;
 
@@ -490,7 +490,7 @@ public class XtendJvmModelInferrer extends AbstractModelInferrer {
 			JvmOperation operation = deriveGenericDispatchOperationSignature(localOperations, target);
 			if (operation != null) {
 				dispatchHelper.markAsDispatcherFunction(operation);
-				operation.getAnnotations().add(_annotationTypesBuilder.annotationRef(Generated.class));
+				operation.getAnnotations().add(_annotationTypesBuilder.annotationRef(XbaseGenerated.class));
 				operation.setSimpleName(signature.getSimpleName());
 				operation.setReturnType(jvmTypesBuilder.inferredType());
 			}

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/macros/AbstractReusableActiveAnnotationTests.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/macros/AbstractReusableActiveAnnotationTests.xtend
@@ -1749,6 +1749,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				
 				import java.util.Arrays;
 				import myannotation.AddDispatchCase;
+				import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 				
 				@AddDispatchCase
 				@SuppressWarnings("all")
@@ -1757,6 +1758,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				    return null;
 				  }
 				
+				  @XbaseGenerated
 				  public String m(final Object i) {
 				    if (i instanceof Integer) {
 				      return _m((Integer)i);
@@ -1856,12 +1858,14 @@ abstract class AbstractReusableActiveAnnotationTests {
 				package myusercode;
 				
 				import myannotation.Base;
+				import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 				
 				@SuppressWarnings("all")
 				public class D1 {
 				  protected void _m(final Base b) {
 				  }
 				
+				  @XbaseGenerated
 				  public void m(final Base b) {
 				    _m(b);
 				    return;
@@ -1873,6 +1877,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				
 				import java.util.Arrays;
 				import myannotation.Base;
+				import org.eclipse.xtext.xbase.lib.XbaseGenerated;
 				
 				@SuppressWarnings("all")
 				public class D2 extends D1 {
@@ -1885,6 +1890,7 @@ abstract class AbstractReusableActiveAnnotationTests {
 				  protected void _m(final Derived3 d) {
 				  }
 				
+				  @XbaseGenerated
 				  public void m(final Base d) {
 				    if (d instanceof Derived1) {
 				      _m((Derived1)d);

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/macros/AbstractReusableActiveAnnotationTests.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/macros/AbstractReusableActiveAnnotationTests.java
@@ -3323,6 +3323,8 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_2.newLine();
     _builder_2.append("import myannotation.AddDispatchCase;");
     _builder_2.newLine();
+    _builder_2.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
+    _builder_2.newLine();
     _builder_2.newLine();
     _builder_2.append("@AddDispatchCase");
     _builder_2.newLine();
@@ -3339,6 +3341,9 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_2.append("  ");
     _builder_2.append("}");
     _builder_2.newLine();
+    _builder_2.newLine();
+    _builder_2.append("  ");
+    _builder_2.append("@XbaseGenerated");
     _builder_2.newLine();
     _builder_2.append("  ");
     _builder_2.append("public String m(final Object i) {");
@@ -3530,6 +3535,8 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_5.newLine();
     _builder_5.append("import myannotation.Base;");
     _builder_5.newLine();
+    _builder_5.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
+    _builder_5.newLine();
     _builder_5.newLine();
     _builder_5.append("@SuppressWarnings(\"all\")");
     _builder_5.newLine();
@@ -3541,6 +3548,9 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_5.append("  ");
     _builder_5.append("}");
     _builder_5.newLine();
+    _builder_5.newLine();
+    _builder_5.append("  ");
+    _builder_5.append("@XbaseGenerated");
     _builder_5.newLine();
     _builder_5.append("  ");
     _builder_5.append("public void m(final Base b) {");
@@ -3563,6 +3573,8 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_6.append("import java.util.Arrays;");
     _builder_6.newLine();
     _builder_6.append("import myannotation.Base;");
+    _builder_6.newLine();
+    _builder_6.append("import org.eclipse.xtext.xbase.lib.XbaseGenerated;");
     _builder_6.newLine();
     _builder_6.newLine();
     _builder_6.append("@SuppressWarnings(\"all\")");
@@ -3589,6 +3601,9 @@ public abstract class AbstractReusableActiveAnnotationTests {
     _builder_6.append("  ");
     _builder_6.append("}");
     _builder_6.newLine();
+    _builder_6.newLine();
+    _builder_6.append("  ");
+    _builder_6.append("@XbaseGenerated");
     _builder_6.newLine();
     _builder_6.append("  ");
     _builder_6.append("public void m(final Base d) {");

--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendCompilerMojo.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendCompilerMojo.java
@@ -81,6 +81,13 @@ public abstract class AbstractXtendCompilerMojo extends AbstractXtendMojo {
 	private boolean generateSyntheticSuppressWarnings;
 
 	/**
+	 * Whether <code>@XbaseGenerated</code> shall be generated for synthetic members.
+	 * @since 2.36
+	 */
+	@Parameter(defaultValue="true")
+	private boolean useXbaseGenerated;
+
+	/**
 	 * Whether <code>@Generated</code> shall be generated for non-nested types.
 	 */
 	@Parameter(defaultValue="false")
@@ -129,6 +136,8 @@ public abstract class AbstractXtendCompilerMojo extends AbstractXtendMojo {
 		compiler.setJavaSourceVersion(javaSourceVersion);
 		log.debug("Set generateSyntheticSuppressWarnings: " + generateSyntheticSuppressWarnings);
 		compiler.setGenerateSyntheticSuppressWarnings(generateSyntheticSuppressWarnings);
+		log.debug("Set useXbaseGenerated: " + useXbaseGenerated);
+		compiler.setUseXbaseGenerated(useXbaseGenerated);
 		log.debug("Set generateGeneratedAnnotation: " + generateGeneratedAnnotation);
 		compiler.setGenerateGeneratedAnnotation(generateGeneratedAnnotation);
 		log.debug("Set includeDateInGeneratedAnnotation: " + includeDateInGeneratedAnnotation);

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/Generated.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/Generated.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Lorenzo Bettini and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.xbase.lib;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.google.common.annotations.Beta;
+import com.google.common.annotations.GwtCompatible;
+
+/**
+ * By annotating a class or method with this annotation, JaCoCo will not
+ * considered the annotated member.
+ * 
+ * @author Lorenzo Bettini - Initial contribution and API
+ * 
+ * @since 2.36
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({
+    ElementType.TYPE,
+    ElementType.METHOD,
+    ElementType.CONSTRUCTOR
+})
+@Documented
+@Beta
+@GwtCompatible public @interface Generated {
+
+}

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/XbaseGenerated.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/XbaseGenerated.java
@@ -33,6 +33,6 @@ import com.google.common.annotations.GwtCompatible;
 })
 @Documented
 @Beta
-@GwtCompatible public @interface Generated {
+@GwtCompatible public @interface XbaseGenerated {
 
 }

--- a/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/XbaseGenerated.java
+++ b/org.eclipse.xtext.xbase.lib/src/org/eclipse/xtext/xbase/lib/XbaseGenerated.java
@@ -18,8 +18,8 @@ import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 
 /**
- * By annotating a class or method with this annotation, JaCoCo will not
- * considered the annotated member.
+ * By annotating a class or method with this annotation, JaCoCo will ignore the
+ * annotated member.
  * 
  * @author Lorenzo Bettini - Initial contribution and API
  * 

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/builder/XbaseBuilderConfigurationBlock.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/builder/XbaseBuilderConfigurationBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -28,12 +28,13 @@ import com.google.inject.Inject;
  * Builder configuration block that adds compiler settings for Xbase.
  * 
  * @author Miro Spoenemann - Initial contribution and API
+ * @author Lorenzo Bettini - useXbaseGenerated
  */
 public class XbaseBuilderConfigurationBlock extends BuilderConfigurationBlock {
-	
+
 	@Inject
 	private XbaseBuilderPreferenceAccess preferenceAccess;
-	
+
 	private Combo versionCombo;
 
 	private Button useComplianceButton;
@@ -67,6 +68,8 @@ public class XbaseBuilderConfigurationBlock extends BuilderConfigurationBlock {
 		
 		addCheckBox(composite, "Generate @SuppressWarnings annotations",
 				PREF_GENERATE_SUPPRESS_WARNINGS, BOOLEAN_VALUES, 0);
+		addCheckBox(composite, "Annotate synthetic members with @XbaseGenerated",
+				USE_XBASE_GENERATED, BOOLEAN_VALUES, 0);
 		
 		final Button generateGeneratedButton = addCheckBox(composite, "Generate @Generated annotations",
 				PREF_GENERATE_GENERATED, BOOLEAN_VALUES, 0);

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/builder/XbaseBuilderPreferenceAccess.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/builder/XbaseBuilderPreferenceAccess.java
@@ -21,13 +21,21 @@ import com.google.inject.Inject;
 
 /**
  * @author Miro Spoenemann - Initial contribution and API
+ * @author Lorenzo Bettini - useXbaseGenerated
  */
 public class XbaseBuilderPreferenceAccess {
-	
+
 	/**
 	 * Preference identifier for generating <code>@SuppressWarnings</code>.
 	 */
 	public static final String PREF_GENERATE_SUPPRESS_WARNINGS = "generateSuppressWarnings"; //$NON-NLS-1$
+
+	/**
+	 * Preference identifier for generating <code>@XbaseGenerated</code>.
+	 * @since 2.36
+	 */
+	public static final String USE_XBASE_GENERATED = "useXbaseGenerated"; //$NON-NLS-1$
+
 	/**
 	 * Preference identifier for generating <code>@Generated</code>.
 	 */
@@ -59,6 +67,7 @@ public class XbaseBuilderPreferenceAccess {
 		protected void initializeBuilderPreferences(IPreferenceStore store) {
 			super.initializeBuilderPreferences(store);
 			store.setDefault(PREF_GENERATE_SUPPRESS_WARNINGS, true);
+			store.setDefault(USE_XBASE_GENERATED, true);
 			store.setDefault(PREF_GENERATE_GENERATED, false);
 			store.setDefault(PREF_DATE_IN_GENERATED, false);
 			store.setDefault(PREF_JAVA_VERSION, JavaVersion.JAVA8.toString());
@@ -73,6 +82,7 @@ public class XbaseBuilderPreferenceAccess {
 	public void loadBuilderPreferences(GeneratorConfig generatorConfig, Object context) {
 		IPreferenceStore preferenceStore = preferenceStoreAccess.getContextPreferenceStore(context);
 		generatorConfig.setGenerateSyntheticSuppressWarnings(preferenceStore.getBoolean(PREF_GENERATE_SUPPRESS_WARNINGS));
+		generatorConfig.setUseXbaseGenerated(preferenceStore.getBoolean(USE_XBASE_GENERATED));
 		generatorConfig.setGenerateGeneratedAnnotation(preferenceStore.getBoolean(PREF_GENERATE_GENERATED));
 		if (generatorConfig.isGenerateGeneratedAnnotation()) {
 			generatorConfig.setIncludeDateInGeneratedAnnotation(preferenceStore.getBoolean(PREF_DATE_IN_GENERATED));

--- a/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/GeneratorConfig.java
+++ b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/compiler/GeneratorConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2020, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -13,6 +13,7 @@ import org.eclipse.xtext.util.JavaVersion;
 /**
  * @author Holger Schill - Initial contribution and API
  * @author Miro Spoenemann
+ * @author Lorenzo Bettini - useXbaseGenerated
  */
 public class GeneratorConfig {
 	/**
@@ -25,6 +26,11 @@ public class GeneratorConfig {
 	 * types.
 	 */
 	private boolean generateSyntheticSuppressWarnings = true;
+
+	/**
+	 * Whether <code>@XbaseGenerated</code> shall be generated for synthetic members.
+	 */
+	private boolean useXbaseGenerated = true;
 
 	/**
 	 * Whether <code>@Generated</code> shall be generated for non-nested types.
@@ -78,6 +84,20 @@ public class GeneratorConfig {
 
 	public void setGenerateSyntheticSuppressWarnings(boolean generateSyntheticSuppressWarnings) {
 		this.generateSyntheticSuppressWarnings = generateSyntheticSuppressWarnings;
+	}
+
+	/**
+	 * @since 2.36
+	 */
+	public boolean isUseXbaseGenerated() {
+		return useXbaseGenerated;
+	}
+
+	/**
+	 * @since 2.36
+	 */
+	public void setUseXbaseGenerated(boolean useXbaseGenerated) {
+		this.useXbaseGenerated = useXbaseGenerated;
 	}
 
 	public boolean isGenerateGeneratedAnnotation() {


### PR DESCRIPTION
Closes #3077 

I put the new `Generated` annotation in xbase.lib instead of xtend.lib because it could be useful in general for Xbase languages