### PR TITLE
Allow renaming of the Thread Queue Name Format

### DIFF
--- a/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/RequestManager.java
+++ b/org.eclipse.xtext.ide/src/org/eclipse/xtext/ide/server/concurrent/RequestManager.java
@@ -43,9 +43,20 @@ public class RequestManager {
 	}
 	
 	private final ExecutorService queue = Executors.newSingleThreadExecutor(
-			new ThreadFactoryBuilder().setDaemon(true).setNameFormat("RequestManager-Queue-%d").build());
+			new ThreadFactoryBuilder().setDaemon(true).setNameFormat(getThreadQueueNameFormat()).build());
 
 	private List<AbstractRequest<?>> requests = new ArrayList<>();
+
+	/**
+	 * Override with a different name format for the queue thread if desired. 
+	 * 
+	 * It must not refer to fields of the class, as it will be called during class instantiation.
+	 * 
+	 * @since 2.40
+	 */
+	protected String getThreadQueueNameFormat() {
+		return "RequestManager-Queue-%d";
+	}
 
 	/**
 	 * An orderly shutdown of this request manager.
@@ -123,7 +134,7 @@ public class RequestManager {
 		}
 		Throwable cause = t;
 		if (t instanceof CompletionException) {
-			cause = ((CompletionException) t).getCause();
+			cause = t.getCause();
 		}
 		return operationCanceledManager.isOperationCanceledException(cause);
 	}


### PR DESCRIPTION
In our language server we have several request managers for different types of request, to aid analysis of thread-dumps, it is useful to be able to change the name of the thread used for the queue.