### PR TITLE
[Build] Set up publication of Test results as comment on pull-requests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -103,3 +103,12 @@ jobs:
         with:
           name: logs-${{ runner.os }}
           path: '**/target/**/*.log'
+  event_file:
+    name: "Upload Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+      with:
+        name: Event File
+        path: ${{ github.event_path }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,41 @@
+name: Publish Unit Test Results
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+jobs:
+  unit-test-results:
+    name: Publish Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+      issues: read
+      actions: read
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@567cc7f8dcea3eba5da355f6ebc95663310d8a07 # v2.17.0
+        id: test-results
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"


### PR DESCRIPTION
As suggested in https://github.com/eclipse/xtext/pull/3139#issuecomment-2280471647.

@cdietrich, @LorenzoBettini unfortunately this is only picked up after it is submitted to the main branch (since I don't have write access to this repo and the new workflow runs when another one is complted).
But as far as I can tell this is the same config as we use in
- m2e:  https://github.com/eclipse-m2e/m2e-core/tree/master/.github/workflows
- eclipse-platform/equinox/jdt/pde (a bit more convoluted): https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/tree/master/.github/workflows