### PR TITLE
Activate Annotation of synthetic members in Xtext's Oomph setup

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -342,6 +342,14 @@
           key="/instance/org.eclipse.xtext.builder/schedulingrule"
           value="ALL_XTEXT_PROJECTS"/>
     </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.xtend.core.Xtend">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.xtend.core.Xtend/useXbaseGenerated"
+          value="true"/>
+    </setupTask>
   </setupTask>
   <setupTask
       xsi:type="setup.p2:P2Task"


### PR DESCRIPTION
Explicitly activate the Xtend compiler preference `Annotate synthetic members with @XbaseGenerated`.
The generated code committed to the repository uses that and if one has disabled once it will generate diffs in the Git worktree.
So the Oomph setup should explicitly activate that Option.