### PR TITLE
Use maven.compiler.release instead of source plus target

### DIFF
--- a/org.eclipse.xtend.maven.archetype/src/main/resources/archetype-resources/pom.xml
+++ b/org.eclipse.xtend.maven.archetype/src/main/resources/archetype-resources/pom.xml
@@ -10,8 +10,7 @@
 	<properties>
 		<xtend.version>${project.version}</xtend.version>
 		<project.build.sourceEncoding>${sourceEncoding}</project.build.sourceEncoding>
-		<maven.compiler.source>${javaVersion}</maven.compiler.source>
-		<maven.compiler.target>${javaVersion}</maven.compiler.target>
+		<maven.compiler.release>${javaVersion}</maven.compiler.release>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/org.eclipse.xtend.maven.parent/pom.xml
+++ b/org.eclipse.xtend.maven.parent/pom.xml
@@ -22,8 +22,7 @@
 
 		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 		<maven.javadoc.opts></maven.javadoc.opts>
 	</properties>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/simple-java25/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/simple-java25/pom.xml
@@ -10,8 +10,7 @@
 	</parent>
 	<artifactId>simple-java25</artifactId>
 	<properties>
-		<maven.compiler.source>25</maven.compiler.source>
-		<maven.compiler.target>25</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 	</properties>
 	<build>
 		<plugins>

--- a/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/wizard/WizardConfigurationTest.java
+++ b/org.eclipse.xtext.tests/src/org/eclipse/xtext/xtext/wizard/WizardConfigurationTest.java
@@ -75,7 +75,7 @@ public class WizardConfigurationTest {
 		assertTrue(config.getP2Project().pom().getContent().contains("eclipse-repository"));
 		assertTrue(config.getParentProject().pom().getContent().contains("tycho"));
 	}
-	
+
 	@Test
 	public void p2ProjectsEnablesSourceGenerationWithTychoWhenMavenBuiltIsEnabled() {
 		config.getUiProject().setEnabled(true);
@@ -351,8 +351,7 @@ public class WizardConfigurationTest {
 	@Test
 	public void allBuildSystemsUseJava21() {
 		String parentPom = config.getParentProject().pom().getContent();
-		assertTrue(parentPom.contains("<maven.compiler.source>21</maven.compiler.source>"));
-		assertTrue(parentPom.contains("<maven.compiler.target>21</maven.compiler.target>"));
+		assertTrue(parentPom.contains("<maven.compiler.release>21</maven.compiler.release>"));
 		String parentGradle = config.getParentProject().buildGradle().getContent();
 		assertTrue(parentGradle.contains("sourceCompatibility = JavaVersion.VERSION_21"));
 		assertTrue(parentGradle.contains("targetCompatibility = JavaVersion.VERSION_21"));

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/pom.xml
@@ -10,8 +10,7 @@
 		<xtextVersion>unspecified</xtextVersion>
 		<mwe2Version>2.25.0</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 		<!-- Tycho settings -->
 		<tycho-version>5.0.2</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenApp/lsMavenApp.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenApp/lsMavenApp.parent/pom.xml
@@ -9,8 +9,7 @@
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 	</properties>
 	<modules>
 		<module>lsMavenApp</module>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenFatjar/lsMavenFatjar.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenFatjar/lsMavenFatjar.parent/pom.xml
@@ -9,8 +9,7 @@
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 	</properties>
 	<modules>
 		<module>lsMavenFatjar</module>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/pom.xml
@@ -10,8 +10,7 @@
 		<xtextVersion>unspecified</xtextVersion>
 		<mwe2Version>2.25.0</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 		<!-- Tycho settings -->
 		<tycho-version>5.0.2</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/pom.xml
@@ -10,8 +10,7 @@
 		<xtextVersion>unspecified</xtextVersion>
 		<mwe2Version>2.25.0</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 		<!-- Tycho settings -->
 		<tycho-version>5.0.2</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/pom.xml
@@ -10,8 +10,7 @@
 		<xtextVersion>unspecified</xtextVersion>
 		<mwe2Version>2.25.0</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 		<!-- Tycho settings -->
 		<tycho-version>5.0.2</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit5/mavenTychoJUnit5.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit5/mavenTychoJUnit5.parent/pom.xml
@@ -10,8 +10,7 @@
 		<xtextVersion>unspecified</xtextVersion>
 		<mwe2Version>2.25.0</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 		<!-- Tycho settings -->
 		<tycho-version>5.0.2</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/pom.xml
@@ -10,8 +10,7 @@
 		<xtextVersion>unspecified</xtextVersion>
 		<mwe2Version>2.25.0</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 		<!-- Tycho settings -->
 		<tycho-version>5.0.2</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J25/mavenTychoP2J25.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J25/mavenTychoP2J25.parent/pom.xml
@@ -10,8 +10,7 @@
 		<xtextVersion>unspecified</xtextVersion>
 		<mwe2Version>2.25.0</mwe2Version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>25</maven.compiler.source>
-		<maven.compiler.target>25</maven.compiler.target>
+		<maven.compiler.release>25</maven.compiler.release>
 		<!-- Tycho settings -->
 		<tycho-version>5.0.2</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/plainMaven/plainMaven.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/plainMaven/plainMaven.parent/pom.xml
@@ -9,8 +9,7 @@
 	<properties>
 		<xtextVersion>unspecified</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 	</properties>
 	<modules>
 		<module>plainMaven</module>

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/pom.xml
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/pom.xml
@@ -18,8 +18,7 @@
 	</dependencyManagement>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 		<!-- Tycho settings -->
 		<tycho-version>5.0.2</tycho-version>
 		<targetplatform.groupId>${project.groupId}</targetplatform.groupId>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
@@ -219,8 +219,7 @@ class ParentProjectDescriptor extends ProjectDescriptor {
 					<mwe2Version>«config.xtextVersion.mweVersion»</mwe2Version>
 					«ENDIF»
 					<project.build.sourceEncoding>«config.encoding»</project.build.sourceEncoding>
-					<maven.compiler.source>«javaVersion»</maven.compiler.source>
-					<maven.compiler.target>«javaVersion»</maven.compiler.target>
+					<maven.compiler.release>«javaVersion»</maven.compiler.release>
 					«IF config.needsTychoBuild»
 						<!-- Tycho settings -->
 						<tycho-version>«tychoVersion»</tycho-version>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
@@ -559,16 +559,10 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
       _builder.append("</project.build.sourceEncoding>");
       _builder.newLineIfNotEmpty();
       _builder.append("\t");
-      _builder.append("<maven.compiler.source>");
+      _builder.append("<maven.compiler.release>");
       String _javaVersion = this.getJavaVersion();
       _builder.append(_javaVersion, "\t");
-      _builder.append("</maven.compiler.source>");
-      _builder.newLineIfNotEmpty();
-      _builder.append("\t");
-      _builder.append("<maven.compiler.target>");
-      String _javaVersion_1 = this.getJavaVersion();
-      _builder.append(_javaVersion_1, "\t");
-      _builder.append("</maven.compiler.target>");
+      _builder.append("</maven.compiler.release>");
       _builder.newLineIfNotEmpty();
       {
         boolean _needsTychoBuild_1 = this.getConfig().needsTychoBuild();

--- a/pom.xml
+++ b/pom.xml
@@ -128,9 +128,6 @@
 		<tycho-version>5.0.2</tycho-version>
 
 		<maven.compiler.release>21</maven.compiler.release>
-		<maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
-		<maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
-
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 
 		<build-helper-maven-plugin-version>3.3.0</build-helper-maven-plugin-version>


### PR DESCRIPTION
The use of the `--release` option of the Java compiler implies a corresponding `--source` and `--target` value and is even more powerful: https://docs.oracle.com/en/java/javase/21/docs/specs/man/javac.html#option-release