### PR TITLE
Migrate to latest commons-logging (currently 1.3.3)

### DIFF
--- a/org.eclipse.xtext.ide.tests/build.properties
+++ b/org.eclipse.xtext.ide.tests/build.properties
@@ -8,4 +8,4 @@ source.. = src-gen,\
            testlang-src-gen
 src.includes = about.html
 additional.bundles = org.eclipse.emf.mwe2.launch,\
-                     org.apache.commons.logging
+                     org.apache.commons.commons-logging

--- a/org.eclipse.xtext.purexbase/build.properties
+++ b/org.eclipse.xtext.purexbase/build.properties
@@ -16,7 +16,7 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j
 
 

--- a/org.eclipse.xtext.testlanguages/build.properties
+++ b/org.eclipse.xtext.testlanguages/build.properties
@@ -9,4 +9,4 @@ src.includes = about.html
 additional.bundles = org.eclipse.emf.mwe.utils,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
-                     org.apache.commons.logging
+                     org.apache.commons.commons-logging

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/eclipsePlugin/eclipsePlugin/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/eclipsePlugin/eclipsePlugin/build.properties
@@ -14,5 +14,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/eclipsePluginP2/eclipsePluginP2/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/eclipsePluginP2/eclipsePluginP2/build.properties
@@ -14,5 +14,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/full.target/full.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/full.target/full.target.target
@@ -26,7 +26,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="org.objectweb.asm" version="9.7.0"/>
 			<unit id="io.github.classgraph.classgraph" version="4.8.174"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-09"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/full/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/full/build.properties
@@ -14,5 +14,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/lsMavenTychoApp.target/lsMavenTychoApp.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/lsMavenTychoApp.target/lsMavenTychoApp.target.target
@@ -26,7 +26,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="org.objectweb.asm" version="9.7.0"/>
 			<unit id="io.github.classgraph.classgraph" version="4.8.174"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-09"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/lsMavenTychoApp/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/lsMavenTychoApp/build.properties
@@ -14,5 +14,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/lsMavenTychoFatjar.target/lsMavenTychoFatjar.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/lsMavenTychoFatjar.target/lsMavenTychoFatjar.target.target
@@ -26,7 +26,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="org.objectweb.asm" version="9.7.0"/>
 			<unit id="io.github.classgraph.classgraph" version="4.8.174"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-09"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/lsMavenTychoFatjar/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/lsMavenTychoFatjar/build.properties
@@ -14,5 +14,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/mavenTycho.target/mavenTycho.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/mavenTycho.target/mavenTycho.target.target
@@ -26,7 +26,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="org.objectweb.asm" version="9.7.0"/>
 			<unit id="io.github.classgraph.classgraph" version="4.8.174"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-09"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/mavenTycho/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/mavenTycho/build.properties
@@ -14,5 +14,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ17/mavenTychoJ17.parent/mavenTychoJ17.target/mavenTychoJ17.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ17/mavenTychoJ17.parent/mavenTychoJ17.target/mavenTychoJ17.target.target
@@ -26,7 +26,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="org.apiguardian.api" version="0.0.0"/>
 			<unit id="junit-jupiter-api" version="0.0.0"/>
 			<unit id="junit-jupiter-engine" version="0.0.0"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ17/mavenTychoJ17.parent/mavenTychoJ17/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJ17/mavenTychoJ17.parent/mavenTychoJ17/build.properties
@@ -14,5 +14,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/mavenTychoP2.target/mavenTychoP2.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/mavenTychoP2.target/mavenTychoP2.target.target
@@ -26,7 +26,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="org.objectweb.asm" version="9.7.0"/>
 			<unit id="io.github.classgraph.classgraph" version="4.8.174"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-09"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/mavenTychoP2/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/mavenTychoP2/build.properties
@@ -14,5 +14,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J17/mavenTychoP2J17.parent/mavenTychoP2J17.target/mavenTychoP2J17.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J17/mavenTychoP2J17.parent/mavenTychoP2J17.target/mavenTychoP2J17.target.target
@@ -26,7 +26,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="org.objectweb.asm" version="9.7.0"/>
 			<unit id="io.github.classgraph.classgraph" version="4.8.174"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-09"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J17/mavenTychoP2J17.parent/mavenTychoP2J17/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J17/mavenTychoP2J17.parent/mavenTychoP2J17/build.properties
@@ -14,5 +14,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J21/mavenTychoP2J21.parent/mavenTychoP2J21.target/mavenTychoP2J21.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J21/mavenTychoP2J21.parent/mavenTychoP2J21.target/mavenTychoP2J21.target.target
@@ -26,7 +26,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="org.objectweb.asm" version="9.7.0"/>
 			<unit id="io.github.classgraph.classgraph" version="4.8.174"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-09"/>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J21/mavenTychoP2J21.parent/mavenTychoP2J21/build.properties
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J21/mavenTychoP2J21.parent/mavenTychoP2J21/build.properties
@@ -14,5 +14,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.xbase.testlanguages/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testlanguages/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-SymbolicName: org.eclipse.xtext.xbase.testlanguages; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext;bundle-version="2.36.0";visibility:=reexport,
  org.eclipse.xtext.xbase;bundle-version="2.36.0";resolution:=optional;visibility:=reexport,
- org.apache.commons.logging;bundle-version="1.0.4";resolution:=optional,
  org.eclipse.emf.ecore;bundle-version="2.26.0",
  org.eclipse.emf.common;bundle-version="2.24.0",
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",

--- a/org.eclipse.xtext.xtext.bootstrap/build.properties
+++ b/org.eclipse.xtext.xtext.bootstrap/build.properties
@@ -2,4 +2,4 @@ source.. = src/
 bin.includes = META-INF/,\
                .
 additional.bundles = org.eclipse.emf.mwe2.launch,\
-                     org.apache.commons.logging
+                     org.apache.commons.commons-logging

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/build.properties
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/build.properties
@@ -12,5 +12,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
@@ -8,6 +8,7 @@
       <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
       <unit id="org.apache.commons.jxpath" version="0.0.0"/>
+      <unit id="org.apache.commons.commons-logging"/>
       <repository location="https://download.eclipse.org/releases/2024-09"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/build.properties
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/build.properties
@@ -15,5 +15,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/build.properties
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/build.properties
@@ -14,5 +14,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/build.properties
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/build.properties
@@ -13,5 +13,5 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.launch,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
-                     org.apache.commons.logging,\
+                     org.apache.commons.commons-logging,\
                      org.apache.log4j

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.xtend
@@ -113,7 +113,7 @@ class RuntimeProjectDescriptor extends TestedProjectDescriptor {
 			"org.eclipse.emf.mwe2.launch",
 			"org.eclipse.emf.mwe2.lib",
 			"org.objectweb.asm",
-			"org.apache.commons.logging", 
+			"org.apache.commons.commons-logging",
 			"org.apache.log4j"
 		)
 		if (isFromExistingEcoreModels) {

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
@@ -93,7 +93,7 @@ class TargetPlatformProject extends ProjectDescriptor {
 					<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 					<unit id="org.hamcrest" version="2.2.0"/>
 					<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-					<unit id="org.apache.commons.logging" version="1.2.0"/>
+					<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 					«IF config.junitVersion == JUnitVersion.JUNIT_5»
 						<unit id="org.apiguardian.api" version="0.0.0"/>
 						<unit id="junit-jupiter-api" version="0.0.0"/>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
@@ -163,7 +163,7 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
       "org.eclipse.emf.mwe2.launch", 
       "org.eclipse.emf.mwe2.lib", 
       "org.objectweb.asm", 
-      "org.apache.commons.logging", 
+      "org.apache.commons.commons-logging", 
       "org.apache.log4j");
     boolean _isFromExistingEcoreModels = this.isFromExistingEcoreModels();
     if (_isFromExistingEcoreModels) {

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
@@ -206,7 +206,7 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.append("<unit id=\"org.hamcrest.core\" version=\"2.2.0.v20230809-1000\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.apache.commons.logging\" version=\"1.2.0\"/>");
+    _builder.append("<unit id=\"org.apache.commons.commons-logging\" version=\"0.0.0\"/>");
     _builder.newLine();
     {
       JUnitVersion _junitVersion = this.getConfig().getJunitVersion();

--- a/xtext-latest.target
+++ b/xtext-latest.target
@@ -61,7 +61,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="junit-jupiter-api" version="0.0.0"/>
 			<unit id="junit-jupiter-engine" version="0.0.0"/>
 			<unit id="junit-jupiter-migrationsupport" version="0.0.0"/>

--- a/xtext-r202203.target
+++ b/xtext-r202203.target
@@ -63,7 +63,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/oomph/simrel-orbit/2023-06"/>

--- a/xtext-r202206.target
+++ b/xtext-r202206.target
@@ -62,7 +62,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/oomph/simrel-orbit/2023-06"/>

--- a/xtext-r202209.target
+++ b/xtext-r202209.target
@@ -62,7 +62,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-09"/>

--- a/xtext-r202212.target
+++ b/xtext-r202212.target
@@ -63,7 +63,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="junit-jupiter-api" version="0.0.0"/>
 			<unit id="junit-jupiter-engine" version="0.0.0"/>
 			<unit id="junit-jupiter-migrationsupport" version="0.0.0"/>

--- a/xtext-r202303.target
+++ b/xtext-r202303.target
@@ -63,7 +63,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="junit-jupiter-api" version="0.0.0"/>
 			<unit id="junit-jupiter-engine" version="0.0.0"/>
 			<unit id="junit-jupiter-migrationsupport" version="0.0.0"/>

--- a/xtext-r202306.target
+++ b/xtext-r202306.target
@@ -63,7 +63,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="junit-jupiter-api" version="0.0.0"/>
 			<unit id="junit-jupiter-engine" version="0.0.0"/>
 			<unit id="junit-jupiter-migrationsupport" version="0.0.0"/>

--- a/xtext-r202309.target
+++ b/xtext-r202309.target
@@ -63,7 +63,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="junit-jupiter-api" version="0.0.0"/>
 			<unit id="junit-jupiter-engine" version="0.0.0"/>
 			<unit id="junit-jupiter-migrationsupport" version="0.0.0"/>

--- a/xtext-r202312.target
+++ b/xtext-r202312.target
@@ -63,7 +63,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="junit-jupiter-api" version="0.0.0"/>
 			<unit id="junit-jupiter-engine" version="0.0.0"/>
 			<unit id="junit-jupiter-migrationsupport" version="0.0.0"/>

--- a/xtext-r202403.target
+++ b/xtext-r202403.target
@@ -58,7 +58,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="junit-jupiter-api" version="0.0.0"/>
 			<unit id="junit-jupiter-engine" version="0.0.0"/>
 			<unit id="junit-jupiter-migrationsupport" version="0.0.0"/>

--- a/xtext-r202406.target
+++ b/xtext-r202406.target
@@ -58,7 +58,7 @@
 			<unit id="org.junit" version="4.13.2.v20230809-1000"/>
 			<unit id="org.hamcrest" version="2.2.0"/>
 			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.logging" version="1.2.0"/>
+			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
 			<unit id="junit-jupiter-api" version="0.0.0"/>
 			<unit id="junit-jupiter-engine" version="0.0.0"/>
 			<unit id="junit-jupiter-migrationsupport" version="0.0.0"/>


### PR DESCRIPTION
Adapt to the new Bundle-SymbolicName in target-files, the `additional.bundles` required for development and defined in `build.properties` and adjust the templates to generate the new name.

Should fix https://github.com/eclipse/xtext/issues/3127 for Xtext.