### PR TITLE
support Java 21 in Jenkins

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,6 +19,7 @@ jobs:
         include:
         - os: ubuntu-22.04
           java: 21
+          additional-maven-args: -Pstrict-jdk-21
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -49,7 +50,7 @@ jobs:
       - name: Build and test
         uses: coactions/setup-xvfb@v1.0.1
         with: 
-          run: ./mvnw clean verify "-Dmaven.home=${{ env.MAVEN_WRAPPER_HOME }}" -PuseJenkinsSnapshots -f org.eclipse.xtext.full.releng
+          run: ./mvnw clean verify "-Dmaven.home=${{ env.MAVEN_WRAPPER_HOME }}" -PuseJenkinsSnapshots ${{ matrix.additional-maven-args }} -f org.eclipse.xtext.full.releng
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4
@@ -88,7 +89,7 @@ jobs:
         run: echo "MAVEN_WRAPPER_HOME=$(./mvnw --version | grep "Maven home:" | cut -c 13-)" >> "$GITHUB_ENV"
 
       - name: Build Maven artifacts
-        run: ./mvnw clean verify "-Dmaven.home=${{ env.MAVEN_WRAPPER_HOME }}" -PuseJenkinsSnapshots -f org.eclipse.xtext.maven.releng
+        run: ./mvnw clean verify "-Dmaven.home=${{ env.MAVEN_WRAPPER_HOME }}" -PuseJenkinsSnapshots -Pstrict-jdk-21 -f org.eclipse.xtext.maven.releng
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   parameters {
     choice(name: 'TARGET_PLATFORM', choices: ['r202203', 'r202206', 'r202209', 'r202212', 'r202303', 'r202306', 'r202309', 'r202312', 'r202403', 'r202406', 'latest'], description: 'Which Target Platform should be used?')
     // see https://wiki.eclipse.org/Jenkins#JDK
-    choice(name: 'JDK_VERSION', choices: [ '11', '17' ], description: 'Which JDK version should be used?')
+    choice(name: 'JDK_VERSION', choices: [ '11', '17', '21' ], description: 'Which JDK version should be used?')
   }
 
   triggers {
@@ -25,7 +25,9 @@ pipeline {
   }
 
   tools {
+     jdk "temurin-jdk11-latest"
      jdk "temurin-jdk17-latest"
+     jdk "temurin-jdk21-latest"
   }
 
   stages {
@@ -64,7 +66,8 @@ pipeline {
         xvnc(useXauthority: true) {
           sh """
             ./full-build.sh --tp=${selectedTargetPlatform()} \
-              ${javaVersion() == 17 ? '' : '--toolchains releng/toolchains.xml -Pstrict-release-jdk'}
+              ${javaVersion() == 11 ? '--toolchains releng/toolchains.xml -Pstrict-jdk-11' : ''} \
+              ${javaVersion() == 21 ? '-Pstrict-jdk-21' : ''}
           """
         }
       }// END steps

--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
 			</build>
 		</profile>
 		<profile>
-			<id>strict-release-jdk</id>
+			<id>strict-jdk-11</id>
 			<build>
 				<plugins>
 					<plugin>
@@ -437,7 +437,7 @@
 							<toolchains>
 								<jdk>
 									<!-- Toolchain selected by maven/tycho-compiler for compilation and maven/tycho-surefire as JRE of launched test-runtimes-->
-									<version>${maven.compiler.release}</version>
+									<version>11</version>
 								</jdk>
 							</toolchains>
 						</configuration>
@@ -447,9 +447,6 @@
 		</profile>
 		<profile>
 			<id>strict-jdk-21</id>
-			<activation>
-				<jdk>[21,)</jdk>
-			</activation>
 			<properties>
 				<!--
 					Since the Xtend compiler generates Java code using new API introduced in Java 21,


### PR DESCRIPTION
Now the profiles for Java 11 and Java 21 are explicit and will not disturb each other.
Since the profile for Java 21 is not activated automatically anymore, the GitHub Actions workflows have been updated accordingly.