### PR TITLE
Remove trailing whitespace in generated parent pom.xml

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/pom.xml
@@ -209,7 +209,7 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent 
+		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent
 			which is taken from exec-maven-plugin from at least version 1.6.0 -->
 		<repository>
 			<id>ossrh-snapshots</id>
@@ -222,7 +222,7 @@
 			</snapshots>
 			<url>http://oss.sonatype.org/content/repositories/snapshots</url>
 		</repository>
-		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by 
+		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by
 			org/xtext/antlr-generator/3.2.1 -->
 		<repository>
 			<id>sonatype-nexus-snapshots</id>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/pom.xml
@@ -173,7 +173,7 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent 
+		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent
 			which is taken from exec-maven-plugin from at least version 1.6.0 -->
 		<repository>
 			<id>ossrh-snapshots</id>
@@ -186,7 +186,7 @@
 			</snapshots>
 			<url>http://oss.sonatype.org/content/repositories/snapshots</url>
 		</repository>
-		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by 
+		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by
 			org/xtext/antlr-generator/3.2.1 -->
 		<repository>
 			<id>sonatype-nexus-snapshots</id>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/pom.xml
@@ -173,7 +173,7 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent 
+		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent
 			which is taken from exec-maven-plugin from at least version 1.6.0 -->
 		<repository>
 			<id>ossrh-snapshots</id>
@@ -186,7 +186,7 @@
 			</snapshots>
 			<url>http://oss.sonatype.org/content/repositories/snapshots</url>
 		</repository>
-		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by 
+		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by
 			org/xtext/antlr-generator/3.2.1 -->
 		<repository>
 			<id>sonatype-nexus-snapshots</id>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/pom.xml
@@ -176,7 +176,7 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent 
+		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent
 			which is taken from exec-maven-plugin from at least version 1.6.0 -->
 		<repository>
 			<id>ossrh-snapshots</id>
@@ -189,7 +189,7 @@
 			</snapshots>
 			<url>http://oss.sonatype.org/content/repositories/snapshots</url>
 		</repository>
-		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by 
+		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by
 			org/xtext/antlr-generator/3.2.1 -->
 		<repository>
 			<id>sonatype-nexus-snapshots</id>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit5/mavenTychoJUnit5.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit5/mavenTychoJUnit5.parent/pom.xml
@@ -176,7 +176,7 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent 
+		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent
 			which is taken from exec-maven-plugin from at least version 1.6.0 -->
 		<repository>
 			<id>ossrh-snapshots</id>
@@ -189,7 +189,7 @@
 			</snapshots>
 			<url>http://oss.sonatype.org/content/repositories/snapshots</url>
 		</repository>
-		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by 
+		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by
 			org/xtext/antlr-generator/3.2.1 -->
 		<repository>
 			<id>sonatype-nexus-snapshots</id>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/pom.xml
@@ -211,7 +211,7 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent 
+		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent
 			which is taken from exec-maven-plugin from at least version 1.6.0 -->
 		<repository>
 			<id>ossrh-snapshots</id>
@@ -224,7 +224,7 @@
 			</snapshots>
 			<url>http://oss.sonatype.org/content/repositories/snapshots</url>
 		</repository>
-		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by 
+		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by
 			org/xtext/antlr-generator/3.2.1 -->
 		<repository>
 			<id>sonatype-nexus-snapshots</id>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J25/mavenTychoP2J25.parent/pom.xml
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J25/mavenTychoP2J25.parent/pom.xml
@@ -211,7 +211,7 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
-		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent 
+		<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent
 			which is taken from exec-maven-plugin from at least version 1.6.0 -->
 		<repository>
 			<id>ossrh-snapshots</id>
@@ -224,7 +224,7 @@
 			</snapshots>
 			<url>http://oss.sonatype.org/content/repositories/snapshots</url>
 		</repository>
-		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by 
+		<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by
 			org/xtext/antlr-generator/3.2.1 -->
 		<repository>
 			<id>sonatype-nexus-snapshots</id>

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2026 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -432,7 +432,7 @@ class ParentProjectDescriptor extends ProjectDescriptor {
 						</snapshots>
 					</repository>
 					«IF config.needsTychoBuild»
-						<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent 
+						<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent
 							which is taken from exec-maven-plugin from at least version 1.6.0 -->
 						<repository>
 							<id>ossrh-snapshots</id>
@@ -445,7 +445,7 @@ class ParentProjectDescriptor extends ProjectDescriptor {
 							</snapshots>
 							<url>http://oss.sonatype.org/content/repositories/snapshots</url>
 						</repository>
-						<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by 
+						<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by
 							org/xtext/antlr-generator/3.2.1 -->
 						<repository>
 							<id>sonatype-nexus-snapshots</id>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/ParentProjectDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, 2025 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2026 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -1369,7 +1369,7 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
         boolean _needsTychoBuild_5 = this.getConfig().needsTychoBuild();
         if (_needsTychoBuild_5) {
           _builder.append("\t");
-          _builder.append("<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent ");
+          _builder.append("<!-- This must be disabled explicitly, otherwise it is enabled by https://github.com/mojohaus/mojo-parent");
           _builder.newLine();
           _builder.append("\t");
           _builder.append("\t");
@@ -1418,7 +1418,7 @@ public class ParentProjectDescriptor extends ProjectDescriptor {
           _builder.append("</repository>");
           _builder.newLine();
           _builder.append("\t");
-          _builder.append("<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by ");
+          _builder.append("<!-- This is enabled by /org/sonatype/oss/oss-parent/7 used as parent by");
           _builder.newLine();
           _builder.append("\t");
           _builder.append("\t");


### PR DESCRIPTION
This constantly lead to changes if one has removal of trailing white-spaces enabled.