### PR TITLE
Support maven.compiler.release parameter in Xtext/Xtend Maven plugins

### DIFF
--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendCompilerMojo.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendCompilerMojo.java
@@ -45,10 +45,23 @@ public abstract class AbstractXtendCompilerMojo extends AbstractXtendMojo {
 	/**
 	 * Create Java Source Code that is compatible to this Java version.
 	 * 
-	 * Supported values: 11, 17 and so forth
+	 * Supported values: 11, 17, 21 and so forth
 	 */
 	@Parameter(property="maven.compiler.source", defaultValue="11")
 	private String javaSourceVersion;
+
+	/**
+	 * Create Java Source Code that targets this Java release.
+	 * <p>
+	 * If set, this implies a {@link #javaSourceVersion} of the same value and any value explicitly configured for the latter is ignored.
+	 * Nevertheless specifying this parameter does not enforce strict Java API checks like the {@code release} option for a Java compiler
+	 * does. Still it is possible to enforce strict Java API checks by specifying the {@code release} option for the compiler-plugin.
+	 * </p>
+	 * 
+	 * Supported values: 11, 17, 21 and so forth
+	 */
+	@Parameter(property = "maven.compiler.release")
+	private String javaReleaseVersion;
 
 	/**
 	 * The current build session instance. This is used for toolchain manager API calls.
@@ -132,8 +145,9 @@ public abstract class AbstractXtendCompilerMojo extends AbstractXtendMojo {
 			return;
 		}
 		String baseDir = project.getBasedir().getAbsolutePath();
-		log.debug("Set Java Compliance Level: " + javaSourceVersion);
-		compiler.setJavaSourceVersion(javaSourceVersion);
+		String sourceVersion = javaReleaseVersion != null && !javaReleaseVersion.isBlank() ? javaReleaseVersion : javaSourceVersion;
+		log.debug("Set Java Compliance Level: " + sourceVersion);
+		compiler.setJavaSourceVersion(sourceVersion);
 		log.debug("Set generateSyntheticSuppressWarnings: " + generateSyntheticSuppressWarnings);
 		compiler.setGenerateSyntheticSuppressWarnings(generateSyntheticSuppressWarnings);
 		log.debug("Set useXbaseGenerated: " + useXbaseGenerated);

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/simple-java21/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/simple-java21/pom.xml
@@ -10,8 +10,7 @@
 	</parent>
 	<artifactId>simple-java21</artifactId>
 	<properties>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 	</properties>
 	<build>
 		<plugins>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/pom.xml
@@ -6,8 +6,7 @@
 	<version>IT-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.release>17</maven.compiler.release>
 		<xtextVersion>@project.version@</xtextVersion>
 		<xtextBOMVersion>${xtextVersion}</xtextBOMVersion>
 	</properties>

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/java-lang-21-bi-ref/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/java-lang-21-bi-ref/pom.xml
@@ -11,8 +11,7 @@
 	</parent>
 
 	<properties>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 	</properties>
 
 	<artifactId>java-lang-21-bi-ref</artifactId>

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
@@ -10,8 +10,7 @@
 	<properties>
 		<JENKINS_URL>https://ci.eclipse.org/xtext</JENKINS_URL>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.release>17</maven.compiler.release>
 		<!-- The @...@ will be replaced during resource filtering with
 			the current version of our project -->
 		<xtext-version>@project.version@</xtext-version>


### PR DESCRIPTION
Add support for reading the maven.compiler.release parameter and grant it precedence over a `maven.compiler.source` or `maven.compiler.target` configuration (similar to the Java compiler).

As suggested in
- https://github.com/eclipse-xtext/xtext/pull/3603#issuecomment-3908158432

