### PR TITLE
Fix: Ensure xtext cleans all output folders even if previous output is missing

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/BuilderParticipant.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/BuilderParticipant.java
@@ -487,7 +487,7 @@ public class BuilderParticipant implements IXtextBuilderParticipant {
 		final IProject project = ctx.getBuiltProject();
 		for (IContainer container : getOutputs(project, config)) {
 			if (!container.exists()) {
-				return;
+				continue;
 			}
 			if (canClean(container, config)) {
 				for (IResource resource : container.members()) {


### PR DESCRIPTION
The issue for this fix can be found here: [#2853]