### PR TITLE
Run GH workflow build in batch-mode and fail at end

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build and test
         uses: coactions/setup-xvfb@v1.0.1
         with: 
-          run: ./mvnw clean verify "-Dmaven.home=${{ env.MAVEN_WRAPPER_HOME }}" -PuseJenkinsSnapshots ${{ matrix.additional-maven-args }} -f org.eclipse.xtext.full.releng
+          run: ./mvnw clean verify -B -fae "-Dmaven.home=${{ env.MAVEN_WRAPPER_HOME }}" -PuseJenkinsSnapshots ${{ matrix.additional-maven-args }} -f org.eclipse.xtext.full.releng
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4
@@ -89,7 +89,7 @@ jobs:
         run: echo "MAVEN_WRAPPER_HOME=$(./mvnw --version | grep "Maven home:" | cut -c 13-)" >> "$GITHUB_ENV"
 
       - name: Build Maven artifacts
-        run: ./mvnw clean verify "-Dmaven.home=${{ env.MAVEN_WRAPPER_HOME }}" -PuseJenkinsSnapshots -Pstrict-jdk-21 -f org.eclipse.xtext.maven.releng
+        run: ./mvnw clean verify -B -fae "-Dmaven.home=${{ env.MAVEN_WRAPPER_HOME }}" -PuseJenkinsSnapshots -Pstrict-jdk-21 -f org.eclipse.xtext.maven.releng
 
       - name: Archive Test Results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Without the -B Maven CLI option a lot of print-out in the build logs of Github workflows is just transfer progress.

The `full-Build.sh` uses the same arguments for a build in Jenkins.