### PR TITLE
Allow to distinguish between save and revert in editor callback

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/CompoundXtextEditorCallback.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/CompoundXtextEditorCallback.java
@@ -67,6 +67,17 @@ public class CompoundXtextEditorCallback implements IXtextEditorCallback {
 	}
 
 	@Override
+	public void afterRevert(XtextEditor xtextEditor) {
+		for (IXtextEditorCallback xtextEditorCallback : editorCallbacks) {
+			try {
+				xtextEditorCallback.afterRevert(xtextEditor);
+			} catch (Exception e) {
+				handle(e);
+			}
+		}
+	}
+
+	@Override
 	public void beforeDispose(XtextEditor xtextEditor) {
 		for (IXtextEditorCallback xtextEditorCallback : editorCallbacks) {
 			try {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/IXtextEditorCallback.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/IXtextEditorCallback.java
@@ -29,6 +29,10 @@ public interface IXtextEditorCallback {
 	 */
 	void afterSave(XtextEditor editor);
 	
+	default void afterRevert(XtextEditor editor) {
+		afterSave(editor);
+	}
+	
 	void beforeDispose(XtextEditor editor);
 	
 	boolean onValidateEditorInputState(XtextEditor editor);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -364,7 +364,7 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 	@Override
 	public void doRevertToSaved() {
 		super.doRevertToSaved();
-		callback.afterSave(this);
+		callback.afterRevert(this);
 	}
 	
 	/**


### PR DESCRIPTION
This adds a new method afterRevert in IXtextEditorCallback to allow implementations to distinguish between save and revert. The default implementation delegates to afterSave, in order to preserve compatibility with existing implementations.

Fixes https://github.com/eclipse-xtext/xtext/issues/3487