### PR TITLE
Demote error to warning in TextRegionAccessBuildingSequencer and AbstractDeclarativeFormatter

### DIFF
--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting/impl/AbstractDeclarativeFormatter.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting/impl/AbstractDeclarativeFormatter.java
@@ -76,7 +76,7 @@ public abstract class AbstractDeclarativeFormatter extends BaseFormatter {
 		if(context != null && context.eResource() != null && context.eResource().getURI() != null) {
 			contextResourceURI = EcoreUtil2.getPlatformResourceOrNormalizedURI(context).trimFragment();
 		} else if (context != null && context.eResource() == null) {
-			log.error("Model has no XtextResource. This is likely to cause follow-up errors");
+			log.warn("Model has no XtextResource. This is likely to cause follow-up errors");
 		}
 		return new FormattingConfigBasedStream(out, indent, getConfig(), createMatcher(), hiddenTokenHelper,
 				preserveWhitespaces);

--- a/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/TextRegionAccessBuildingSequencer.java
+++ b/org.eclipse.xtext/src/org/eclipse/xtext/formatting2/regionaccess/internal/TextRegionAccessBuildingSequencer.java
@@ -228,7 +228,7 @@ public class TextRegionAccessBuildingSequencer implements ISequenceAcceptor {
 
 	public TextRegionAccessBuildingSequencer withRoot(ISerializationContext ctx, EObject root) {
 		if (root.eResource() == null) {
-			log.error("Root has no XtextResource. This is likely to cause follow-up errors");
+			log.warn("Root has no XtextResource. This is likely to cause follow-up errors");
 		}
 		this.regionAccess = new StringBasedRegionAccess((XtextResource) root.eResource());
 		this.last = createHiddenRegion();


### PR DESCRIPTION
Just a proposal for a very minor improvement. This really looks like a warning rather than an error - it warns the user that things *might* go south later on, but it does not prevent the rest of the method from being executed anyway. Do you agree?