### PR TITLE
Deal with Java 11, 17, and 21 for the Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,9 +25,9 @@ pipeline {
   }
 
   tools {
-     // the Java version we use to run the build (minimal requirement for Maven/Tycho)
-     // we force other Java versions through Maven toolchains
-     jdk "temurin-jdk17-latest"
+     // the Java version we use to run the build
+     // we force the effective JDK version for compilation/testing through Maven toolchains
+     jdk "temurin-jdk21-latest"
   }
 
   stages {
@@ -68,6 +68,7 @@ pipeline {
           sh """
             ./full-build.sh --tp=${selectedTargetPlatform()} \
               ${javaVersion() == 11 ? '--toolchains releng/toolchains.xml -Pstrict-jdk-11' : ''} \
+              ${javaVersion() == 17 ? '--toolchains releng/toolchains.xml -Pstrict-jdk-17' : ''} \
               ${javaVersion() == 21 ? '-Pstrict-jdk-21' : ''}
           """
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,9 +25,9 @@ pipeline {
   }
 
   tools {
-     jdk "temurin-jdk11-latest"
+     // the Java version we use to run the build (minimal requirement for Maven/Tycho)
+     // we force other Java versions through Maven toolchains
      jdk "temurin-jdk17-latest"
-     jdk "temurin-jdk21-latest"
   }
 
   stages {
@@ -58,6 +58,7 @@ pipeline {
     stage('Maven/Tycho Build & Test') {
       environment {
         MAVEN_OPTS = "-Xmx1500m"
+        // set all Java versions needed by our toolchains.xml
         JAVA_HOME_11_X64 = tool(type:'jdk', name:'temurin-jdk11-latest')
         JAVA_HOME_17_X64 = tool(type:'jdk', name:'temurin-jdk17-latest')
         JAVA_HOME_21_X64 = tool(type:'jdk', name:'temurin-jdk21-latest')

--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,36 @@
 			</build>
 		</profile>
 		<profile>
+			<id>strict-jdk-17</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-toolchains-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>toolchain</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<toolchains>
+								<jdk>
+									<!-- Toolchain selected by maven/tycho-compiler for compilation and maven/tycho-surefire as JRE of launched test-runtimes-->
+									<version>17</version>
+								</jdk>
+							</toolchains>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>strict-jdk-21</id>
+			<!--
+				Here we don't use the toolchain relying on the effective Java version used for the build
+			-->
 			<properties>
 				<!--
 					Since the Xtend compiler generates Java code using new API introduced in Java 21,


### PR DESCRIPTION
and rely on the toolchain to force compilation and tests with other Java versions.

I left comments to document what I think it's the semantics of those Jenkinsfile parts

Closes #3135 