### PR TITLE
#2457 Disable verify in ReplaceFileContentChange for UNDO

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
@@ -130,7 +130,7 @@ public class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 				change.getResource().save(outputStream, null);
 				byte[] newContent = outputStream.toByteArray();
 				String lastSegment = change.getOldURI().lastSegment();
-				ReplaceFileContentChange ltkChange = new ReplaceFileContentChange(lastSegment, file, newContent);
+				Change ltkChange = createReplaceFileContentChange(lastSegment, file, newContent);
 				addChange(ltkChange);
 			} catch (IOException e) {
 				Exceptions.throwUncheckedException(e);
@@ -138,6 +138,26 @@ public class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 		} catch (IOException e) {
 			LOG.error("Error closing stream", e);
 		}
+	}
+
+	/**
+	 * The change to replace the files textual content.
+	 * 
+	 * @implNote take care that this change can be part of more actions also influences this file. Especially file renaming or move. The
+	 *           verification of prerequisites happens in {@link Change#isValid(org.eclipse.core.runtime.IProgressMonitor)} before any
+	 *           change is performed. This can lead during UNDO to the situation, where the UNDO shall happen in a file that will only be
+	 *           present, after the move change UNDO has happened. Therefore this implementation forces the change to skip the verify during
+	 *           UNDO.
+	 * @param name
+	 *            the name of the file to be modified
+	 * @param file
+	 *            file to be modified
+	 * @param newContent
+	 *            the content to be stored into the file
+	 * @return the change object to be added
+	 */
+	protected Change createReplaceFileContentChange(String name, IFile file, byte[] newContent) {
+		return ReplaceFileContentChange.createWithSkippingUndoVerify(name, file, newContent);
 	}
 
 	protected void _handleReplacements(ITextDocumentChange change) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ReplaceFileContentChange.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ReplaceFileContentChange.java
@@ -38,14 +38,27 @@ public class ReplaceFileContentChange extends ResourceChange {
 
 	private String name;
 
+	private final VerifyMode verifyMode;
+
+	protected enum VerifyMode {
+		BOTH,
+		NOT_FOR_UNDO_NOW_FWD,
+		NOT_FOR_UNDO_NOW_UNDO
+	}
+
 	public ReplaceFileContentChange(String name, IFile file, byte[] newContents) {
-		this(file, newContents);
-		this.name = name;
+		this(name, file, newContents, VerifyMode.BOTH);
 	}
 
 	public ReplaceFileContentChange(IFile file, byte[] newContents) {
+		this(null, file, newContents, VerifyMode.BOTH);
+	}
+
+	protected ReplaceFileContentChange(String name, IFile file, byte[] newContents, VerifyMode verifyMode) {
+		this.name = name;
 		this.file = file;
 		this.newContents = newContents;
+		this.verifyMode = verifyMode;
 	}
 
 	@Override
@@ -56,7 +69,7 @@ public class ReplaceFileContentChange extends ResourceChange {
 	@Override
 	public RefactoringStatus isValid(IProgressMonitor pm) throws CoreException, OperationCanceledException {
 		RefactoringStatus result = new RefactoringStatus();
-		if (!file.exists()) {
+		if (verifyMode != VerifyMode.NOT_FOR_UNDO_NOW_UNDO && !file.exists()) {
 			result.addFatalError("File " + file.getFullPath() + " does not exist");
 		}
 		return result;
@@ -68,11 +81,21 @@ public class ReplaceFileContentChange extends ResourceChange {
 		Change change = null;
 		try (ByteArrayInputStream newContentsIS = new ByteArrayInputStream(newContents)) {
 			file.setContents(newContentsIS, true, true, pm);
-			change = new ReplaceFileContentChange(file, oldContents);
+			change = new ReplaceFileContentChange(null, file, oldContents, getNextUndoVerifyMode());
 		} catch (IOException e) {
 			LOG.error("Error closing stream", e);
 		}
 		return change;
+	}
+
+	protected VerifyMode getNextUndoVerifyMode() {
+		if(verifyMode == VerifyMode.NOT_FOR_UNDO_NOW_FWD ) {
+			return VerifyMode.NOT_FOR_UNDO_NOW_UNDO;
+		}
+		if(verifyMode == VerifyMode.NOT_FOR_UNDO_NOW_UNDO ) {
+			return VerifyMode.NOT_FOR_UNDO_NOW_FWD;
+		}
+		return VerifyMode.BOTH;
 	}
 
 	protected byte[] getOldContents() {
@@ -98,5 +121,14 @@ public class ReplaceFileContentChange extends ResourceChange {
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	/**
+	 * {@link #isValid(IProgressMonitor)} does verify that the file is existing.
+	 * But when this change is potentially combined with file renaming or move, that verify will fail for UNDO.
+	 * Skipping it avoids the problem.
+	 */
+	public static ReplaceFileContentChange createWithSkippingUndoVerify(String name, IFile file, byte[] newContents) {
+		return new ReplaceFileContentChange(name, file, newContents, VerifyMode.NOT_FOR_UNDO_NOW_FWD);
 	}
 }


### PR DESCRIPTION
The verify is executed before the any change is performed. When the verify checks for the existance of files beforehand, this might not work for UNDO when there are move/rename is involved. Hence skipping the check for UNDO.

Signed-off-by: frank.rene.benoit@gmail.com