### PR TITLE
Fix expected Tycho version in mavenTychoP2J25.parent test

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J25/mavenTychoP2J25.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J25/mavenTychoP2J25.parent/pom.xml
@@ -13,7 +13,7 @@
 		<maven.compiler.source>25</maven.compiler.source>
 		<maven.compiler.target>25</maven.compiler.target>
 		<!-- Tycho settings -->
-		<tycho-version>4.0.13</tycho-version>
+		<tycho-version>5.0.2</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->
 		<platformSystemProperties></platformSystemProperties>
 		<moduleProperties></moduleProperties>


### PR DESCRIPTION
This was forgotten in the Update to Tycho 5.0.2 in
- https://github.com/eclipse-xtext/xtext/pull/3602
 
because that PR was not rebased on latest main and in the meantime that new case was introduced with
- https://github.com/eclipse-xtext/xtext/pull/3604