### PR TITLE
Set default Java version to 21 in Xtext/Xtend Maven plugins

### DIFF
--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendCompilerMojo.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendCompilerMojo.java
@@ -44,10 +44,10 @@ public abstract class AbstractXtendCompilerMojo extends AbstractXtendMojo {
 
 	/**
 	 * Create Java Source Code that is compatible to this Java version.
-	 * 
+	 *
 	 * Supported values: 11, 17, 21 and so forth
 	 */
-	@Parameter(property="maven.compiler.source", defaultValue="11")
+	@Parameter(property="maven.compiler.source", defaultValue="21")
 	private String javaSourceVersion;
 
 	/**

--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/AbstractXtextGeneratorMojo.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/AbstractXtextGeneratorMojo.java
@@ -95,10 +95,10 @@ public abstract class AbstractXtextGeneratorMojo extends AbstractXtextMojo {
 	@Parameter(defaultValue = "true")
 	private boolean failOnValidationError = true;
 
-	@Parameter(property = "maven.compiler.source", defaultValue = "11")
+	@Parameter(property = "maven.compiler.source", defaultValue = "21")
 	private String compilerSourceLevel;
 
-	@Parameter(property = "maven.compiler.target", defaultValue = "11")
+	@Parameter(property = "maven.compiler.target", defaultValue = "21")
 	private String compilerTargetLevel;
 	/**
 	 * Create Java Source Code that is compatible to this Java release.

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/xcore-auto-mapping/sample-auto.emf/model/a.xcore
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/xcore-auto-mapping/sample-auto.emf/model/a.xcore
@@ -7,12 +7,12 @@
 	editPluginID="sample-auto.emf.edit", 
 	forceOverwrite="true", 
 	resource="XMI",
-	complianceLevel="11.0"
+	complianceLevel="21.0"
 )
 package axcore
 
 annotation "http://www.eclipse.org/emf/2002/GenModel" as GenModel
 
 class ModelA {
-	
+
 }

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/xcore-mapping/sample.emf/model/a.xcore
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/xcore-mapping/sample.emf/model/a.xcore
@@ -7,12 +7,12 @@
 	editPluginID="sample.emf.edit", 
 	forceOverwrite="true", 
 	resource="XMI",
-	complianceLevel="11.0"
+	complianceLevel="21.0"
 )
 package axcore
 
 annotation "http://www.eclipse.org/emf/2002/GenModel" as GenModel
 
 class ModelA {
-	
+
 }


### PR DESCRIPTION
Follow-up on
- https://github.com/eclipse-xtext/xtext/pull/3647

and also discussed in
- https://github.com/eclipse-xtext/xtext/pull/3603