### PR TITLE
#2457 Disable verify in ReplaceFileContentChange for UNDO

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
@@ -130,7 +130,7 @@ public class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 				change.getResource().save(outputStream, null);
 				byte[] newContent = outputStream.toByteArray();
 				String lastSegment = change.getOldURI().lastSegment();
-				ReplaceFileContentChange ltkChange = new ReplaceFileContentChange(lastSegment, file, newContent);
+				ReplaceFileContentChange ltkChange = ReplaceFileContentChange.createWithSkippingUndoVerify(lastSegment, file, newContent);
 				addChange(ltkChange);
 			} catch (IOException e) {
 				Exceptions.throwUncheckedException(e);


### PR DESCRIPTION
The verify is executed before the any change is performed. When the verify checks for the existance of files beforehand, this might not work for UNDO when there are move/rename is involved. Hence skipping the check for UNDO.

Signed-off-by: frank.rene.benoit@gmail.com