### PR TITLE
EcoreUtil2: Introduce getAllContentsOfType() for resources

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/EcoreUtil2.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/EcoreUtil2.java
@@ -189,6 +189,13 @@ public class EcoreUtil2 extends EcoreUtil {
 		return Lists.newArrayList(Iterators.filter(ele.eAllContents(), type));
 	}
 
+	/**
+	 * @since 2.37
+	 */
+	public static <T extends EObject> List<T> getAllContentsOfType(Resource resource, Class<T> type) {
+		return Lists.newArrayList(Iterators.filter(resource.getAllContents(), type));
+	}
+
 	public static <T> List<T> typeSelect(List<?> elements, Class<T> clazz) {
 		return Lists.newArrayList(Iterables.filter(elements, clazz));
 	}


### PR DESCRIPTION
Hi, I'd like to propose this patch. Nothing special actually, simply since EcoreUtil2 already offers one variant of some of its methods for EObjects and one for Resources, I think this one could be handy as well. At the moment I'm working around its absence by using `EcoreUtil2.typeSelect(EcoreUtil2.eAllContentsAsList(resource), MyType.class)` extensively in my project, which works fine but looks quite verbose IMHO.