### PR TITLE
Allow fragments in unordered groups

### DIFF
--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/unorderedGroups/GrammarParserTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/parser/unorderedGroups/GrammarParserTest.java
@@ -22,6 +22,7 @@ import org.eclipse.xtext.UnorderedGroup;
 import org.eclipse.xtext.XtextStandaloneSetup;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.testing.AbstractXtextTests;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -124,6 +125,15 @@ public class GrammarParserTest extends AbstractXtextTests {
 	
 	@Test public void testNotAllowedInAssignment() throws Exception {
 		getModelAndExpect("name=(ID & STRING)", 2);
+	}
+	
+	@Test public void testFragments() throws Exception {
+		String grammar =
+			"MyRule;\n" +
+			"MyRule: IntFeature & 'keyword';\n" +
+			"fragment IntFeature: myFeature=INT\n";
+		XtextResource resource = getResourceFromString(grammar);
+		Assert.assertTrue(resource.getErrors().isEmpty());
 	}
 	
 	@Override

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextValidationTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/XtextValidationTest.java
@@ -1342,6 +1342,23 @@ public class XtextValidationTest extends AbstractValidationMessageAcceptingTestC
 		messageAcceptor.validate();
 	}
 	
+	@Test public void testCheckFragmentCallInUnorderedGroup() throws Exception {
+		XtextValidator validator = get(XtextValidator.class);
+		UnorderedGroup unorderedGroup = XtextFactory.eINSTANCE.createUnorderedGroup();
+		RuleCall ruleCall = XtextFactory.eINSTANCE.createRuleCall();
+		TypeRef typeRef = XtextFactory.eINSTANCE.createTypeRef();
+		typeRef.setClassifier(EcorePackage.Literals.EOBJECT);
+		ParserRule parserRule = XtextFactory.eINSTANCE.createParserRule();
+		parserRule.setType(typeRef);
+		parserRule.setFragment(true);
+		ruleCall.setRule(parserRule);
+		unorderedGroup.getElements().add(ruleCall);
+		ValidatingMessageAcceptor messageAcceptor = new ValidatingMessageAcceptor(null, false, false);
+		validator.setMessageAcceptor(messageAcceptor);
+		validator.checkRuleCallInUnorderedGroup(ruleCall);
+		messageAcceptor.validate();
+	}
+	
 	@Test public void testCheckRuleCallInUnorderedGroup_01() throws Exception {
 		XtextValidator validator = get(XtextValidator.class);
 		UnorderedGroup unorderedGroup = XtextFactory.eINSTANCE.createUnorderedGroup();

--- a/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextValidator.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/xtext/XtextValidator.java
@@ -1136,6 +1136,8 @@ public class XtextValidator extends AbstractDeclarativeValidator {
 			return;
 		if (GrammarUtil.isAssigned(call))
 			return;
+		if (GrammarUtil.isEObjectFragmentRuleCall(call))
+			return;
 		if (EcoreUtil2.getContainerOfType(call, UnorderedGroup.class) != null)
 			error(
 					"Unassigned rule calls may not be used in unordered groups.", 


### PR DESCRIPTION
To fix issue #3068 as hinted by @szarnekow 
Please let me know if I should add a test case (where and what should I test? I'm not familiar with Xtext tests at all).