### PR TITLE
Fix uninitialized target field in RenameElementProcessor2

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/rename/RenameElementProcessor2.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/rename/RenameElementProcessor2.java
@@ -111,7 +111,7 @@ public class RenameElementProcessor2 extends AbstractRenameProcessor {
 		}
 
 		resourceSet = resourceSetProvider.get(project);
-		EObject target = resourceSet.getEObject(renameElementContext.getTargetElementURI(), true);
+		target = resourceSet.getEObject(renameElementContext.getTargetElementURI(), true);
 		if (target == null) {
 			status.add(RefactoringIssueAcceptor.Severity.ERROR, "Rename target does not exist", renameElementContext.getTargetElementURI());
 		} else {


### PR DESCRIPTION
The `target` field in `RenameElementProcessor2` is not initialized, since it is shadowed by a local variable in `initialize(IRenameElementContext)`. As a result, the target passed to `IRenameNameValidator.validate(...)` in `validateNewName(String)` is always `null`.

This commit removes the local variable, so that the field is properly initialized instead.

Closes #3132 