### PR TITLE
Fix for loosing focus when entering linked mode (rename element) #3245

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameLinkedMode.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameLinkedMode.java
@@ -89,6 +89,8 @@ public class RenameLinkedMode {
 				registry.register(focusEditingSupport);
 			}
 			openPopup();
+			// Lost the focus, set back the focus
+			viewer.getTextWidget().setFocus();
 			return true;
 		} catch (BadLocationException e) {
 			throw new WrappedException(e);


### PR DESCRIPTION
This patch fixes the issue when the user is entering the linked editing mode and looses the focus (happens because of showing up the popup dialog).