### PR TITLE
Remove strict version of Guava in some places

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "io.github.classgraph:classgraph"
+      - dependency-name: "com.google.guava:*"

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -70,7 +70,7 @@ Google Gson (2.9.x)
 
 * License: Apache License, 2.0
 
-Google Guava (33.3.1)
+Google Guava (33.3.x)
 
 * License: Apache License 2.0
 
@@ -82,7 +82,7 @@ Gradle Wrapper (8)
 
 * License: Apache License, 2.0
 
-guava gwt (33.3.1)
+guava gwt (33.3.x)
 
 * License: Apache License, 2.0
 

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/pom.xml
@@ -14,16 +14,15 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-				<version>33.3.1-jre</version>
-			</dependency>
-			<dependency>
 				<groupId>org.eclipse.xtext</groupId>
 				<artifactId>xtext-dev-bom</artifactId>
 				<version>${xtextBOMVersion}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.xtend</groupId>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/pom.xml
@@ -21,10 +21,6 @@
 				<scope>import</scope>
 			</dependency>
 			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-			</dependency>
-			<dependency>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>org.eclipse.xtend.lib</artifactId>
 				<version>${xtextVersion}</version>

--- a/xtext-latest.target
+++ b/xtext-latest.target
@@ -46,7 +46,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>

--- a/xtext-r202203.target
+++ b/xtext-r202203.target
@@ -49,7 +49,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>

--- a/xtext-r202206.target
+++ b/xtext-r202206.target
@@ -48,7 +48,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>

--- a/xtext-r202209.target
+++ b/xtext-r202209.target
@@ -48,7 +48,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>

--- a/xtext-r202212.target
+++ b/xtext-r202212.target
@@ -48,7 +48,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>

--- a/xtext-r202303.target
+++ b/xtext-r202303.target
@@ -48,7 +48,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>

--- a/xtext-r202306.target
+++ b/xtext-r202306.target
@@ -48,7 +48,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>

--- a/xtext-r202309.target
+++ b/xtext-r202309.target
@@ -48,7 +48,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>

--- a/xtext-r202312.target
+++ b/xtext-r202312.target
@@ -48,7 +48,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>

--- a/xtext-r202403.target
+++ b/xtext-r202403.target
@@ -43,7 +43,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>

--- a/xtext-r202406.target
+++ b/xtext-r202406.target
@@ -43,7 +43,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>

--- a/xtext-r202409.target
+++ b/xtext-r202409.target
@@ -43,7 +43,7 @@
 			<unit id="org.apache.log4j" version="1.2.25"/>
 			<unit id="org.kohsuke.args4j" version="0.0.0"/>
 			<unit id="com.google.gson" version="2.11.0"/>
-			<unit id="com.google.guava" version="33.3.1.jre"/>
+			<unit id="com.google.guava" version="0.0.0"/>
 			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
 			<unit id="com.google.inject" version="7.0.0"/>
 			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>


### PR DESCRIPTION
- from the target platform
- in NOTICE replaced patch version with `x`
- removed redundant version from an Xtext Maven plugin IT

NOTE: in other places, MANIFEST, feature and category, possible version bumps must still be done manually