### PR TITLE
Remove obsolete compiler option assignments

### DIFF
--- a/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.java
+++ b/org.eclipse.xtext.java/src/org/eclipse/xtext/java/resource/JavaDerivedStateComputer.java
@@ -286,9 +286,21 @@ public class JavaDerivedStateComputer {
 		compilerOptions.sourceLevel = sourceLevel;
 		compilerOptions.produceMethodParameters = true;
 		compilerOptions.produceReferenceInfo = true;
-		compilerOptions.originalSourceLevel = targetLevel;
 		compilerOptions.complianceLevel = sourceLevel;
-		compilerOptions.originalComplianceLevel = targetLevel;
+		if (ORIGINAL_SOURCE_LEVEL != null) {
+			try {
+				ORIGINAL_SOURCE_LEVEL.invoke(compilerOptions, targetLevel);
+			} catch (Throwable e) {
+				// ignore
+			}
+		}
+		if (ORIGINAL_COMPLIANCE_LEVEL != null) {
+			try {
+				ORIGINAL_COMPLIANCE_LEVEL.invoke(compilerOptions, targetLevel);
+			} catch (Throwable e) {
+				// ignore
+			}
+		}
 		if (INLINE_JSR_BYTECODE != null) {
 			try {
 				INLINE_JSR_BYTECODE.invoke(compilerOptions, true);
@@ -308,6 +320,24 @@ public class JavaDerivedStateComputer {
 		}
 	}
 
+	private final static MethodHandle ORIGINAL_SOURCE_LEVEL = findOriginalSourceLevel();
+	private static MethodHandle findOriginalSourceLevel() {
+		try {
+			return MethodHandles.lookup().findSetter(CompilerOptions.class, "originalSourceLevel", long.class);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	private final static MethodHandle ORIGINAL_COMPLIANCE_LEVEL = findOriginalComplianceLevel();
+	private static MethodHandle findOriginalComplianceLevel() {
+		try {
+			return MethodHandles.lookup().findSetter(CompilerOptions.class, "originalComplianceLevel", long.class);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+	
 	protected long toJdtVersion(JavaVersion version) {
 		return version.toJdtClassFileConstant();
 	}

--- a/org.eclipse.xtext.xbase.testing/src/org/eclipse/xtext/xbase/testing/InMemoryJavaCompiler.java
+++ b/org.eclipse.xtext.xbase.testing/src/org/eclipse/xtext/xbase/testing/InMemoryJavaCompiler.java
@@ -225,6 +225,24 @@ public class InMemoryJavaCompiler {
 		}
 	}
 
+	private final static MethodHandle ORIGINAL_SOURCE_LEVEL = findOriginalSourceLevel();
+	private static MethodHandle findOriginalSourceLevel() {
+		try {
+			return MethodHandles.lookup().findSetter(CompilerOptions.class, "originalSourceLevel", long.class);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	private final static MethodHandle ORIGINAL_COMPLIANCE_LEVEL = findOriginalComplianceLevel();
+	private static MethodHandle findOriginalComplianceLevel() {
+		try {
+			return MethodHandles.lookup().findSetter(CompilerOptions.class, "originalComplianceLevel", long.class);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
 	public InMemoryJavaCompiler(ClassLoader parent, CompilerOptions compilerOptions) {
 		this.nameEnv = new ClassLoaderBasedNameEnvironment(parent);
 		this.parentClassLoader = parent;
@@ -257,7 +275,13 @@ public class InMemoryJavaCompiler {
 	 */
 	private void setSourceLevel(long jdkVersion) {
 		compilerOptions.sourceLevel = jdkVersion;
-		compilerOptions.originalSourceLevel = jdkVersion;
+		if (ORIGINAL_SOURCE_LEVEL != null) {
+			try {
+				ORIGINAL_SOURCE_LEVEL.invoke(compilerOptions, jdkVersion);
+			} catch (Throwable e) {
+				// ignore
+			}
+		}	
 	}
 
 	/**
@@ -266,7 +290,13 @@ public class InMemoryJavaCompiler {
 	 */
 	private void setComplianceLevel(long jdkVersion) {
 		compilerOptions.complianceLevel = jdkVersion;
-		compilerOptions.originalComplianceLevel = jdkVersion;
+		if (ORIGINAL_COMPLIANCE_LEVEL != null) {
+			try {
+				ORIGINAL_COMPLIANCE_LEVEL.invoke(compilerOptions, jdkVersion);
+			} catch (Throwable e) {
+				// ignore
+			}
+		}
 	}
 
 	public Result compile(JavaSource... sources) {


### PR DESCRIPTION
This should fix the compilation errors caused by removed CompilerOptions in Jdt.