### PR TITLE
[Build] Fix nightly build TP and drop unused upstream trigger handling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
 
   triggers {
     parameterizedCron(env.BRANCH_NAME == 'main' ? '''
-      H H(0-1) * * * %TARGET_PLATFORM=r202403;JDK_VERSION=21
+      H H(0-1) * * * %TARGET_PLATFORM=r202512;JDK_VERSION=21
       H H(3-4) * * * %TARGET_PLATFORM=latest;JDK_VERSION=25
       ''' : '')
   }
@@ -72,7 +72,7 @@ pipeline {
               export JAVA_${javaVersion()}_HOME=''
               jdkEnvVar='JAVA_HOME'
             fi
-            ./full-build.sh --tp=${selectedTargetPlatform()} \
+            ./full-build.sh --tp=${params.TARGET_PLATFORM} \
               -Pstrict-jdk-${javaVersion()} -Dtoolchain.jdk.env=\${jdkEnvVar}
           """
         }
@@ -146,17 +146,12 @@ def javaVersion() {
   return Integer.parseInt(params.JDK_VERSION)
 }
 
-/** returns true when this build was triggered by an upstream build */
-def isTriggeredByUpstream() {
-  return !"[]".equals(currentBuild.getBuildCauses('org.jenkinsci.plugins.workflow.support.steps.build.BuildUpstreamCause').toString())
-}
-
 /**
  * Returns the Eclipse version dependent on the selected target platform.
  * Result: '4.XX'
  */
 def eclipseVersion() {
-  def targetPlatform = selectedTargetPlatform()
+  def targetPlatform = params.TARGET_PLATFORM
   if (targetPlatform == 'latest') {
     return "4.40"
   } else {
@@ -166,25 +161,4 @@ def eclipseVersion() {
     long monthsBetween = java.time.temporal.ChronoUnit.MONTHS.between(baseDate, targetDate);
     return "4."+ (8+(monthsBetween/3))
   }
-}
-
-/**
- * The target platform is primarily defined by the build parameter TARGET_PLATFORM.
- * But when the build is triggered by upstream with at least Java version 21, 'latest'
- * is returned.
- */
-def selectedTargetPlatform() {
-    def tp = params.TARGET_PLATFORM
-    def isUpstream = isTriggeredByUpstream()
-    def javaVersion = javaVersion()
-
-    if (isTriggeredByUpstream() && javaVersion>=25) {
-        println("Choosing 'latest' target since this build was triggered by upstream with Java ${javaVersion}")
-        return 'latest'
-    } else if (isTriggeredByUpstream() && javaVersion>=21) {
-        println("Choosing 'r2025-12' target since this build was triggered by upstream with Java ${javaVersion}")
-        return 'r2025-12'
-    } else {
-        return tp
-    }
 }


### PR DESCRIPTION
Upstream builds that trigger the Xtext Jenkins pipelines do not exist anymore and therefore isTriggeredByUpstream() always returns false. With that assumption the pipline can be simplify and also selectedTargetPlatform() can be removed.
The latter returned an erroneous tp file name fragment anyways if it where called by an upstream job.

Follow-up on
- https://github.com/eclipse-xtext/xtext/pull/3650