### PR TITLE
Refactoring the AbstractLinkedEditingIntegrationTest test cases.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractLinkedEditingIntegrationTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractLinkedEditingIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -32,6 +32,10 @@ public abstract class AbstractLinkedEditingIntegrationTest extends AbstractEdito
 		});
 	}
 	
+	/**
+	 * @deprecated, use the inherited {@link AbstractWorkbenchTest#waitForEventProcessing} method instead.
+	 */
+	@Deprecated
 	protected void waitForDisplay() {
 		while(Display.getDefault().readAndDispatch()) {
 		}

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/ToSaveOrNotToSaveTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/ToSaveOrNotToSaveTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -77,7 +77,7 @@ public class ToSaveOrNotToSaveTest extends AbstractLinkedEditingIntegrationTest 
 			if(editor instanceof XtextEditor) {
 				waitForReconciler((XtextEditor) editor);
 			}
-			waitForDisplay();
+			waitForEventProcessing();
 			assertTrue(editor.isDirty());
 		}
 	}
@@ -240,7 +240,7 @@ public class ToSaveOrNotToSaveTest extends AbstractLinkedEditingIntegrationTest 
 
 	protected void renameFooToFooBar(final XtextEditor contextEditor) throws Exception {
 		contextEditor.getEditorSite().getPage().activate(contextEditor);
-		waitForDisplay();
+		waitForEventProcessing();
 		IXtextDocument document = contextEditor.getDocument();
 		final int offset = document.get().indexOf("foo");
 		contextEditor.selectAndReveal(offset, 3);
@@ -262,9 +262,9 @@ public class ToSaveOrNotToSaveTest extends AbstractLinkedEditingIntegrationTest 
 //		controller.startRefactoring(RefactoringType.LINKED_EDITING);
 //		waitForDisplay();
 		pressKeys(contextEditor, "fooBar\n");
-		waitForDisplay();
+		waitForEventProcessing();
 		waitForReconciler(fooEditor);
 		waitForReconciler(barEditor);
-		waitForDisplay();
+		waitForEventProcessing();
 	}
 }

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/LinkedEditingRefactoringIntegrationTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/LinkedEditingRefactoringIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -87,7 +87,7 @@ public class LinkedEditingRefactoringIntegrationTest extends AbstractLinkedEditi
 		final XtextEditor editor = openEditor(file);
 		final TextSelection selection = new TextSelection(model.indexOf(TEST_CLASS), TEST_CLASS.length());
 		editor.getSelectionProvider().setSelection(selection);
-		waitForDisplay();
+		waitForEventProcessing();
 		IRenameElementContext context = editor.getDocument().readOnly(new IUnitOfWork<IRenameElementContext, XtextResource>() {
 			@Override
 			public IRenameElementContext exec(XtextResource state) throws Exception {
@@ -98,10 +98,10 @@ public class LinkedEditingRefactoringIntegrationTest extends AbstractLinkedEditi
 			}
 		});
 		renameRefactoringController.startRefactoring(context);
-		waitForDisplay();
+		waitForEventProcessing();
 		pressKeys(editor, "NewTestClass\n");
 		waitForReconciler(editor);
-		waitForDisplay();
+		waitForEventProcessing();
 		waitForBuild();
 		ecoreResource.load(null);
 		assertEquals("NewTestClass", ((EPackage)ecoreResource.getContents().get(0)).getEClassifiers().get(0).getName());

--- a/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/refactoring/XtextGrammarRefactoringIntegrationTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/refactoring/XtextGrammarRefactoringIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2024 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -160,7 +160,7 @@ public class XtextGrammarRefactoringIntegrationTest extends AbstractLinkedEditin
 		final XtextEditor editor = openEditor(grammarFile);
 		doRefactoring(editor);
 		waitForReconciler(editor);
-		waitForDisplay();
+		waitForEventProcessing();
 		waitForBuild();
 		checkConsistenceOfGrammar(editor);
 	}
@@ -217,7 +217,7 @@ public class XtextGrammarRefactoringIntegrationTest extends AbstractLinkedEditin
 		refToGreetingResource.unload();
 		ecoreModelResource.unload();
 		waitForBuild();
-		waitForDisplay();
+		waitForEventProcessing();
 		XtextEditor editor = openEditor(grammarFile);
 		doRefactoring(editor);
 		waitForBuild();
@@ -273,13 +273,13 @@ public class XtextGrammarRefactoringIntegrationTest extends AbstractLinkedEditin
 	private XtextEditor doRefactoring(XtextEditor editor) throws Exception {
 		final TextSelection selection = new TextSelection(grammar.indexOf(CLASSIFIERNAME), CLASSIFIERNAME.length());
 		editor.getSelectionProvider().setSelection(selection);
-		waitForDisplay();
+		waitForEventProcessing();
 		IRenameElementContext context = new IRenameElementContext.Impl(greetingParserRuleUri,
 				XtextPackage.Literals.PARSER_RULE, editor, selection, grammarUri);
 		renameRefactoringController.startRefactoring(context);
-		waitForDisplay();
+		waitForEventProcessing();
 		pressKeys(editor, REFACTOREDCLASSIFIERNAME + "\n");
-		waitForDisplay();
+		waitForEventProcessing();
 		return editor;
 	}
 


### PR DESCRIPTION
- Deprecate the `waitForDisplay()` method in the `AbstractLinkedEditingIntegrationTest` class in favor of the `waitForEventProcessing()` method in the `AbstractWorkbenchTest` class.
- Modify the test cases inherited from the `AbstractLinkedEditingIntegrationTest` base class to use the preferred method instead of the deprecated one.