### PR TITLE
fix: be more lenient in xtend hover test

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/XtendHoverInEditorTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/XtendHoverInEditorTest.xtend
@@ -276,7 +276,7 @@ class XtendHoverInEditorTest extends AbstractXtendUITestCase {
 	}
 
 	private def hasHoverOverObject(CharSequence it) {
-		hasHoverOverJavaType("Object", '''Class <code>Object</code> is the root of the class hierarchy.''')
+		hasHoverOverJavaType("Object", '''</code> is the root of the class hierarchy.''')
 	}
 
 	private def hasHoverOverJavaType(CharSequence it, String textUnderHover, String expectedHoverContent) {

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/XtendHoverInEditorTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/XtendHoverInEditorTest.java
@@ -478,7 +478,7 @@ public class XtendHoverInEditorTest extends AbstractXtendUITestCase {
 
   private void hasHoverOverObject(final CharSequence it) {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("Class <code>Object</code> is the root of the class hierarchy.");
+    _builder.append("</code> is the root of the class hierarchy.");
     this.hasHoverOverJavaType(it, "Object", _builder.toString());
   }
 


### PR DESCRIPTION
the new jdt has a newline before the close code tag