### PR TITLE
Fix editor sync bug, when model file was edited outside of eclipse.

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -76,6 +76,8 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.editors.text.TextEditor;
 import org.eclipse.ui.texteditor.DefaultMarkerAnnotationAccess;
+import org.eclipse.ui.texteditor.IDocumentProvider;
+import org.eclipse.ui.texteditor.IDocumentProviderExtension3;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.texteditor.ITextEditorActionConstants;
 import org.eclipse.ui.texteditor.ITextEditorActionDefinitionIds;
@@ -327,6 +329,20 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 		callback.afterSave(this);
 	}
 	
+	@Override
+	protected void performSave(boolean overwrite, IProgressMonitor progressMonitor) {
+		super.performSave(overwrite || isSynchronized(), progressMonitor);
+	}
+	
+	
+	private boolean isSynchronized() {
+		IResource resource = getResource();
+		if (resource != null) {
+			return resource.isSynchronized(IResource.DEPTH_ZERO);
+		}
+		return false;
+	}
+
 	@Override
 	protected void updateState(final IEditorInput input) {
 		new DisplayRunnable() {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentProvider.java
@@ -409,20 +409,6 @@ public class XtextDocumentProvider extends FileDocumentProvider {
 	}
 	
 	@Override
-	public boolean isSynchronized(Object element) {
-		ElementInfo info = getElementInfo(element);
-		long synchronizationStamp;
-		if (info instanceof FileInfo) {
-			synchronizationStamp = ((FileInfo) info).fModificationStamp;
-		} else if (info instanceof URIInfo) {
-			synchronizationStamp = ((URIInfo) info).synchronizationStamp;
-		} else {
-			return super.isSynchronized(element);
-		}
-		return synchronizationStamp == getModificationStamp(element);
-	}
-	
-	@Override
 	public boolean isModifiable(Object element) {
 		if (isWorkspaceExternalEditorInput(element)) {
 			URIInfo info= (URIInfo) getElementInfo(element);


### PR DESCRIPTION
This bugfix contains the fix for unsync workspace files wrt. the file system (see the
DirtyStateEditorSupportIntegrationTest.testModifyFileInExternEditor) and a one liner for beeing able to save the file when the changes were ignored. (see the ignored test case
DirtyStateEditorSupportIntegrationTest.testModifyDirtyFileInExternEditor).

The issue for this fix can be found here:
https://github.com/eclipse/xtext/issues/2385