### PR TITLE
bump org.objectweb.asm 9.7.1 also in BOM

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -56,7 +56,7 @@ args4j (2.33)
 
 * License: MIT License
 
-ASM (9.7)
+ASM (9.7.x)
 
 * License: BSD-3-Clause
 

--- a/org.eclipse.xtext.dev-bom/pom.xml
+++ b/org.eclipse.xtext.dev-bom/pom.xml
@@ -453,7 +453,7 @@
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm</artifactId>
-				<version>9.7</version>
+				<version>9.7.1</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Sorry, I didn't note the version in the BOM because it has a different name and the previous Maven artifact has version 9.7 instead of 9.7.0.

I hope you don't mind in the NOTICE I only put `.x`

Related to https://github.com/eclipse/xtext/issues/3224