### PR TITLE
Clean-up and format target files

### DIFF
--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/full.target/full.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/full/full.parent/full.target/full.target.target
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="full.target" sequenceNumber="1">
+<target name="full.target">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.jdt.feature.group"/>
+			<unit id="org.eclipse.platform.feature.group"/>
+			<unit id="org.eclipse.pde.feature.group"/>
+			<unit id="org.eclipse.draw2d.feature.group"/>
+			<unit id="org.eclipse.emf.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/releases/2026-06"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.mwe2.launcher.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.xtext.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.13.2"/>
-			<unit id="com.google.inject" version="7.0.0"/>
-			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
-			<unit id="org.antlr.runtime" version="3.2.0.v20230929-1400"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.hamcrest" version="2.2.0"/>
-			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="9.9.1"/>
-			<unit id="io.github.classgraph.classgraph" version="0.0.0"/>
+			<unit id="com.google.gson"/>
+			<unit id="com.google.inject" version="[7,8)"/>
+			<unit id="jakarta.inject.jakarta.inject-api" version="[2,3)"/>
+			<unit id="org.antlr.runtime"/>
+			<unit id="org.junit"/>
+			<unit id="org.hamcrest" version="[2,3)"/>
+			<unit id="org.hamcrest.core" version="[2,3)"/>
+			<unit id="org.apache.commons.commons-logging"/>
+			<unit id="org.objectweb.asm"/>
+			<unit id="io.github.classgraph.classgraph"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
 		</location>
 	</locations>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/lsMavenTychoApp.target/lsMavenTychoApp.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoApp/lsMavenTychoApp.parent/lsMavenTychoApp.target/lsMavenTychoApp.target.target
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="lsMavenTychoApp.target" sequenceNumber="1">
+<target name="lsMavenTychoApp.target">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.jdt.feature.group"/>
+			<unit id="org.eclipse.platform.feature.group"/>
+			<unit id="org.eclipse.pde.feature.group"/>
+			<unit id="org.eclipse.draw2d.feature.group"/>
+			<unit id="org.eclipse.emf.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/releases/2026-06"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.mwe2.launcher.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.xtext.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.13.2"/>
-			<unit id="com.google.inject" version="7.0.0"/>
-			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
-			<unit id="org.antlr.runtime" version="3.2.0.v20230929-1400"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.hamcrest" version="2.2.0"/>
-			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="9.9.1"/>
-			<unit id="io.github.classgraph.classgraph" version="0.0.0"/>
+			<unit id="com.google.gson"/>
+			<unit id="com.google.inject" version="[7,8)"/>
+			<unit id="jakarta.inject.jakarta.inject-api" version="[2,3)"/>
+			<unit id="org.antlr.runtime"/>
+			<unit id="org.junit"/>
+			<unit id="org.hamcrest" version="[2,3)"/>
+			<unit id="org.hamcrest.core" version="[2,3)"/>
+			<unit id="org.apache.commons.commons-logging"/>
+			<unit id="org.objectweb.asm"/>
+			<unit id="io.github.classgraph.classgraph"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
 		</location>
 	</locations>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/lsMavenTychoFatjar.target/lsMavenTychoFatjar.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/lsMavenTychoFatjar/lsMavenTychoFatjar.parent/lsMavenTychoFatjar.target/lsMavenTychoFatjar.target.target
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="lsMavenTychoFatjar.target" sequenceNumber="1">
+<target name="lsMavenTychoFatjar.target">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.jdt.feature.group"/>
+			<unit id="org.eclipse.platform.feature.group"/>
+			<unit id="org.eclipse.pde.feature.group"/>
+			<unit id="org.eclipse.draw2d.feature.group"/>
+			<unit id="org.eclipse.emf.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/releases/2026-06"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.mwe2.launcher.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.xtext.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.13.2"/>
-			<unit id="com.google.inject" version="7.0.0"/>
-			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
-			<unit id="org.antlr.runtime" version="3.2.0.v20230929-1400"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.hamcrest" version="2.2.0"/>
-			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="9.9.1"/>
-			<unit id="io.github.classgraph.classgraph" version="0.0.0"/>
+			<unit id="com.google.gson"/>
+			<unit id="com.google.inject" version="[7,8)"/>
+			<unit id="jakarta.inject.jakarta.inject-api" version="[2,3)"/>
+			<unit id="org.antlr.runtime"/>
+			<unit id="org.junit"/>
+			<unit id="org.hamcrest" version="[2,3)"/>
+			<unit id="org.hamcrest.core" version="[2,3)"/>
+			<unit id="org.apache.commons.commons-logging"/>
+			<unit id="org.objectweb.asm"/>
+			<unit id="io.github.classgraph.classgraph"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
 		</location>
 	</locations>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/mavenTycho.target/mavenTycho.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTycho/mavenTycho.parent/mavenTycho.target/mavenTycho.target.target
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="mavenTycho.target" sequenceNumber="1">
+<target name="mavenTycho.target">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.jdt.feature.group"/>
+			<unit id="org.eclipse.platform.feature.group"/>
+			<unit id="org.eclipse.pde.feature.group"/>
+			<unit id="org.eclipse.draw2d.feature.group"/>
+			<unit id="org.eclipse.emf.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/releases/2026-06"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.mwe2.launcher.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.xtext.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.13.2"/>
-			<unit id="com.google.inject" version="7.0.0"/>
-			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
-			<unit id="org.antlr.runtime" version="3.2.0.v20230929-1400"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.hamcrest" version="2.2.0"/>
-			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="9.9.1"/>
-			<unit id="io.github.classgraph.classgraph" version="0.0.0"/>
+			<unit id="com.google.gson"/>
+			<unit id="com.google.inject" version="[7,8)"/>
+			<unit id="jakarta.inject.jakarta.inject-api" version="[2,3)"/>
+			<unit id="org.antlr.runtime"/>
+			<unit id="org.junit"/>
+			<unit id="org.hamcrest" version="[2,3)"/>
+			<unit id="org.hamcrest.core" version="[2,3)"/>
+			<unit id="org.apache.commons.commons-logging"/>
+			<unit id="org.objectweb.asm"/>
+			<unit id="io.github.classgraph.classgraph"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
 		</location>
 	</locations>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit6/mavenTychoJUnit6.parent/mavenTychoJUnit6.target/mavenTychoJUnit6.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoJUnit6/mavenTychoJUnit6.parent/mavenTychoJUnit6.target/mavenTychoJUnit6.target.target
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="mavenTychoJUnit6.target" sequenceNumber="1">
+<target name="mavenTychoJUnit6.target">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.jdt.feature.group"/>
+			<unit id="org.eclipse.platform.feature.group"/>
+			<unit id="org.eclipse.pde.feature.group"/>
+			<unit id="org.eclipse.draw2d.feature.group"/>
+			<unit id="org.eclipse.emf.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/releases/2026-06"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.mwe2.launcher.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.xtext.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.13.2"/>
-			<unit id="com.google.inject" version="7.0.0"/>
-			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
-			<unit id="org.antlr.runtime" version="3.2.0.v20230929-1400"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.hamcrest" version="2.2.0"/>
-			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-			<unit id="org.apiguardian.api" version="0.0.0"/>
+			<unit id="com.google.gson"/>
+			<unit id="com.google.inject" version="[7,8)"/>
+			<unit id="jakarta.inject.jakarta.inject-api" version="[2,3)"/>
+			<unit id="org.antlr.runtime"/>
+			<unit id="org.junit"/>
+			<unit id="org.hamcrest" version="[2,3)"/>
+			<unit id="org.hamcrest.core" version="[2,3)"/>
+			<unit id="org.apache.commons.commons-logging"/>
+			<unit id="org.apiguardian.api"/>
 			<unit id="junit-jupiter-api" version="[6.0.0,7.0.0)"/>
 			<unit id="junit-jupiter-engine" version="[6.0.0,7.0.0)"/>
 			<unit id="junit-jupiter-migrationsupport" version="[6.0.0,7.0.0)"/>
@@ -38,9 +38,9 @@
 			<unit id="junit-platform-launcher" version="[6.0.0,7.0.0)"/>
 			<unit id="junit-platform-suite-api" version="[6.0.0,7.0.0)"/>
 			<unit id="junit-vintage-engine" version="[6.0.0,7.0.0)"/>
-			<unit id="org.opentest4j" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="9.9.1"/>
-			<unit id="io.github.classgraph.classgraph" version="0.0.0"/>
+			<unit id="org.opentest4j"/>
+			<unit id="org.objectweb.asm"/>
+			<unit id="io.github.classgraph.classgraph"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
 		</location>
 	</locations>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/mavenTychoP2.target/mavenTychoP2.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2/mavenTychoP2.parent/mavenTychoP2.target/mavenTychoP2.target.target
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="mavenTychoP2.target" sequenceNumber="1">
+<target name="mavenTychoP2.target">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.jdt.feature.group"/>
+			<unit id="org.eclipse.platform.feature.group"/>
+			<unit id="org.eclipse.pde.feature.group"/>
+			<unit id="org.eclipse.draw2d.feature.group"/>
+			<unit id="org.eclipse.emf.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/releases/2026-06"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.mwe2.launcher.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.xtext.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.13.2"/>
-			<unit id="com.google.inject" version="7.0.0"/>
-			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
-			<unit id="org.antlr.runtime" version="3.2.0.v20230929-1400"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.hamcrest" version="2.2.0"/>
-			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="9.9.1"/>
-			<unit id="io.github.classgraph.classgraph" version="0.0.0"/>
+			<unit id="com.google.gson"/>
+			<unit id="com.google.inject" version="[7,8)"/>
+			<unit id="jakarta.inject.jakarta.inject-api" version="[2,3)"/>
+			<unit id="org.antlr.runtime"/>
+			<unit id="org.junit"/>
+			<unit id="org.hamcrest" version="[2,3)"/>
+			<unit id="org.hamcrest.core" version="[2,3)"/>
+			<unit id="org.apache.commons.commons-logging"/>
+			<unit id="org.objectweb.asm"/>
+			<unit id="io.github.classgraph.classgraph"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
 		</location>
 	</locations>

--- a/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J25/mavenTychoP2J25.parent/mavenTychoP2J25.target/mavenTychoP2J25.target.target
+++ b/org.eclipse.xtext.tests/testdata/wizard-expectations/mavenTychoP2J25/mavenTychoP2J25.parent/mavenTychoP2J25.target/mavenTychoP2J25.target.target
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="mavenTychoP2J25.target" sequenceNumber="1">
+<target name="mavenTychoP2J25.target">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-25"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.jdt.feature.group"/>
+			<unit id="org.eclipse.platform.feature.group"/>
+			<unit id="org.eclipse.pde.feature.group"/>
+			<unit id="org.eclipse.draw2d.feature.group"/>
+			<unit id="org.eclipse.emf.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/releases/2026-06"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.mwe2.launcher.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.xtext.sdk.feature.group"/>
 			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.13.2"/>
-			<unit id="com.google.inject" version="7.0.0"/>
-			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
-			<unit id="org.antlr.runtime" version="3.2.0.v20230929-1400"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.hamcrest" version="2.2.0"/>
-			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="9.9.1"/>
-			<unit id="io.github.classgraph.classgraph" version="0.0.0"/>
+			<unit id="com.google.gson"/>
+			<unit id="com.google.inject" version="[7,8)"/>
+			<unit id="jakarta.inject.jakarta.inject-api" version="[2,3)"/>
+			<unit id="org.antlr.runtime"/>
+			<unit id="org.junit"/>
+			<unit id="org.hamcrest" version="[2,3)"/>
+			<unit id="org.hamcrest.core" version="[2,3)"/>
+			<unit id="org.apache.commons.commons-logging"/>
+			<unit id="org.objectweb.asm"/>
+			<unit id="io.github.classgraph.classgraph"/>
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
 		</location>
 	</locations>

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
@@ -4,19 +4,19 @@
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.jdt.feature.group"/>
+      <unit id="org.eclipse.platform.feature.group"/>
+      <unit id="org.eclipse.pde.feature.group"/>
+      <unit id="org.eclipse.emf.sdk.feature.group"/>
       <unit id="org.apache.commons.commons-logging"/>
       <repository location="https://download.eclipse.org/releases/2026-06"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.mwe2.launcher.feature.group"/>
       <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.xtext.sdk.feature.group"/>
       <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/nightly"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
+++ b/org.eclipse.xtext.xtext.wizard/src/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.xtend
@@ -49,11 +49,11 @@ class TargetPlatformProject extends ProjectDescriptor {
 	override getSourceFolders() {
 		#{}
 	}
-	
+
 	def target() '''
 		<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 		<?pde version="3.8"?>
-		<target name="«name»" sequenceNumber="1">
+		<target name="«name»">
 			«IF config.javaVersion.isAtLeast(JavaVersion.JAVA25)»
 				<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-25"/>
 			«ELSE»
@@ -61,15 +61,15 @@ class TargetPlatformProject extends ProjectDescriptor {
 			«ENDIF»
 			<locations>
 				<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-					<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-					<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-					<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-					<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-					<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+					<unit id="org.eclipse.jdt.feature.group"/>
+					<unit id="org.eclipse.platform.feature.group"/>
+					<unit id="org.eclipse.pde.feature.group"/>
+					<unit id="org.eclipse.draw2d.feature.group"/>
+					<unit id="org.eclipse.emf.sdk.feature.group"/>
 					<repository location="https://download.eclipse.org/releases/2026-06"/>
 				</location>
 				<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-					<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+					<unit id="org.eclipse.emf.mwe2.launcher.feature.group"/>
 					«IF config.xtextVersion.mweVersion.matches("\\d+\\.\\d+(\\.\\d+)+")»
 						<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/«config.xtextVersion.mweVersion»/"/>
 					«ELSE»
@@ -77,7 +77,7 @@ class TargetPlatformProject extends ProjectDescriptor {
 					«ENDIF»
 				</location>
 				<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-					<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+					<unit id="org.eclipse.xtext.sdk.feature.group"/>
 					«IF config.xtextVersion.isSnapshot»
 						<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/nightly/"/>
 					«ELSEIF config.xtextVersion.isStable»
@@ -87,16 +87,16 @@ class TargetPlatformProject extends ProjectDescriptor {
 					«ENDIF»
 				</location>
 				<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-					<unit id="com.google.gson" version="2.13.2"/>
-					<unit id="com.google.inject" version="7.0.0"/>
-					<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
-					<unit id="org.antlr.runtime" version="3.2.0.v20230929-1400"/>
-					<unit id="org.junit" version="0.0.0"/>
-					<unit id="org.hamcrest" version="2.2.0"/>
-					<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-					<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
+					<unit id="com.google.gson"/>
+					<unit id="com.google.inject" version="[7,8)"/>
+					<unit id="jakarta.inject.jakarta.inject-api" version="[2,3)"/>
+					<unit id="org.antlr.runtime"/>
+					<unit id="org.junit"/>
+					<unit id="org.hamcrest" version="[2,3)"/>
+					<unit id="org.hamcrest.core" version="[2,3)"/>
+					<unit id="org.apache.commons.commons-logging"/>
 					«IF config.junitVersion == JUnitVersion.JUNIT_6»
-						<unit id="org.apiguardian.api" version="0.0.0"/>
+						<unit id="org.apiguardian.api"/>
 						<unit id="junit-jupiter-api" version="[6.0.0,7.0.0)"/>
 						<unit id="junit-jupiter-engine" version="[6.0.0,7.0.0)"/>
 						<unit id="junit-jupiter-migrationsupport" version="[6.0.0,7.0.0)"/>
@@ -106,10 +106,10 @@ class TargetPlatformProject extends ProjectDescriptor {
 						<unit id="junit-platform-launcher" version="[6.0.0,7.0.0)"/>
 						<unit id="junit-platform-suite-api" version="[6.0.0,7.0.0)"/>
 						<unit id="junit-vintage-engine" version="[6.0.0,7.0.0)"/>
-						<unit id="org.opentest4j" version="0.0.0"/>
+						<unit id="org.opentest4j"/>
 					«ENDIF»
-					<unit id="org.objectweb.asm" version="9.9.1"/>
-					<unit id="io.github.classgraph.classgraph" version="0.0.0"/>
+					<unit id="org.objectweb.asm"/>
+					<unit id="io.github.classgraph.classgraph"/>
 					<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
 				</location>
 			</locations>

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/RuntimeProjectDescriptor.java
@@ -555,7 +555,7 @@ public class RuntimeProjectDescriptor extends TestedProjectDescriptor {
         _builder.newLine();
         _builder.append("\t\t\t");
         _builder.append("\t");
-        _builder.append("junitVersion = \"5\"");
+        _builder.append("junitVersion = \"6\"");
         _builder.newLine();
         _builder.append("\t\t\t");
         _builder.append("}");

--- a/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
+++ b/org.eclipse.xtext.xtext.wizard/xtend-gen/org/eclipse/xtext/xtext/wizard/TargetPlatformProject.java
@@ -85,7 +85,7 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.append("<target name=\"");
     String _name = this.getName();
     _builder.append(_name);
-    _builder.append("\" sequenceNumber=\"1\">");
+    _builder.append("\">");
     _builder.newLineIfNotEmpty();
     {
       boolean _isAtLeast = this.getConfig().getJavaVersion().isAtLeast(JavaVersion.JAVA25);
@@ -106,19 +106,19 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.append("<location includeAllPlatforms=\"false\" includeConfigurePhase=\"false\" includeMode=\"planner\" includeSource=\"true\" type=\"InstallableUnit\">");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.eclipse.jdt.feature.group\" version=\"0.0.0\"/>");
+    _builder.append("<unit id=\"org.eclipse.jdt.feature.group\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.eclipse.platform.feature.group\" version=\"0.0.0\"/>");
+    _builder.append("<unit id=\"org.eclipse.platform.feature.group\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.eclipse.pde.feature.group\" version=\"0.0.0\"/>");
+    _builder.append("<unit id=\"org.eclipse.pde.feature.group\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.eclipse.draw2d.feature.group\" version=\"0.0.0\"/>");
+    _builder.append("<unit id=\"org.eclipse.draw2d.feature.group\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.eclipse.emf.sdk.feature.group\" version=\"0.0.0\"/>");
+    _builder.append("<unit id=\"org.eclipse.emf.sdk.feature.group\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
     _builder.append("<repository location=\"https://download.eclipse.org/releases/2026-06\"/>");
@@ -130,7 +130,7 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.append("<location includeAllPlatforms=\"false\" includeConfigurePhase=\"false\" includeMode=\"planner\" includeSource=\"true\" type=\"InstallableUnit\">");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.eclipse.emf.mwe2.launcher.feature.group\" version=\"0.0.0\"/>");
+    _builder.append("<unit id=\"org.eclipse.emf.mwe2.launcher.feature.group\"/>");
     _builder.newLine();
     {
       boolean _matches = this.getConfig().getXtextVersion().getMweVersion().matches("\\d+\\.\\d+(\\.\\d+)+");
@@ -157,7 +157,7 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.append("<location includeAllPlatforms=\"false\" includeConfigurePhase=\"false\" includeMode=\"planner\" includeSource=\"true\" type=\"InstallableUnit\">");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.eclipse.xtext.sdk.feature.group\" version=\"0.0.0\"/>");
+    _builder.append("<unit id=\"org.eclipse.xtext.sdk.feature.group\"/>");
     _builder.newLine();
     {
       boolean _isSnapshot = this.getConfig().getXtextVersion().isSnapshot();
@@ -188,35 +188,35 @@ public class TargetPlatformProject extends ProjectDescriptor {
     _builder.append("<location includeAllPlatforms=\"false\" includeConfigurePhase=\"false\" includeMode=\"planner\" includeSource=\"true\" type=\"InstallableUnit\">");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"com.google.gson\" version=\"2.13.2\"/>");
+    _builder.append("<unit id=\"com.google.gson\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"com.google.inject\" version=\"7.0.0\"/>");
+    _builder.append("<unit id=\"com.google.inject\" version=\"[7,8)\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"jakarta.inject.jakarta.inject-api\" version=\"2.0.1\"/>");
+    _builder.append("<unit id=\"jakarta.inject.jakarta.inject-api\" version=\"[2,3)\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.antlr.runtime\" version=\"3.2.0.v20230929-1400\"/>");
+    _builder.append("<unit id=\"org.antlr.runtime\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.junit\" version=\"0.0.0\"/>");
+    _builder.append("<unit id=\"org.junit\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.hamcrest\" version=\"2.2.0\"/>");
+    _builder.append("<unit id=\"org.hamcrest\" version=\"[2,3)\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.hamcrest.core\" version=\"2.2.0.v20230809-1000\"/>");
+    _builder.append("<unit id=\"org.hamcrest.core\" version=\"[2,3)\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.apache.commons.commons-logging\" version=\"0.0.0\"/>");
+    _builder.append("<unit id=\"org.apache.commons.commons-logging\"/>");
     _builder.newLine();
     {
       JUnitVersion _junitVersion = this.getConfig().getJunitVersion();
       boolean _equals = Objects.equals(_junitVersion, JUnitVersion.JUNIT_6);
       if (_equals) {
         _builder.append("\t\t\t");
-        _builder.append("<unit id=\"org.apiguardian.api\" version=\"0.0.0\"/>");
+        _builder.append("<unit id=\"org.apiguardian.api\"/>");
         _builder.newLine();
         _builder.append("\t\t\t");
         _builder.append("<unit id=\"junit-jupiter-api\" version=\"[6.0.0,7.0.0)\"/>");
@@ -246,15 +246,15 @@ public class TargetPlatformProject extends ProjectDescriptor {
         _builder.append("<unit id=\"junit-vintage-engine\" version=\"[6.0.0,7.0.0)\"/>");
         _builder.newLine();
         _builder.append("\t\t\t");
-        _builder.append("<unit id=\"org.opentest4j\" version=\"0.0.0\"/>");
+        _builder.append("<unit id=\"org.opentest4j\"/>");
         _builder.newLine();
       }
     }
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"org.objectweb.asm\" version=\"9.9.1\"/>");
+    _builder.append("<unit id=\"org.objectweb.asm\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
-    _builder.append("<unit id=\"io.github.classgraph.classgraph\" version=\"0.0.0\"/>");
+    _builder.append("<unit id=\"io.github.classgraph.classgraph\"/>");
     _builder.newLine();
     _builder.append("\t\t\t");
     _builder.append("<repository location=\"https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06\"/>");

--- a/xtext-latest.target
+++ b/xtext-latest.target
@@ -1,69 +1,68 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="xtext-latest" sequenceNumber="37">
+<target name="xtext-latest">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/nightly/latest" />
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/nightly/latest"/>
+			<unit id="org.eclipse.emf.sdk.feature.group"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
-			<unit id="org.eclipse.emf.mwe2.launch" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.launch.ui" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.language.ui" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.runtime" version="0.0.0"/>
+			<unit id="org.eclipse.emf.mwe2.launch"/>
+			<unit id="org.eclipse.emf.mwe2.launch.ui"/>
+			<unit id="org.eclipse.emf.mwe2.language.ui"/>
+			<unit id="org.eclipse.emf.mwe2.lib"/>
+			<unit id="org.eclipse.emf.mwe2.runtime"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/releases/2026-06/"/>
-			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.buildship.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.draw2d.feature.group"/>
+			<unit id="org.eclipse.m2e.feature.feature.group"/>
+			<unit id="org.eclipse.buildship.feature.group"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.sdk" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds" />
+			<unit id="org.eclipse.equinox.executable.feature.group"/>
+			<unit id="org.eclipse.sdk"/>
+			<unit id="org.eclipse.platform.feature.group"/>
+			<unit id="org.eclipse.jdt.feature.group"/>
+			<unit id="org.eclipse.pde.feature.group"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/lsp4j/updates/releases/1.0.0"/>
-			<unit id="org.eclipse.lsp4j" version="0.0.0"/>
-			<unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
+			<unit id="org.eclipse.lsp4j"/>
+			<unit id="org.eclipse.lsp4j.jsonrpc"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://artifacts.itemis.cloud/repository/p2/xtext-updates/releases/2.1.1"/>
-			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
+			<unit id="de.itemis.xtext.antlr.feature.feature.group"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.swtbot.eclipse.feature.group"/>
+			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group"/>
 			<repository location="https://download.eclipse.org/technology/swtbot/releases/4.1.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
-			<unit id="org.apache.log4j" version="1.2.26"/>
-			<unit id="org.kohsuke.args4j" version="0.0.0"/>
-			<unit id="com.google.gson" version="2.13.2"/>
-			<unit id="com.google.guava" version="0.0.0"/>
-			<unit id="com.google.guava.failureaccess" version="1.0.3"/>
-			<unit id="com.google.inject" version="7.0.0"/>
-			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
-			<unit id="org.antlr.runtime" version="3.2.0.v20230929-1400"/>
-			<unit id="org.aopalliance" version="1.0.0.v20230720-0728"/>
-			<unit id="org.opentest4j" version="0.0.0"/>
-			<unit id="org.apiguardian.api" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="9.9.1"/>
-			<unit id="io.github.classgraph.classgraph" version="0.0.0"/>
-			<unit id="slf4j.api" version="0.0.0"/>
-			<unit id="slf4j.simple" version="0.0.0"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.hamcrest" version="2.2.0"/>
-			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
+			<unit id="org.apache.log4j"/>
+			<unit id="org.kohsuke.args4j"/>
+			<unit id="com.google.gson"/>
+			<unit id="com.google.guava"/>
+			<unit id="com.google.inject" version="[7,8)"/>
+			<unit id="jakarta.inject.jakarta.inject-api" version="[2,3)"/>
+			<unit id="org.antlr.runtime"/>
+			<unit id="org.aopalliance"/>
+			<unit id="org.opentest4j"/>
+			<unit id="org.apiguardian.api"/>
+			<unit id="org.objectweb.asm"/>
+			<unit id="io.github.classgraph.classgraph"/>
+			<unit id="slf4j.api"/>
+			<unit id="slf4j.simple"/>
+			<unit id="org.junit"/>
+			<unit id="org.hamcrest" version="[2,3)"/>
+			<unit id="org.hamcrest.core" version="[2,3)"/>
+			<unit id="org.apache.commons.commons-logging"/>
 			<unit id="junit-jupiter-api" version="[6.0.0,7.0.0)"/>
 			<unit id="junit-jupiter-engine" version="[6.0.0,7.0.0)"/>
 			<unit id="junit-jupiter-migrationsupport" version="[6.0.0,7.0.0)"/>
@@ -75,7 +74,7 @@
 			<unit id="junit-vintage-engine" version="[6.0.0,7.0.0)"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
+			<unit id="org.eclipse.license.feature.group" version="[2.0,2.1)"/>
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 		</location>
 	</locations>

--- a/xtext-r202512.target
+++ b/xtext-r202512.target
@@ -1,66 +1,65 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="xtext-r202512" sequenceNumber="37">
+<target name="xtext-r202512">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.44.0"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.sdk.feature.group"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
-			<unit id="org.eclipse.emf.mwe2.launch" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.launch.ui" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.language.ui" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.runtime" version="0.0.0"/>
+			<unit id="org.eclipse.emf.mwe2.launch"/>
+			<unit id="org.eclipse.emf.mwe2.launch.ui"/>
+			<unit id="org.eclipse.emf.mwe2.language.ui"/>
+			<unit id="org.eclipse.emf.mwe2.lib"/>
+			<unit id="org.eclipse.emf.mwe2.runtime"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/releases/2025-12/"/>
-			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.sdk" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.buildship.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.executable.feature.group"/>
+			<unit id="org.eclipse.sdk"/>
+			<unit id="org.eclipse.platform.feature.group"/>
+			<unit id="org.eclipse.jdt.feature.group"/>
+			<unit id="org.eclipse.pde.feature.group"/>
+			<unit id="org.eclipse.draw2d.feature.group"/>
+			<unit id="org.eclipse.m2e.feature.feature.group"/>
+			<unit id="org.eclipse.buildship.feature.group"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/lsp4j/updates/releases/1.0.0"/>
-			<unit id="org.eclipse.lsp4j" version="0.0.0"/>
-			<unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
+			<unit id="org.eclipse.lsp4j"/>
+			<unit id="org.eclipse.lsp4j.jsonrpc"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://artifacts.itemis.cloud/repository/p2/xtext-updates/releases/2.1.1"/>
-			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
+			<unit id="de.itemis.xtext.antlr.feature.feature.group"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.swtbot.eclipse.feature.group"/>
+			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group"/>
 			<repository location="https://download.eclipse.org/technology/swtbot/releases/4.1.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
-			<unit id="org.apache.log4j" version="1.2.26"/>
-			<unit id="org.kohsuke.args4j" version="0.0.0"/>
-			<unit id="com.google.gson" version="2.13.2"/>
-			<unit id="com.google.guava" version="0.0.0"/>
-			<unit id="com.google.guava.failureaccess" version="1.0.3"/>
-			<unit id="com.google.inject" version="7.0.0"/>
-			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
-			<unit id="org.antlr.runtime" version="3.2.0.v20230929-1400"/>
-			<unit id="org.aopalliance" version="1.0.0.v20230720-0728"/>
-			<unit id="org.opentest4j" version="0.0.0"/>
-			<unit id="org.apiguardian.api" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="9.9.1"/>
-			<unit id="io.github.classgraph.classgraph" version="0.0.0"/>
-			<unit id="slf4j.api" version="0.0.0"/>
-			<unit id="slf4j.simple" version="0.0.0"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.hamcrest" version="2.2.0"/>
-			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
+			<unit id="org.apache.log4j"/>
+			<unit id="org.kohsuke.args4j"/>
+			<unit id="com.google.gson"/>
+			<unit id="com.google.guava"/>
+			<unit id="com.google.inject" version="[7,8)"/>
+			<unit id="jakarta.inject.jakarta.inject-api" version="[2,3)"/>
+			<unit id="org.antlr.runtime"/>
+			<unit id="org.aopalliance"/>
+			<unit id="org.opentest4j"/>
+			<unit id="org.apiguardian.api"/>
+			<unit id="org.objectweb.asm"/>
+			<unit id="io.github.classgraph.classgraph"/>
+			<unit id="slf4j.api"/>
+			<unit id="slf4j.simple"/>
+			<unit id="org.junit"/>
+			<unit id="org.hamcrest" version="[2,3)"/>
+			<unit id="org.hamcrest.core" version="[2,3)"/>
+			<unit id="org.apache.commons.commons-logging"/>
 			<unit id="junit-jupiter-api" version="[6.0.0,7.0.0)"/>
 			<unit id="junit-jupiter-engine" version="[6.0.0,7.0.0)"/>
 			<unit id="junit-jupiter-migrationsupport" version="[6.0.0,7.0.0)"/>
@@ -72,7 +71,7 @@
 			<unit id="junit-vintage-engine" version="[6.0.0,7.0.0)"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
+			<unit id="org.eclipse.license.feature.group" version="[2.0,2.1)"/>
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 		</location>
 	</locations>

--- a/xtext-r202603.target
+++ b/xtext-r202603.target
@@ -1,66 +1,65 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="xtext-r202603" sequenceNumber="37">
+<target name="xtext-r202603">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.45.0"/>
-			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.sdk.feature.group"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
-			<unit id="org.eclipse.emf.mwe2.launch" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.launch.ui" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.language.ui" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
-			<unit id="org.eclipse.emf.mwe2.runtime" version="0.0.0"/>
+			<unit id="org.eclipse.emf.mwe2.launch"/>
+			<unit id="org.eclipse.emf.mwe2.launch.ui"/>
+			<unit id="org.eclipse.emf.mwe2.language.ui"/>
+			<unit id="org.eclipse.emf.mwe2.lib"/>
+			<unit id="org.eclipse.emf.mwe2.runtime"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/releases/2026-03/"/>
-			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.sdk" version="0.0.0"/>
-			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0" />
-			<unit id="org.eclipse.buildship.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.equinox.executable.feature.group"/>
+			<unit id="org.eclipse.sdk"/>
+			<unit id="org.eclipse.platform.feature.group"/>
+			<unit id="org.eclipse.jdt.feature.group"/>
+			<unit id="org.eclipse.pde.feature.group"/>
+			<unit id="org.eclipse.draw2d.feature.group"/>
+			<unit id="org.eclipse.m2e.feature.feature.group"/>
+			<unit id="org.eclipse.buildship.feature.group"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/lsp4j/updates/releases/1.0.0"/>
-			<unit id="org.eclipse.lsp4j" version="0.0.0"/>
-			<unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
+			<unit id="org.eclipse.lsp4j"/>
+			<unit id="org.eclipse.lsp4j.jsonrpc"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://artifacts.itemis.cloud/repository/p2/xtext-updates/releases/2.1.1"/>
-			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
+			<unit id="de.itemis.xtext.antlr.feature.feature.group"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.swtbot.eclipse.feature.group"/>
+			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group"/>
 			<repository location="https://download.eclipse.org/technology/swtbot/releases/4.1.0/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
-			<unit id="org.apache.log4j" version="1.2.26"/>
-			<unit id="org.kohsuke.args4j" version="0.0.0"/>
-			<unit id="com.google.gson" version="2.13.2"/>
-			<unit id="com.google.guava" version="0.0.0"/>
-			<unit id="com.google.guava.failureaccess" version="1.0.3"/>
-			<unit id="com.google.inject" version="7.0.0"/>
-			<unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
-			<unit id="org.antlr.runtime" version="3.2.0.v20230929-1400"/>
-			<unit id="org.aopalliance" version="1.0.0.v20230720-0728"/>
-			<unit id="org.opentest4j" version="0.0.0"/>
-			<unit id="org.apiguardian.api" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="9.9.1"/>
-			<unit id="io.github.classgraph.classgraph" version="0.0.0"/>
-			<unit id="slf4j.api" version="0.0.0"/>
-			<unit id="slf4j.simple" version="0.0.0"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.hamcrest" version="2.2.0"/>
-			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.apache.commons.commons-logging" version="0.0.0"/>
+			<unit id="org.apache.log4j"/>
+			<unit id="org.kohsuke.args4j"/>
+			<unit id="com.google.gson"/>
+			<unit id="com.google.guava"/>
+			<unit id="com.google.inject" version="[7,8)"/>
+			<unit id="jakarta.inject.jakarta.inject-api" version="[2,3)"/>
+			<unit id="org.antlr.runtime"/>
+			<unit id="org.aopalliance"/>
+			<unit id="org.opentest4j"/>
+			<unit id="org.apiguardian.api"/>
+			<unit id="org.objectweb.asm"/>
+			<unit id="io.github.classgraph.classgraph"/>
+			<unit id="slf4j.api"/>
+			<unit id="slf4j.simple"/>
+			<unit id="org.junit"/>
+			<unit id="org.hamcrest" version="[2,3)"/>
+			<unit id="org.hamcrest.core" version="[2,3)"/>
+			<unit id="org.apache.commons.commons-logging"/>
 			<unit id="junit-jupiter-api" version="[6.0.0,7.0.0)"/>
 			<unit id="junit-jupiter-engine" version="[6.0.0,7.0.0)"/>
 			<unit id="junit-jupiter-migrationsupport" version="[6.0.0,7.0.0)"/>
@@ -72,7 +71,7 @@
 			<unit id="junit-vintage-engine" version="[6.0.0,7.0.0)"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.license.feature.group" version="2.0.2.v20181016-2210"/>
+			<unit id="org.eclipse.license.feature.group" version="[2.0,2.1)"/>
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 		</location>
 	</locations>


### PR DESCRIPTION
Leverage omitted version specification to get the latest version available in locations.
Use version ranges where versions are necessary, because not always the latest version is intended.

Remove unused `sequenceNumber` attribute.
Additionally format file content.

This is similar to
- https://github.com/eclipse-mwe/mwe/pull/362